### PR TITLE
Unselect component after refresh

### DIFF
--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -53,6 +53,7 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
         try {
             this._scanInProgress = true;
             await this.repopulateTree(quickScan);
+            vscode.commands.executeCommand('jfrog.xray.focus');
         } catch (error) {
             if (error.message !== DependenciesTreeDataProvider.CANCELLATION_ERROR.message) {
                 // Unexpected error


### PR DESCRIPTION
**Steps to reproduce:**
Had a vulnerable dependency.
Removed it from package.json.
Run npm install.
The dependency was removed from our components tree - good.
It is still shown in the component details, and component issue details - not good