### PR TITLE
Improve log messages

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { HoverManager } from './main/hover/hoverManager';
 import { ScanCacheManager } from './main/scanCache/scanCacheManager';
 import { TreesManager } from './main/treeDataProviders/treesManager';
 import { WatcherManager } from './main/watchers/watcherManager';
+import { LogManager } from './main/log/logManager';
 
 /**
  * This method is called when the extension is activated.
@@ -17,9 +18,10 @@ import { WatcherManager } from './main/watchers/watcherManager';
 export async function activate(context: vscode.ExtensionContext) {
     let workspaceFolders: vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
 
+    let logManager: LogManager = new LogManager().activate(context);
     let connectionManager: ConnectionManager = await new ConnectionManager().activate(context);
     let scanCacheManager: ScanCacheManager = new ScanCacheManager().activate(context);
-    let treesManager: TreesManager = await new TreesManager(workspaceFolders, connectionManager, scanCacheManager).activate(context);
+    let treesManager: TreesManager = await new TreesManager(workspaceFolders, connectionManager, scanCacheManager, logManager).activate(context);
     let filterManager: FilterManager = new FilterManager(treesManager).activate(context);
     let focusManager: FocusManager = new FocusManager().activate(context);
 

--- a/src/main/log/logManager.ts
+++ b/src/main/log/logManager.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import { ExtensionComponent } from '../extensionComponent';
+
+type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERR';
+
+/**
+ * Log to the "OUTPUT" channel. Add date and log level.
+ */
+export class LogManager implements ExtensionComponent {
+    private _outputChannel!: vscode.OutputChannel;
+
+    activate(context: vscode.ExtensionContext): LogManager {
+        this._outputChannel = vscode.window.createOutputChannel('JFrog');
+        return this;
+    }
+
+    /**
+     * Log a message.
+     * @param message - The message to log
+     * @param level - The log level
+     */
+    public logMessage(message: string, level: LogLevel): void {
+        const title: string = new Date().toLocaleTimeString();
+        this._outputChannel.appendLine(`[${level} - ${title}] ${message}`);
+    }
+
+    /**
+     * Log an error. Show a toast if required.
+     * @param error - The error
+     * @param shouldToast - True iff toast should be shown
+     */
+    public logError(error: Error, shouldToast: boolean) {
+        this.logMessage(error.name, 'ERR');
+        if (error.message) {
+            this._outputChannel.appendLine(error.message);
+            if (shouldToast) {
+                vscode.window.showErrorMessage(error.message);
+            }
+        }
+        if (error.stack) {
+            this._outputChannel.appendLine(error.stack);
+        }
+        this._outputChannel.show();
+    }
+}

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
@@ -1,23 +1,23 @@
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
-import { ScanCacheManager } from '../../scanCache/scanCacheManager';
 import { GoUtils } from '../../utils/goUtils';
 import { NpmUtils } from '../../utils/npmUtils';
 import { PypiUtils } from '../../utils/pypiUtils';
 import { DependenciesTreeNode } from './dependenciesTreeNode';
+import { TreesManager } from '../treesManager';
 
 export class DependenciesTreesFactory {
     public static async createDependenciesTrees(
         workspaceFolders: vscode.WorkspaceFolder[],
         progress: vscode.Progress<{ message?: string; increment?: number }>,
         componentsToScan: Collections.Set<ComponentDetails>,
-        scanCacheManager: ScanCacheManager,
-        dependenciesTree: DependenciesTreeNode,
+        treesManager: TreesManager,
+        parent: DependenciesTreeNode,
         quickScan: boolean
     ) {
-        await NpmUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, scanCacheManager, dependenciesTree, quickScan);
-        await PypiUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, scanCacheManager, dependenciesTree, quickScan);
-        await GoUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, scanCacheManager, dependenciesTree, quickScan);
+        await NpmUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
+        await PypiUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
+        await GoUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
     }
 }

--- a/src/main/treeDataProviders/dependenciesTree/goTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/goTreeNode.ts
@@ -2,9 +2,9 @@ import * as exec from 'child_process';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
-import { ScanCacheManager } from '../../scanCache/scanCacheManager';
 import { GeneralInfo } from '../../types/generalInfo';
 import { GoUtils } from '../../utils/goUtils';
+import { TreesManager } from '../treesManager';
 import { DependenciesTreeNode } from './dependenciesTreeNode';
 
 export class GoTreeNode extends DependenciesTreeNode {
@@ -15,7 +15,7 @@ export class GoTreeNode extends DependenciesTreeNode {
     constructor(
         private _workspaceFolder: string,
         private _componentsToScan: Collections.Set<ComponentDetails>,
-        private _scanCacheManager: ScanCacheManager,
+        private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
         super(new GeneralInfo('', '', _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
@@ -32,7 +32,7 @@ export class GoTreeNode extends DependenciesTreeNode {
             goList.pop(); // Remove the last new line
             rootPackageName = this.getModuleName();
         } catch (error) {
-            vscode.window.showWarningMessage(error.toString());
+            this._treesManager.logManager.logError(error, !quickScan);
             this.label = this._workspaceFolder + ' [Not installed]';
             this.generalInfo = new GeneralInfo(this.label, '', this._workspaceFolder, GoUtils.PKG_TYPE);
             return;
@@ -94,7 +94,7 @@ export class GoTreeNode extends DependenciesTreeNode {
 
     private addComponentToScan(dependenciesTreeNode: DependenciesTreeNode, quickScan: boolean) {
         let componentId: string = dependenciesTreeNode.generalInfo.artifactId + ':' + dependenciesTreeNode.generalInfo.version;
-        if (!quickScan || !this._scanCacheManager.validateOrDelete(componentId)) {
+        if (!quickScan || !this._treesManager.scanCacheManager.validateOrDelete(componentId)) {
             this._componentsToScan.add(new ComponentDetails(GoTreeNode.COMPONENT_PREFIX + componentId));
         }
     }

--- a/src/main/treeDataProviders/dependenciesTree/pypiTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/pypiTreeNode.ts
@@ -2,9 +2,9 @@ import * as exec from 'child_process';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
-import { ScanCacheManager } from '../../scanCache/scanCacheManager';
 import { GeneralInfo } from '../../types/generalInfo';
 import { PypiUtils } from '../../utils/pypiUtils';
+import { TreesManager } from '../treesManager';
 import { DependenciesTreeNode } from './dependenciesTreeNode';
 
 /**
@@ -18,7 +18,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
     constructor(
         private _projectDir: string,
         private _componentsToScan: Collections.Set<ComponentDetails>,
-        private _scanCacheManager: ScanCacheManager,
+        private _treesManager: TreesManager,
         private _pythonPath: string,
         parent?: DependenciesTreeNode
     ) {
@@ -33,7 +33,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
             );
             this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', this._projectDir, PypiUtils.PKG_TYPE);
         } catch (error) {
-            vscode.window.showWarningMessage(error.toString());
+            this._treesManager.logManager.logError(error, !quickScan);
         }
         this.label = this.generalInfo.artifactId;
         this.populateDependenciesTree(this, pypiList, quickScan);
@@ -55,7 +55,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
                         : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode);
                 let componentId: string = dependency.key + ':' + version;
-                if (!quickScan || !this._scanCacheManager.validateOrDelete(componentId)) {
+                if (!quickScan || !this._treesManager.scanCacheManager.validateOrDelete(componentId)) {
                     this._componentsToScan.add(new ComponentDetails(PypiTreeNode.COMPONENT_PREFIX + componentId));
                 }
                 this.populateDependenciesTree(child, childDependencies, quickScan);

--- a/src/main/treeDataProviders/treesManager.ts
+++ b/src/main/treeDataProviders/treesManager.ts
@@ -7,6 +7,7 @@ import { DependenciesTreeDataProvider } from './dependenciesTree/dependenciesDat
 import { DependenciesTreeNode } from './dependenciesTree/dependenciesTreeNode';
 import { IssuesDataProvider } from './issuesDataProvider';
 import { SetCredentialsNode } from './utils/setCredentialsNode';
+import { LogManager } from '../log/logManager';
 
 /**
  * Manages all 3 trees in the extension: Components, component details and component issues details.
@@ -17,8 +18,8 @@ export class TreesManager implements ExtensionComponent {
     private _dependenciesDataProvider: DependenciesTreeDataProvider;
     private _issuesDataProvider: IssuesDataProvider;
 
-    constructor(workspaceFolders: vscode.WorkspaceFolder[], connectionManager: ConnectionManager, scanCacheManager: ScanCacheManager) {
-        this._dependenciesDataProvider = new DependenciesTreeDataProvider(workspaceFolders, connectionManager, scanCacheManager);
+    constructor(workspaceFolders: vscode.WorkspaceFolder[], private _connectionManager: ConnectionManager, private _scanCacheManager: ScanCacheManager, private _logManager: LogManager) {
+        this._dependenciesDataProvider = new DependenciesTreeDataProvider(workspaceFolders, this);
         this._componentDetailsDataProvider = new ComponentDetailsDataProvider();
         this._issuesDataProvider = new IssuesDataProvider();
     }
@@ -51,5 +52,17 @@ export class TreesManager implements ExtensionComponent {
 
     public get dependenciesTreeDataProvider(): DependenciesTreeDataProvider {
         return this._dependenciesDataProvider;
+    }
+
+    public get connectionManager(): ConnectionManager {
+        return this._connectionManager;
+    }
+
+    public get scanCacheManager(): ScanCacheManager {
+        return this._scanCacheManager;
+    }
+
+    public get logManager(): LogManager {
+        return this._logManager;
     }
 }

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../../main/treeDataProviders/treesManager';
 import { GeneralInfo } from '../../main/types/generalInfo';
 import { GoUtils } from '../../main/utils/goUtils';
 
@@ -114,7 +115,7 @@ describe('Go Utils Tests', () => {
             workspaceFolders,
             dummyProgress,
             componentsToScan,
-            dummyScanCacheManager,
+            { scanCacheManager: dummyScanCacheManager } as TreesManager,
             parent,
             false
         );

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
+import { ConnectionManager } from '../../main/connect/connectionManager';
+import { LogManager } from '../../main/log/logManager';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../../main/treeDataProviders/treesManager';
@@ -17,6 +19,12 @@ describe('Go Utils Tests', () => {
     let dummyScanCacheManager: ScanCacheManager = new ScanCacheManager().activate({
         workspaceState: { get(key: string) {} } as vscode.Memento
     } as vscode.ExtensionContext);
+    let treesManager: TreesManager = new TreesManager(
+        [],
+        new ConnectionManager(),
+        dummyScanCacheManager,
+        new LogManager().activate({} as vscode.ExtensionContext)
+    );
     let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['dependency', 'empty'];
     let workspaceFolders: vscode.WorkspaceFolder[];
@@ -115,7 +123,7 @@ describe('Go Utils Tests', () => {
             workspaceFolders,
             dummyProgress,
             componentsToScan,
-            { scanCacheManager: dummyScanCacheManager } as TreesManager,
+            treesManager,
             parent,
             false
         );

--- a/src/test/tests/npmUtils.test.ts
+++ b/src/test/tests/npmUtils.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../../main/treeDataProviders/treesManager';
 import { GeneralInfo } from '../../main/types/generalInfo';
 import { NpmUtils } from '../../main/utils/npmUtils';
 
@@ -151,7 +152,7 @@ describe('Npm Utils Tests', () => {
             workspaceFolders,
             dummyProgress,
             componentsToScan,
-            dummyScanCacheManager,
+            { scanCacheManager: dummyScanCacheManager } as TreesManager,
             parent,
             false
         );

--- a/src/test/tests/npmUtils.test.ts
+++ b/src/test/tests/npmUtils.test.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
+import { ConnectionManager } from '../../main/connect/connectionManager';
+import { LogManager } from '../../main/log/logManager';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../../main/treeDataProviders/treesManager';
@@ -18,6 +20,12 @@ describe('Npm Utils Tests', () => {
     let dummyScanCacheManager: ScanCacheManager = new ScanCacheManager().activate({
         workspaceState: { get(key: string) {} } as vscode.Memento
     } as vscode.ExtensionContext);
+    let treesManager: TreesManager = new TreesManager(
+        [],
+        new ConnectionManager(),
+        dummyScanCacheManager,
+        new LogManager().activate({} as vscode.ExtensionContext)
+    );
     let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['dependency', 'dependencyPackageLock', 'empty'];
     let workspaceFolders: vscode.WorkspaceFolder[];
@@ -152,7 +160,7 @@ describe('Npm Utils Tests', () => {
             workspaceFolders,
             dummyProgress,
             componentsToScan,
-            { scanCacheManager: dummyScanCacheManager } as TreesManager,
+            treesManager,
             parent,
             false
         );

--- a/src/test/tests/pypiUtils.test.ts
+++ b/src/test/tests/pypiUtils.test.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { PypiTreeNode } from '../../main/treeDataProviders/dependenciesTree/pypiTreeNode';
+import { TreesManager } from '../../main/treeDataProviders/treesManager';
 import { GeneralInfo } from '../../main/types/generalInfo';
 import { PypiUtils } from '../../main/utils/pypiUtils';
 
@@ -90,7 +91,7 @@ describe('Pypi Utils Tests', () => {
         let dependenciesTreeNode: PypiTreeNode = new PypiTreeNode(
             workspaceFolders[0].uri.fsPath,
             new Collections.Set(),
-            dummyScanCacheManager,
+            { scanCacheManager: dummyScanCacheManager } as TreesManager,
             path.join(workspaceFolders[0].uri.fsPath, localPython),
             new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
         );
@@ -103,7 +104,7 @@ describe('Pypi Utils Tests', () => {
         dependenciesTreeNode = new PypiTreeNode(
             workspaceFolders[1].uri.fsPath,
             new Collections.Set(),
-            dummyScanCacheManager,
+            { scanCacheManager: dummyScanCacheManager } as TreesManager,
             path.join(workspaceFolders[1].uri.fsPath, localPython),
             new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
         );
@@ -119,7 +120,7 @@ describe('Pypi Utils Tests', () => {
         dependenciesTreeNode = new PypiTreeNode(
             workspaceFolders[2].uri.fsPath,
             new Collections.Set(),
-            dummyScanCacheManager,
+            { scanCacheManager: dummyScanCacheManager } as TreesManager,
             path.join(workspaceFolders[2].uri.fsPath, localPython),
             new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
         );

--- a/src/test/tests/pypiUtils.test.ts
+++ b/src/test/tests/pypiUtils.test.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 import * as tmp from 'tmp';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
+import { ConnectionManager } from '../../main/connect/connectionManager';
+import { LogManager } from '../../main/log/logManager';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { PypiTreeNode } from '../../main/treeDataProviders/dependenciesTree/pypiTreeNode';
@@ -19,6 +21,12 @@ describe('Pypi Utils Tests', () => {
     let dummyScanCacheManager: ScanCacheManager = new ScanCacheManager().activate({
         workspaceState: { get(key: string) {} } as vscode.Memento
     } as vscode.ExtensionContext);
+    let treesManager: TreesManager = new TreesManager(
+        [],
+        new ConnectionManager(),
+        dummyScanCacheManager,
+        new LogManager().activate({} as vscode.ExtensionContext)
+    );
     let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['requirements', 'setup', 'setupAndRequirements'];
     let workspaceFolders: vscode.WorkspaceFolder[] = [];
@@ -91,7 +99,7 @@ describe('Pypi Utils Tests', () => {
         let dependenciesTreeNode: PypiTreeNode = new PypiTreeNode(
             workspaceFolders[0].uri.fsPath,
             new Collections.Set(),
-            { scanCacheManager: dummyScanCacheManager } as TreesManager,
+            treesManager,
             path.join(workspaceFolders[0].uri.fsPath, localPython),
             new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
         );
@@ -104,7 +112,7 @@ describe('Pypi Utils Tests', () => {
         dependenciesTreeNode = new PypiTreeNode(
             workspaceFolders[1].uri.fsPath,
             new Collections.Set(),
-            { scanCacheManager: dummyScanCacheManager } as TreesManager,
+            treesManager,
             path.join(workspaceFolders[1].uri.fsPath, localPython),
             new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
         );
@@ -120,7 +128,7 @@ describe('Pypi Utils Tests', () => {
         dependenciesTreeNode = new PypiTreeNode(
             workspaceFolders[2].uri.fsPath,
             new Collections.Set(),
-            { scanCacheManager: dummyScanCacheManager } as TreesManager,
+            treesManager,
             path.join(workspaceFolders[2].uri.fsPath, localPython),
             new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
         );


### PR DESCRIPTION
+ Use vscode [Output channel API](https://code.visualstudio.com/api/references/vscode-api#OutputChannel).
+ Add debug level information.
+ npm/go/python dependencies list error will be toasted only in slow scans.