### PR TITLE
Increate buffersize in child_process.spawnSync()

### DIFF
--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
@@ -7,6 +7,7 @@ import { Severity } from '../../types/severity';
 import { IconsPaths } from '../../utils/iconsPaths';
 
 export class DependenciesTreeNode extends vscode.TreeItem {
+    readonly SPAWN_PROCESS_BUFFER_SIZE: number = 104857600;
     private _children: DependenciesTreeNode[] = [];
     private _licenses: Collections.Set<License> = new Collections.Set(license => license.fullName);
     private _issues: Collections.Set<Issue> = new Collections.Set(issue => issue.summary);

--- a/src/main/treeDataProviders/dependenciesTree/goTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/goTreeNode.ts
@@ -26,7 +26,7 @@ export class GoTreeNode extends DependenciesTreeNode {
         let rootPackageName: string = '';
         try {
             goList = exec
-                .execSync('go mod graph', { cwd: this._workspaceFolder })
+                .execSync('go mod graph', { cwd: this._workspaceFolder, maxBuffer: this.SPAWN_PROCESS_BUFFER_SIZE })
                 .toString()
                 .split(/\s+/);
             goList.pop(); // Remove the last new line

--- a/src/main/treeDataProviders/dependenciesTree/npmTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/npmTreeNode.ts
@@ -23,7 +23,9 @@ export class NpmTreeNode extends DependenciesTreeNode {
     public async refreshDependencies(quickScan: boolean) {
         let npmList: any;
         try {
-            npmList = JSON.parse(exec.execSync('npm ls --json', { cwd: this._workspaceFolder }).toString());
+            npmList = JSON.parse(
+                exec.execSync('npm ls --json', { cwd: this._workspaceFolder, maxBuffer: this.SPAWN_PROCESS_BUFFER_SIZE }).toString()
+            );
         } catch (error) {
             this._treesManager.logManager.logError(error, !quickScan);
             this._treesManager.logManager.logMessage(

--- a/src/main/treeDataProviders/dependenciesTree/pypiTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/pypiTreeNode.ts
@@ -29,7 +29,12 @@ export class PypiTreeNode extends DependenciesTreeNode {
         let pypiList: any;
         try {
             pypiList = JSON.parse(
-                exec.execSync(this._pythonPath + ' ' + PypiUtils.PIP_DEP_TREE_SCRIPT + ' --json-tree', { cwd: this._projectDir }).toString()
+                exec
+                    .execSync(this._pythonPath + ' ' + PypiUtils.PIP_DEP_TREE_SCRIPT + ' --json-tree', {
+                        cwd: this._projectDir,
+                        maxBuffer: this.SPAWN_PROCESS_BUFFER_SIZE
+                    })
+                    .toString()
             );
             this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', this._projectDir, PypiUtils.PKG_TYPE);
         } catch (error) {


### PR DESCRIPTION
Increase buffer size from the default 1MiB to 10MiB.
Information on the default buffer from here: https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options
