### PR TITLE
Fix progressbar

### DIFF
--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -148,7 +148,6 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
             let dependenciesTree: DependenciesTreeNode = <DependenciesTreeNode>this.dependenciesTree;
             await DependenciesTreesFactory.createDependenciesTrees(
                 this._workspaceFolders,
-                progress,
                 this._componentsToScan,
                 this._treesManager,
                 dependenciesTree,

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
@@ -11,15 +11,14 @@ import { MavenUtils } from '../../utils/mavenUtils';
 export class DependenciesTreesFactory {
     public static async createDependenciesTrees(
         workspaceFolders: vscode.WorkspaceFolder[],
-        progress: vscode.Progress<{ message?: string; increment?: number }>,
         componentsToScan: Collections.Set<ComponentDetails>,
         treesManager: TreesManager,
         parent: DependenciesTreeNode,
         quickScan: boolean
     ) {
-        await NpmUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
-        await PypiUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
-        await GoUtils.createDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
-        await MavenUtils.createMavenDependenciesTrees(workspaceFolders, progress, componentsToScan, treesManager, parent, quickScan);
+        await NpmUtils.createDependenciesTrees(workspaceFolders, componentsToScan, treesManager, parent, quickScan);
+        await PypiUtils.createDependenciesTrees(workspaceFolders, componentsToScan, treesManager, parent, quickScan);
+        await GoUtils.createDependenciesTrees(workspaceFolders, componentsToScan, treesManager, parent, quickScan);
+        await MavenUtils.createMavenDependenciesTrees(workspaceFolders, componentsToScan, treesManager, parent, quickScan);
     }
 }

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -16,7 +16,7 @@ export class ScanUtils {
                 cancellable: true
             },
             async (progress: vscode.Progress<{ message?: string; increment?: number }>, token: vscode.CancellationToken) => {
-                scanCbk(progress, () => ScanUtils.checkCanceled(token));
+                await scanCbk(progress, () => ScanUtils.checkCanceled(token));
             }
         );
     }

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -25,7 +25,6 @@ describe('Go Utils Tests', () => {
         dummyScanCacheManager,
         new LogManager().activate({} as vscode.ExtensionContext)
     );
-    let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['dependency', 'empty'];
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'go'));
@@ -44,7 +43,7 @@ describe('Go Utils Tests', () => {
      * Test GoUtils.locateGoMods.
      */
     it('Locate go mods', async () => {
-        let goMods: Collections.Set<vscode.Uri> = await GoUtils.locateGoMods(workspaceFolders, dummyProgress);
+        let goMods: Collections.Set<vscode.Uri> = await GoUtils.locateGoMods(workspaceFolders, treesManager.logManager);
         assert.strictEqual(goMods.size(), projectDirs.length);
 
         // Assert that results contains all projects
@@ -121,7 +120,6 @@ describe('Go Utils Tests', () => {
     async function runCreateGoDependenciesTrees(componentsToScan: Collections.Set<ComponentDetails>, parent: DependenciesTreeNode) {
         let dependenciesTrees: DependenciesTreeNode[] = await GoUtils.createDependenciesTrees(
             workspaceFolders,
-            dummyProgress,
             componentsToScan,
             treesManager,
             parent,

--- a/src/test/tests/mavenUtils.test.ts
+++ b/src/test/tests/mavenUtils.test.ts
@@ -29,7 +29,6 @@ describe('Maven Utils Tests', () => {
         dummyScanCacheManager,
         new LogManager().activate({} as vscode.ExtensionContext)
     );
-    let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['dependency', 'empty', 'multiPomDependency'];
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'maven'));
@@ -50,7 +49,7 @@ describe('Maven Utils Tests', () => {
      * Test locatePomXml.
      */
     it('Locate pom.xml', async () => {
-        let pomXmls: vscode.Uri[] = await MavenUtils.locatePomXmls(workspaceFolders, dummyProgress);
+        let pomXmls: vscode.Uri[] = await MavenUtils.locatePomXmls(workspaceFolders, treesManager.logManager);
         assert.strictEqual(pomXmls.length, 6);
 
         // Assert that results contains all projects
@@ -89,7 +88,7 @@ describe('Maven Utils Tests', () => {
                 index: 0
             } as vscode.WorkspaceFolder
         ];
-        let pomXmlsArray: vscode.Uri[] = await MavenUtils.locatePomXmls(localWorkspaceFolders, dummyProgress);
+        let pomXmlsArray: vscode.Uri[] = await MavenUtils.locatePomXmls(localWorkspaceFolders, treesManager.logManager);
         let got: PomTree[] = MavenUtils.buildPrototypePomTree(pomXmlsArray, treesManager);
         let want: PomTree[][] = expectedBuildPrototypePomTree();
         assert.deepEqual(got, want[0]);
@@ -102,7 +101,7 @@ describe('Maven Utils Tests', () => {
                 index: 0
             } as vscode.WorkspaceFolder
         ];
-        pomXmlsArray = await MavenUtils.locatePomXmls(localWorkspaceFolders, dummyProgress);
+        pomXmlsArray = await MavenUtils.locatePomXmls(localWorkspaceFolders, treesManager.logManager);
         got = MavenUtils.buildPrototypePomTree(pomXmlsArray, treesManager);
         assert.deepEqual(got, want[1]);
     });
@@ -309,7 +308,6 @@ describe('Maven Utils Tests', () => {
     async function runCreateMavenDependenciesTrees(componentsToScan: Collections.Set<ComponentDetails>, parent: DependenciesTreeNode) {
         let dependenciesTrees: DependenciesTreeNode[] = await MavenUtils.createMavenDependenciesTrees(
             workspaceFolders,
-            dummyProgress,
             componentsToScan,
             treesManager,
             parent,

--- a/src/test/tests/npmUtils.test.ts
+++ b/src/test/tests/npmUtils.test.ts
@@ -26,7 +26,6 @@ describe('Npm Utils Tests', () => {
         dummyScanCacheManager,
         new LogManager().activate({} as vscode.ExtensionContext)
     );
-    let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['dependency', 'dependencyPackageLock', 'empty'];
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'npm'));
@@ -45,7 +44,7 @@ describe('Npm Utils Tests', () => {
      * Test NpmUtils.locatePackageJsons.
      */
     it('Locate package jsons', async () => {
-        let packageJsons: Collections.Set<vscode.Uri> = await NpmUtils.locatePackageJsons(workspaceFolders, dummyProgress);
+        let packageJsons: Collections.Set<vscode.Uri> = await NpmUtils.locatePackageJsons(workspaceFolders, treesManager.logManager);
         assert.strictEqual(packageJsons.size(), projectDirs.length);
 
         // Assert that results contains all projects
@@ -158,7 +157,6 @@ describe('Npm Utils Tests', () => {
     async function runCreateNpmDependenciesTrees(componentsToScan: Collections.Set<ComponentDetails>, parent: DependenciesTreeNode) {
         let dependenciesTrees: DependenciesTreeNode[] = await NpmUtils.createDependenciesTrees(
             workspaceFolders,
-            dummyProgress,
             componentsToScan,
             treesManager,
             parent,

--- a/src/test/tests/pypiUtils.test.ts
+++ b/src/test/tests/pypiUtils.test.ts
@@ -27,7 +27,6 @@ describe('Pypi Utils Tests', () => {
         dummyScanCacheManager,
         new LogManager().activate({} as vscode.ExtensionContext)
     );
-    let dummyProgress: vscode.Progress<{ message?: string; increment?: number }> = { report: () => {} };
     let projectDirs: string[] = ['requirements', 'setup', 'setupAndRequirements'];
     let workspaceFolders: vscode.WorkspaceFolder[] = [];
     let tmpDir: vscode.Uri = vscode.Uri.file(tmp.dirSync({} as tmp.DirOptions).name);
@@ -50,7 +49,7 @@ describe('Pypi Utils Tests', () => {
     it('Python files exist', async () => {
         // Assert that results contains all projects
         for (let workspaceFolder of workspaceFolders) {
-            let pythonFilesExist: boolean = await PypiUtils.arePythonFilesExist(workspaceFolder, dummyProgress);
+            let pythonFilesExist: boolean = await PypiUtils.arePythonFilesExist(workspaceFolder, treesManager.logManager);
             assert.isTrue(pythonFilesExist, workspaceFolder.uri + ' should contain Python files');
         }
     });


### PR DESCRIPTION
* Add missing `async` in scanWithProgress
* To avoiding flooding the progressbar - Move most of the reports to the log manager
* Remove redundant Maven progressbar
* Print `Generating Maven Dependency Tree` to the log only when there are pom.xml files