### PR TITLE
Add JFrog status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,5 +29,5 @@ export async function activate(context: vscode.ExtensionContext) {
     new WatcherManager(treesManager).activate(context);
     new HoverManager(treesManager).activate(context);
     new CodeLensManager().activate(context);
-    new CommandManager(connectionManager, treesManager, filterManager, focusManager).activate(context);
+    new CommandManager(logManager, connectionManager, treesManager, filterManager, focusManager).activate(context);
 }

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -3,6 +3,7 @@ import { ConnectionManager } from '../connect/connectionManager';
 import { ExtensionComponent } from '../extensionComponent';
 import { FilterManager } from '../filter/filterManager';
 import { FocusManager } from '../focus/focusManager';
+import { LogManager } from '../log/logManager';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { SetCredentialsNode } from '../treeDataProviders/utils/setCredentialsNode';
@@ -12,6 +13,7 @@ import { SetCredentialsNode } from '../treeDataProviders/utils/setCredentialsNod
  */
 export class CommandManager implements ExtensionComponent {
     constructor(
+        private _logManager: LogManager,
         private _connectionManager: ConnectionManager,
         private _treesManager: TreesManager,
         private _filterManager: FilterManager,
@@ -22,6 +24,7 @@ export class CommandManager implements ExtensionComponent {
         this.registerCommand(context, 'jfrog.xray.showInProjectDesc', dependenciesTreeNode => this.doShowInProjectDesc(dependenciesTreeNode));
         this.registerCommand(context, 'jfrog.xray.codeAction', dependenciesTreeNode => this.doCodeAction(dependenciesTreeNode));
         this.registerCommand(context, 'jfrog.xray.focus', dependenciesTreeNode => this.doFocus(dependenciesTreeNode));
+        this.registerCommand(context, 'jfrog.xray.showOutput', () => this.showOutput());
         this.registerCommand(context, 'jfrog.xray.refresh', () => this.doRefresh());
         this.registerCommand(context, 'jfrog.xray.connect', () => this.doConnect());
         this.registerCommand(context, 'jfrog.xray.filter', () => this.doFilter());
@@ -54,6 +57,13 @@ export class CommandManager implements ExtensionComponent {
      */
     private doFocus(dependenciesTreeNode: DependenciesTreeNode) {
         this.onSelectNode(dependenciesTreeNode);
+    }
+
+    /**
+     * Show JFrog Output tab.
+     */
+    private showOutput() {
+        this._logManager.showOutput();
     }
 
     /**

--- a/src/main/log/logManager.ts
+++ b/src/main/log/logManager.ts
@@ -7,10 +7,18 @@ type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERR';
  * Log to the "OUTPUT" channel. Add date and log level.
  */
 export class LogManager implements ExtensionComponent {
+    private _statusBar!: vscode.StatusBarItem;
     private _outputChannel!: vscode.OutputChannel;
+
+    constructor() {
+        this._statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
+        this._statusBar.tooltip = 'JFrog Xray vulnerabilities scanning status';
+        this._statusBar.command = 'jfrog.xray.showOutput';
+    }
 
     activate(context: vscode.ExtensionContext): LogManager {
         this._outputChannel = vscode.window.createOutputChannel('JFrog');
+        this._statusBar.show();
         return this;
     }
 
@@ -32,16 +40,38 @@ export class LogManager implements ExtensionComponent {
      * @param shouldToast - True iff toast should be shown
      */
     public logError(error: Error, shouldToast: boolean) {
+        this.setFailed();
         this.logMessage(error.name, 'ERR');
         if (error.message) {
             this._outputChannel.appendLine(error.message);
             if (shouldToast) {
                 vscode.window.showErrorMessage(error.message);
+                this.showOutput();
             }
         }
         if (error.stack) {
             this._outputChannel.appendLine(error.stack);
         }
-        this._outputChannel.show();
+    }
+
+    /**
+     * Show JFrog Output tab.
+     */
+    public showOutput() {
+        this._outputChannel.show(true);
+    }
+
+    /**
+     * Set success in the JFrog status bar.
+     */
+    public setSuccess() {
+        this._statusBar.text = 'JFrog: $(check)';
+    }
+
+    /**
+     * Set failure in the JFrog status bar.
+     */
+    private setFailed() {
+        this._statusBar.text = 'JFrog: $(error)';
     }
 }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -53,6 +53,7 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
             this._treesManager.logManager.logMessage('Starting ' + (quickScan ? 'quick' : 'slow') + ' Xray scan...', 'INFO');
             await this.repopulateTree(quickScan);
             vscode.commands.executeCommand('jfrog.xray.focus');
+            this._treesManager.logManager.setSuccess();
         } catch (error) {
             if (error.message !== DependenciesTreeDataProvider.CANCELLATION_ERROR.message) {
                 // Unexpected error


### PR DESCRIPTION
Add JFrog status bar at the right bottom of the screen.

* Clicking on it causes showing the logs
* On success scan: ![image](https://user-images.githubusercontent.com/11367982/78368094-c90b6700-75cb-11ea-990c-4f44c246ef9d.png)
* On failed scan: ![image](https://user-images.githubusercontent.com/11367982/78368296-17206a80-75cc-11ea-81ed-b4e93c593cc9.png)

**Removed functionality**
* When a quick scan fails, the extension trigger a focus on the JFrog output logs screen.
This functionality is annoying when working on the terminal, for example, `git checkout <other branch>` almost always causes a context switch between the tabs.
* Don't take focus from the editor anymore.