### PR TITLE
Tests - make sure branch is clean

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
                   node-version: '10.x'
             - name: Install
               run: npm i
+              # Make sure no new dependencies were installed after running 'npm i'
+            - name: Make sure branch is clean
+              run: git diff --exit-code
             - name: Lint
               run: npm run lint
             - name: Pack Maven GAV Reader


### PR DESCRIPTION
Adding a dependency to `package.json` requires running `npm install`. Failing to do it, may cause a dirty local branch in tests and release jobs.
If the local branch is not clean, the release will fail during 'Publish to marketplace' phase.
We may want to avoid that by running `git diff --exit-code` in tests, after running `npm i`.
If there are any changes in the local branch, this command will fail the job.

For more information: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code