### PR TITLE
Add 'configure Xray details' view

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,13 @@
         "viewsWelcome": [
             {
                 "view": "jfrog.xray.component",
-                "contents": "The JFrog extension pulls security information and metadata from [JFrog GoCenter](https://search.gocenter.io).\n[Connecting VS Code to JFrog Xray](https://github.com/jfrog/jfrog-vscode-extension#configuring-jfrog-xray) provides security intelligence directly from [JFrog Xray](https://jfrog.com/xray), including a list of security issues and module versions with the fixes.\nAll the module metadata provided by GoCenter is still available when connecting to JFrog Xray.",
+                "contents": "The JFrog extension pulls security information and metadata from [JFrog GoCenter](https://search.gocenter.io).\n[Connecting VS Code to JFrog Xray](https://github.com/jfrog/jfrog-vscode-extension#configuring-jfrog-xray) provides security intelligence directly from [JFrog Xray](https://jfrog.com/xray), including a list of security issues and module versions with the fixes.\nAll the module metadata provided by GoCenter is still available when [connecting](command:jfrog.xray.connect) to JFrog Xray.",
                 "when": "isGoCenterMode"
+            },
+            {
+                "view": "jfrog.xray",
+                "contents": "To start using the JFrog extension, please [configure](command:jfrog.xray.connect) your JFrog Xray details.",
+                "when": "!isGoCenterMode && !areCredentialsSet"
             }
         ],
         "viewsContainers": {

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -6,7 +6,6 @@ import { FocusManager } from '../focus/focusManager';
 import { LogManager } from '../log/logManager';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
-import { SetCredentialsNode } from '../treeDataProviders/utils/setCredentialsNode';
 import { ExclusionsManager } from '../exclusions/exclusionsManager';
 
 /**
@@ -39,10 +38,7 @@ export class CommandManager implements ExtensionComponent {
      * Show the dependency in the project descriptor (i.e package.json) file after right click on the components tree and a left click on "Show in project descriptor".
      * @param dependenciesTreeNode - The dependency to show.
      */
-    private doShowInProjectDesc(dependenciesTreeNode: DependenciesTreeNode | SetCredentialsNode) {
-        if (dependenciesTreeNode instanceof SetCredentialsNode) {
-            return;
-        }
+    private doShowInProjectDesc(dependenciesTreeNode: DependenciesTreeNode) {
         this._focusManager.focusOnDependency(dependenciesTreeNode);
         this.onSelectNode(dependenciesTreeNode);
     }
@@ -133,10 +129,7 @@ export class CommandManager implements ExtensionComponent {
      * Populate component details and component issues details with information about dependenciesTreeNode.
      * @param dependenciesTreeNode - The selected node in the components tree.
      */
-    private onSelectNode(dependenciesTreeNode: DependenciesTreeNode | SetCredentialsNode) {
-        if (dependenciesTreeNode instanceof SetCredentialsNode) {
-            return;
-        }
+    private onSelectNode(dependenciesTreeNode: DependenciesTreeNode) {
         this._treesManager.componentDetailsDataProvider.selectNode(dependenciesTreeNode);
         this._treesManager.issuesDataProvider.selectNode(dependenciesTreeNode);
     }

--- a/src/main/filter/filterManager.ts
+++ b/src/main/filter/filterManager.ts
@@ -4,7 +4,6 @@ import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/depe
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { LicensesFilter } from './licensesFilter';
 import { SeverityFilter as SeveritiesFilter } from './severitiesFilter';
-import { SetCredentialsNode } from '../treeDataProviders/utils/setCredentialsNode';
 
 enum FilterTypes {
     SEVERITY = '$(alert)   Issues severity',
@@ -48,7 +47,7 @@ export class FilterManager implements ExtensionComponent {
     }
 
     public applyFilters() {
-        let unfilteredRoot: DependenciesTreeNode | SetCredentialsNode = this._treesManager.dependenciesTreeDataProvider.dependenciesTree;
+        let unfilteredRoot: DependenciesTreeNode = this._treesManager.dependenciesTreeDataProvider.dependenciesTree;
         if (!(unfilteredRoot instanceof DependenciesTreeNode)) {
             return;
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -8,7 +8,6 @@ import { Severity, SeverityUtils } from '../../types/severity';
 import { ScanUtils } from '../../utils/scanUtils';
 import { Translators } from '../../utils/translators';
 import { TreesManager } from '../treesManager';
-import { SetCredentialsNode } from '../utils/setCredentialsNode';
 import { DependenciesTreesFactory } from './dependenciesTreeFactory';
 import { DependenciesTreeNode } from './dependenciesTreeNode';
 import { MavenUtils } from '../../utils/mavenUtils';
@@ -17,18 +16,16 @@ import { GoDependenciesTreeNode } from './goDependenciesTreeNode';
 import { GoTreeNode } from './dependenciesRoot/goTree';
 import { ISeverityCount } from '../../goCenterClient/model/SeverityCount';
 
-export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<DependenciesTreeNode | SetCredentialsNode> {
+export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<DependenciesTreeNode> {
     private static readonly CANCELLATION_ERROR: Error = new Error('Xray Scan cancelled');
 
-    private _onDidChangeTreeData: vscode.EventEmitter<DependenciesTreeNode | SetCredentialsNode | undefined> = new vscode.EventEmitter<
-        DependenciesTreeNode | SetCredentialsNode | undefined
-    >();
-    readonly onDidChangeTreeData: vscode.Event<DependenciesTreeNode | SetCredentialsNode | undefined> = this._onDidChangeTreeData.event;
+    private _onDidChangeTreeData: vscode.EventEmitter<DependenciesTreeNode | undefined> = new vscode.EventEmitter<DependenciesTreeNode | undefined>();
+    readonly onDidChangeTreeData: vscode.Event<DependenciesTreeNode | undefined> = this._onDidChangeTreeData.event;
     private _filterLicenses: Collections.Set<License> = new Collections.Set(license => license.fullName);
     private _componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
     private _goCenterComponentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
     private _filteredDependenciesTree: DependenciesTreeNode | undefined;
-    protected _dependenciesTree!: DependenciesTreeNode | SetCredentialsNode;
+    protected _dependenciesTree!: DependenciesTreeNode;
     private _scanInProgress: boolean = false;
 
     constructor(protected _workspaceFolders: vscode.WorkspaceFolder[], protected _treesManager: TreesManager) {}
@@ -74,15 +71,12 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
         return element;
     }
 
-    public getChildren(element?: DependenciesTreeNode): Thenable<DependenciesTreeNode[] | SetCredentialsNode[]> {
+    public getChildren(element?: DependenciesTreeNode): Thenable<DependenciesTreeNode[]> {
         if (!this.dependenciesTree) {
             return Promise.resolve([]);
         }
         if (element) {
             return Promise.resolve(element.children);
-        }
-        if (this.dependenciesTree instanceof SetCredentialsNode) {
-            return Promise.resolve([this.dependenciesTree]);
         }
         let rootChildren: DependenciesTreeNode[] = this._filteredDependenciesTree
             ? this._filteredDependenciesTree.children
@@ -292,7 +286,7 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
     }
 
     public getDependenciesTreeNode(pkgType: string, path?: string): DependenciesTreeNode | undefined {
-        if (!(this.dependenciesTree instanceof DependenciesTreeNode) && !(this.dependenciesTree instanceof GoDependenciesTreeNode)) {
+        if (!(this.dependenciesTree instanceof DependenciesTreeNode)) {
             return undefined;
         }
         // Unlike other build tools, which rely that each direct dep can be found in the root's child, Maven can have direct dep in each node because,

--- a/src/main/treeDataProviders/treesManager.ts
+++ b/src/main/treeDataProviders/treesManager.ts
@@ -6,14 +6,13 @@ import { ComponentDetailsDataProvider } from './componentDetailsDataProvider';
 import { DependenciesTreeDataProvider } from './dependenciesTree/dependenciesDataProvider';
 import { DependenciesTreeNode } from './dependenciesTree/dependenciesTreeNode';
 import { IssuesDataProvider } from './issuesDataProvider';
-import { SetCredentialsNode } from './utils/setCredentialsNode';
 import { LogManager } from '../log/logManager';
 
 /**
  * Manages all 3 trees in the extension: Components, component details and component issues details.
  */
 export class TreesManager implements ExtensionComponent {
-    private _dependenciesTreeView!: vscode.TreeView<DependenciesTreeNode | SetCredentialsNode>;
+    private _dependenciesTreeView!: vscode.TreeView<DependenciesTreeNode>;
     private _componentDetailsDataProvider: ComponentDetailsDataProvider;
     private _dependenciesDataProvider: DependenciesTreeDataProvider;
     private _issuesDataProvider: IssuesDataProvider;
@@ -47,7 +46,7 @@ export class TreesManager implements ExtensionComponent {
         return this._componentDetailsDataProvider;
     }
 
-    public get dependenciesTreeView(): vscode.TreeView<DependenciesTreeNode | SetCredentialsNode> {
+    public get dependenciesTreeView(): vscode.TreeView<DependenciesTreeNode> {
         return this._dependenciesTreeView;
     }
 

--- a/src/main/treeDataProviders/utils/setCredentialsNode.ts
+++ b/src/main/treeDataProviders/utils/setCredentialsNode.ts
@@ -1,8 +1,0 @@
-import * as vscode from 'vscode';
-
-export class SetCredentialsNode extends vscode.TreeItem {
-    private static readonly SET_CREDENTIALS_MESSAGE: string = 'To start using the JFrog extension, please configure your JFrog Xray details';
-    constructor() {
-        super(SetCredentialsNode.SET_CREDENTIALS_MESSAGE, vscode.TreeItemCollapsibleState.Expanded);
-    }
-}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Add 'configure credentials' view:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/11367982/87230747-963af100-c3ba-11ea-9914-6fc264acb20e.png">

* Remove unused SetCredentialsNode class.

After this PR we will have 2 welcome views:
1. If credentials are not set are the project is not in Go: Show the "configure Xray details" view in the components tree.
2. If credentials are not set and the project is Go: Show the GoCenter view in the component details tree.

