### PR TITLE
Set tooltip & description in generalInfo setter

### DIFF
--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
@@ -28,14 +28,6 @@ export class DependenciesTreeNode extends vscode.TreeItem {
         }
     }
 
-    get tooltip(): string {
-        return this.componentId;
-    }
-
-    get description(): string {
-        return this.generalInfo.version;
-    }
-
     public get componentId(): string {
         return this.generalInfo.getComponentId();
     }
@@ -86,6 +78,8 @@ export class DependenciesTreeNode extends vscode.TreeItem {
 
     public set generalInfo(generalInfo: GeneralInfo) {
         this._generalInfo = generalInfo;
+        this.description = this.generalInfo.version;
+        this.tooltip = this.componentId;
     }
 
     public set parent(parent: DependenciesTreeNode | undefined) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Resolves the following compilation errors:
```
'tooltip' is defined as a property in class 'TreeItem', but is overridden here in 'DependenciesTreeNode' as an accessor.ts(2611)
```
```
'description' is defined as a property in class 'TreeItem', but is overridden here in 'DependenciesTreeNode' as an accessor.ts(2611)
```

See breaking changes in Typescript 4.0: 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#properties-overriding-accessors-and-vice-versa-is-an-error