### PR TITLE
Bugfix: fixed versions not displayed as expected

### DIFF
--- a/src/main/utils/translators.ts
+++ b/src/main/utils/translators.ts
@@ -1,10 +1,11 @@
+import * as Collections from 'typescript-collections';
 import { IGeneral, IIssue, ILicense, IVulnerableComponent, Severity as ClientSeverity } from 'xray-client-js';
+import { ISeverityCount } from '../goCenterClient/model/SeverityCount';
+import { GavGeneralInfo } from '../types/gavGeneralinfo';
 import { GeneralInfo } from '../types/generalInfo';
 import { Issue } from '../types/issue';
 import { License } from '../types/license';
 import { Severity } from '../types/severity';
-import { GavGeneralInfo } from '../types/gavGeneralinfo';
-import { ISeverityCount } from '../goCenterClient/model/SeverityCount';
 
 export class Translators {
     public static toGeneralInfo(clientGeneral: IGeneral): GeneralInfo {
@@ -76,11 +77,12 @@ export class Translators {
         if (!vulnerableComponents) {
             return [];
         }
-        let fixed_versions: string[] = [];
+        let fixed_versions: Collections.Set<string> = new Collections.Set();
         vulnerableComponents
             .map(vulnerableComponent => vulnerableComponent.fixed_versions)
-            .forEach(fixedVersion => (fixed_versions = fixed_versions.concat(fixedVersion)));
-        return fixed_versions;
+            .reduce((acc, val) => acc.concat(val), []) // Flatten the array and filter falsy values
+            .forEach(fixedVersion => fixed_versions.add(fixedVersion));
+        return fixed_versions.toArray();
     }
 
     public static capitalize(str: string): string {

--- a/src/test/tests/translators.test.ts
+++ b/src/test/tests/translators.test.ts
@@ -1,0 +1,43 @@
+import { assert, expect } from 'chai';
+import { IIssue, IVulnerableComponent } from 'xray-client-js';
+import { Issue } from '../../main/types/issue';
+import { Translators } from '../../main/utils/translators';
+
+/**
+ * Test functionality of @class Translators.
+ */
+describe('Translators Tests', () => {
+    it('Fixed versions - No issues', async () => {
+        let issue: Issue = Translators.toIssue({} as IIssue);
+        assert.isEmpty(issue.fixedVersions);
+    });
+
+    it('Fixed versions - Empty', async () => {
+        let component: IVulnerableComponent = { fixed_versions: [] };
+        let issue: Issue = Translators.toIssue({ components: [component] } as IIssue);
+        assert.isEmpty(issue.fixedVersions);
+    });
+
+    it('Fixed versions - Many empty fixed versions', async () => {
+        let component1: IVulnerableComponent = { fixed_versions: [] };
+        let component2: IVulnerableComponent = { fixed_versions: [] };
+        let issue: Issue = Translators.toIssue({ components: [component1, component2] } as IIssue);
+        assert.isEmpty(issue.fixedVersions);
+    });
+
+    it('Fixed versions - Some empty fixed versions', async () => {
+        let component1: IVulnerableComponent = { fixed_versions: ['1'] };
+        let component2: IVulnerableComponent = { fixed_versions: [] };
+        let issue: Issue = Translators.toIssue({ components: [component1, component2] } as IIssue);
+        assert.lengthOf(issue.fixedVersions, 1);
+        expect(issue.fixedVersions).to.have.members(['1']);
+    });
+
+    it('Fixed versions - Distinction', async () => {
+        let component1: IVulnerableComponent = { fixed_versions: ['1', '2'] };
+        let component2: IVulnerableComponent = { fixed_versions: ['2', '1'] };
+        let issue: Issue = Translators.toIssue({ components: [component1, component2] } as IIssue);
+        assert.lengthOf(issue.fixedVersions, 2);
+        expect(issue.fixedVersions).to.have.members(['1', '2']);
+    });
+});


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fix 2 issues:
1. Xray issue's vulnerable component response may return components without fixed_versions. For example:
```json
"components": [
  {
     "component_id": "some component ID"
  }
]
```
But the code expects:
```json
"components": [
  {
     "component_id": "some component ID",
     "fixed_versions": ["1", "2", "..."]
  }
]
```
The results are many "," in fixed version:
![image](https://user-images.githubusercontent.com/11367982/91456749-5063ba80-e88c-11ea-85a8-679b19850534.png)

2. Xray issue's vulnerable component response may return duplicate fixed_versions. For example:
```json
"components": [
  {
     "component_id": "some component ID1",
     "fixed_versions": ["1", "2"]
  },
  {
     "component_id": "some component ID2",
     "fixed_versions": ["1", "2"]
  }
]
```
The result is duplication in fixed version:
![image](https://user-images.githubusercontent.com/11367982/91457462-0c24ea00-e88d-11ea-81ae-84a96b051f65.png)
