### PR TITLE
Bump lodash to 4.17.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,9 +1131,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
             "dev": true
         },
         "log-symbols": {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
