### PR TITLE
Add CVEs information in "Component Issue Details"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -249,11 +249,11 @@
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
             "requires": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.10.0"
             }
         },
         "azure-devops-node-api": {
@@ -556,6 +556,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
             "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
@@ -789,12 +790,9 @@
             "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-            "requires": {
-                "debug": "=3.1.0"
-            }
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+            "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
         },
         "fs-constants": {
             "version": "1.0.0",
@@ -1326,7 +1324,8 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "mute-stream": {
             "version": "0.0.8",
@@ -2242,11 +2241,11 @@
             }
         },
         "xray-client-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/xray-client-js/-/xray-client-js-1.0.3.tgz",
-            "integrity": "sha512-e7w45CFVP0QqVz8dB7bmLkl8oWfKRJlKIBqG2JGcopuuzsLpNtDibt8w3MeDYVZ0UhTaVNLbIYPtU8oHP3Iexw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xray-client-js/-/xray-client-js-1.1.0.tgz",
+            "integrity": "sha512-meh2ZPmnfICDSMc+mmoZCeWpS2SKtldFz7PKi/c5ucU2U/8RZWAWQASGMHZwKfRwToDoO+/0UO6ZDsQNmib3pg==",
             "requires": {
-                "axios": "~0.19.2"
+                "axios": "~0.21.1"
             }
         },
         "y18n": {

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
         "semver": "~7.3.2",
         "typescript-collections": "~1.3.3",
         "xmlbuilder2": "~2.1.2",
-        "xray-client-js": "~1.0.3"
+        "xray-client-js": "~1.1.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.11",

--- a/src/main/treeDataProviders/issuesDataProvider.ts
+++ b/src/main/treeDataProviders/issuesDataProvider.ts
@@ -50,6 +50,7 @@ export class IssuesDataProvider implements vscode.TreeDataProvider<IssueNode> {
                 let issueNode: IssueNode = new IssueNode(
                     issue.severity,
                     issue.summary,
+                    issue.cves,
                     issue.issueType,
                     issue.component,
                     issue.fixedVersions,
@@ -66,6 +67,10 @@ export class IssuesDataProvider implements vscode.TreeDataProvider<IssueNode> {
             new TreeDataHolder('Severity', SeverityUtils.getString(element.severity)),
             new TreeDataHolder('Component', element.component)
         ];
+        let cves: string[] | undefined = element.cves;
+        if (cves && cves.length > 0) {
+            children.push(new TreeDataHolder('CVEs', cves.toString()));
+        }
         let fixedVersions: string[] | undefined = element.fixedVersions;
         if (fixedVersions && fixedVersions.length > 0) {
             children.push(new TreeDataHolder('Fixed Versions', fixedVersions.toString()));
@@ -83,6 +88,7 @@ export class IssueNode extends vscode.TreeItem {
     constructor(
         readonly severity: Severity,
         readonly summary: string,
+        readonly cves?: string[],
         readonly issueType?: string,
         readonly component?: string,
         readonly fixedVersions?: string[],

--- a/src/main/types/issue.ts
+++ b/src/main/types/issue.ts
@@ -10,8 +10,13 @@ export class Issue {
         private _description: string,
         private _issueType: string,
         private _fixedVersions: string[] = [],
+        private _cves?: string[],
         private _gocenter_security_url?: string
     ) {}
+
+    public get cves(): string[] | undefined {
+        return this._cves;
+    }
 
     public get description(): string {
         return this._description;
@@ -39,6 +44,10 @@ export class Issue {
 
     public get gocenter_security_url(): string | undefined {
         return this._gocenter_security_url;
+    }
+
+    public set cves(cves: string[] | undefined) {
+        this._cves = cves;
     }
 
     public set description(value: string) {

--- a/src/main/utils/translators.ts
+++ b/src/main/utils/translators.ts
@@ -1,5 +1,5 @@
 import * as Collections from 'typescript-collections';
-import { IGeneral, IIssue, ILicense, IVulnerableComponent, Severity as ClientSeverity } from 'xray-client-js';
+import { ICve, IGeneral, IIssue, ILicense, IVulnerableComponent, Severity as ClientSeverity } from 'xray-client-js';
 import { ISeverityCount } from '../goCenterClient/model/SeverityCount';
 import { GavGeneralInfo } from '../types/gavGeneralinfo';
 import { GeneralInfo } from '../types/generalInfo';
@@ -21,7 +21,8 @@ export class Translators {
             Translators.toSeverity(clientIssue.severity),
             clientIssue.description,
             Translators.capitalize(clientIssue.issue_type),
-            Translators.toFixedVersions(clientIssue.components)
+            Translators.toFixedVersions(clientIssue.components),
+            Translators.toCves(clientIssue.cves)
         );
     }
 
@@ -36,6 +37,7 @@ export class Translators {
                             Translators.toSeverity(issueLevel),
                             '',
                             '',
+                            [],
                             [],
                             gocenter_security_url
                         )
@@ -71,6 +73,14 @@ export class Translators {
 
     public static stringToLicense(clientLicense: string): License {
         return new License([], [], '', clientLicense);
+    }
+
+    private static toCves(clientCves: ICve[]): string[] {
+        let cves: string[] = [];
+        if (clientCves) {
+            clientCves.filter(cve => cve.cve).forEach(cve => cves.push(cve.cve));
+        }
+        return cves;
     }
 
     private static toFixedVersions(vulnerableComponents: IVulnerableComponent[]): string[] {

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -52,7 +52,7 @@ describe('Nuget Utils Tests', () => {
         }
     });
 
-        /**
+    /**
      * Test NugetUtils.createDependenciesTrees.
      */
     it('Create NuGet Dependencies Trees', async () => {
@@ -96,15 +96,15 @@ describe('Nuget Utils Tests', () => {
 
     function replacePackagesPathInAssets() {
         const projects: string[] = ['api', 'core'];
-        let packagesPath: string = path.join(tmpDir.fsPath, "assets", "packagesFolder");
+        let packagesPath: string = path.join(tmpDir.fsPath, 'assets', 'packagesFolder');
         if (isWindows()) {
-            packagesPath = packagesPath.replace(/\\/g, "\\\\");
+            packagesPath = packagesPath.replace(/\\/g, '\\\\');
         }
         projects.forEach(async project => {
-            const fileToReplace: string = path.join(tmpDir.fsPath, "assets", project, "obj", "project.assets.json");
-            let content: string = fs.readFileSync(fileToReplace, {encoding: "utf8"});
+            const fileToReplace: string = path.join(tmpDir.fsPath, 'assets', project, 'obj', 'project.assets.json');
+            let content: string = fs.readFileSync(fileToReplace, { encoding: 'utf8' });
             content = content.replace(/\${PACKAGES_PATH}/g, packagesPath);
-            fs.writeFileSync(fileToReplace, content, {encoding: "utf8"});
+            fs.writeFileSync(fileToReplace, content, { encoding: 'utf8' });
         });
     }
 });

--- a/src/test/tests/translators.test.ts
+++ b/src/test/tests/translators.test.ts
@@ -45,20 +45,14 @@ describe('Translators Tests', () => {
         let clientCves: ICve[] = [];
         let issues: Issue = Translators.toIssue({ cves: clientCves } as IIssue);
         assert.isDefined(issues.cves);
-        if (!issues.cves) {
-            return;
-        }
-        assert.lengthOf(issues.cves, 0);
+        assert.lengthOf(issues.cves || [], 0);
     });
 
     it('CVEs - Empty CVEs', async () => {
         let clientCves: ICve[] = [{ cve: '', cvss_v2: '4.3/CVSS:2.0/AV:N/AC:M/Au:N/C:N/I:P/A:N' }];
         let issues: Issue = Translators.toIssue({ cves: clientCves } as IIssue);
         assert.isDefined(issues.cves);
-        if (!issues.cves) {
-            return;
-        }
-        assert.lengthOf(issues.cves, 0);
+        assert.lengthOf(issues.cves || [], 0);
     });
 
     it('CVEs - One CVE', async () => {

--- a/src/test/tests/translators.test.ts
+++ b/src/test/tests/translators.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import { IIssue, IVulnerableComponent } from 'xray-client-js';
+import { ICve, IIssue, IVulnerableComponent } from 'xray-client-js';
 import { Issue } from '../../main/types/issue';
 import { Translators } from '../../main/utils/translators';
 
@@ -13,31 +13,77 @@ describe('Translators Tests', () => {
     });
 
     it('Fixed versions - Empty', async () => {
-        let component: IVulnerableComponent = { fixed_versions: [] };
+        let component: IVulnerableComponent = { component_id: '', fixed_versions: [] };
         let issue: Issue = Translators.toIssue({ components: [component] } as IIssue);
         assert.isEmpty(issue.fixedVersions);
     });
 
     it('Fixed versions - Many empty fixed versions', async () => {
-        let component1: IVulnerableComponent = { fixed_versions: [] };
-        let component2: IVulnerableComponent = { fixed_versions: [] };
+        let component1: IVulnerableComponent = { component_id: 'comp1', fixed_versions: [] };
+        let component2: IVulnerableComponent = { component_id: 'comp2', fixed_versions: [] };
         let issue: Issue = Translators.toIssue({ components: [component1, component2] } as IIssue);
         assert.isEmpty(issue.fixedVersions);
     });
 
     it('Fixed versions - Some empty fixed versions', async () => {
-        let component1: IVulnerableComponent = { fixed_versions: ['1'] };
-        let component2: IVulnerableComponent = { fixed_versions: [] };
+        let component1: IVulnerableComponent = { component_id: 'comp1', fixed_versions: ['1'] };
+        let component2: IVulnerableComponent = { component_id: 'comp2', fixed_versions: [] };
         let issue: Issue = Translators.toIssue({ components: [component1, component2] } as IIssue);
         assert.lengthOf(issue.fixedVersions, 1);
         expect(issue.fixedVersions).to.have.members(['1']);
     });
 
     it('Fixed versions - Distinction', async () => {
-        let component1: IVulnerableComponent = { fixed_versions: ['1', '2'] };
-        let component2: IVulnerableComponent = { fixed_versions: ['2', '1'] };
+        let component1: IVulnerableComponent = { component_id: 'comp1', fixed_versions: ['1', '2'] };
+        let component2: IVulnerableComponent = { component_id: 'comp2', fixed_versions: ['2', '1'] };
         let issue: Issue = Translators.toIssue({ components: [component1, component2] } as IIssue);
         assert.lengthOf(issue.fixedVersions, 2);
         expect(issue.fixedVersions).to.have.members(['1', '2']);
+    });
+
+    it('CVEs - No CVEs', async () => {
+        let clientCves: ICve[] = [];
+        let issues: Issue = Translators.toIssue({ cves: clientCves } as IIssue);
+        assert.isDefined(issues.cves);
+        if (!issues.cves) {
+            return;
+        }
+        assert.lengthOf(issues.cves, 0);
+    });
+
+    it('CVEs - Empty CVEs', async () => {
+        let clientCves: ICve[] = [{ cve: '', cvss_v2: '4.3/CVSS:2.0/AV:N/AC:M/Au:N/C:N/I:P/A:N' }];
+        let issues: Issue = Translators.toIssue({ cves: clientCves } as IIssue);
+        assert.isDefined(issues.cves);
+        if (!issues.cves) {
+            return;
+        }
+        assert.lengthOf(issues.cves, 0);
+    });
+
+    it('CVEs - One CVE', async () => {
+        let clientCves: ICve[] = [{ cve: 'CVE-2020-1', cvss_v2: '4.3/CVSS:2.0/AV:N/AC:M/Au:N/C:N/I:P/A:N' }];
+        let issues: Issue = Translators.toIssue({ cves: clientCves } as IIssue);
+        assert.isDefined(issues.cves);
+        if (!issues.cves) {
+            return;
+        }
+        assert.lengthOf(issues.cves, 1);
+        assert.equal(issues.cves[0], 'CVE-2020-1');
+    });
+
+    it('CVEs - Two CVEs', async () => {
+        let clientCves: ICve[] = [
+            { cve: 'CVE-2020-1', cvss_v2: '4.3/CVSS:2.0/AV:N/AC:M/Au:N/C:N/I:P/A:N' },
+            { cve: 'CVE-2020-2', cvss_v2: '4.3/CVSS:2.0/AV:N/AC:M/Au:N/C:N/I:P/A:N' }
+        ];
+        let issues: Issue = Translators.toIssue({ cves: clientCves } as IIssue);
+        assert.isDefined(issues.cves);
+        if (!issues.cves) {
+            return;
+        }
+        assert.lengthOf(issues.cves, 2);
+        expect(issues.cves).to.have.members(['CVE-2020-1', 'CVE-2020-2']);
+        expect(issues.cves.toString()).to.be.oneOf(['CVE-2020-1,CVE-2020-2', 'CVE-2020-2,CVE-2020-1']);
     });
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Depends on: https://github.com/jfrog/xray-client-js/pull/11. Tests will fail without it.

* If 1 CVEs exist add it to the tree (See image below).
* If CVEs does not exist, don't add the CVEs node.
* If more than 1 CVE exist, put them in 1 string delimited by comma (`,`), for example: `CVE-1,CVE-2`.
![image](https://user-images.githubusercontent.com/11367982/93669449-df837d00-fa9c-11ea-82f4-ddbb1e3e0e58.png)
