### PR TITLE
Add example URL in connection

### DIFF
--- a/src/main/connect/connectionManager.ts
+++ b/src/main/connect/connectionManager.ts
@@ -155,9 +155,10 @@ export class ConnectionManager implements ExtensionComponent {
         if (prompt) {
             url =
                 (await vscode.window.showInputBox({
-                    prompt: 'Enter Xray url',
-                    value: this._url ? this._url : 'https://',
+                    prompt: 'Enter Xray URL',
+                    value: this._url,
                     ignoreFocusOut: true,
+                    placeHolder: 'Example: https://myjfrog.acme.org/xray',
                     validateInput: ConnectionUtils.validateUrl
                 })) || '';
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

https://github.com/jfrog/jfrog-vscode-extension/issues/78

Instead of showing `https://`, show an Xray example URL:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/11367982/97906024-a3099900-1d4b-11eb-8f8a-74411a85b76f.png">

Same as we did here: https://github.com/jfrog/jfrog-idea-plugin/pull/89

