### PR TITLE
Add scope dependencies filter

### DIFF
--- a/src/main/filter/filterManager.ts
+++ b/src/main/filter/filterManager.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { ExtensionComponent } from '../extensionComponent';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
-import { GeneralInfo } from '../types/generalInfo';
 import { LicensesFilter } from './licensesFilter';
 import { ScopesFilter } from './scopeFilter';
 import { SeverityFilter as SeveritiesFilter } from './severitiesFilter';

--- a/src/main/filter/filterManager.ts
+++ b/src/main/filter/filterManager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ExtensionComponent } from '../extensionComponent';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
+import { GeneralInfo } from '../types/generalInfo';
 import { LicensesFilter } from './licensesFilter';
 import { ScopesFilter } from './scopeFilter';
 import { SeverityFilter as SeveritiesFilter } from './severitiesFilter';
@@ -57,7 +58,7 @@ export class FilterManager implements ExtensionComponent {
     public getFilters(): string[] {
         let results: string[] = [];
         Object.values(FilterTypes).forEach(filterType => {
-            // Includes sub menu of scopes  in filters iff there is at least one scope in the project.
+            // Includes sub-menu of scopes in filters if there is at least one scope in the project.
             if (filterType === FilterTypes.SCOPE && this._scopeFilter.getValues().length === 0) {
                 return;
             }

--- a/src/main/filter/scopeFilter.ts
+++ b/src/main/filter/scopeFilter.ts
@@ -10,12 +10,13 @@ export class ScopesFilter extends AbstractFilter {
 
     /** @override */
     public getValues(): vscode.QuickPickItem[] {
-        return this._treesManager.dependenciesTreeDataProvider.filterScopes.toArray().map(scope => {
+       let values: vscode.QuickPickItem[] = this._treesManager.dependenciesTreeDataProvider.filterScopes.toArray().map(scope => {
             return <vscode.QuickPickItem>{
                 label: scope.label,
                 picked: true
             };
         });
+        return values.some(v => v.label !== 'None') ? values : [];
     }
 
     /** @override */

--- a/src/main/filter/scopeFilter.ts
+++ b/src/main/filter/scopeFilter.ts
@@ -10,7 +10,7 @@ export class ScopesFilter extends AbstractFilter {
 
     /** @override */
     public getValues(): vscode.QuickPickItem[] {
-       let values: vscode.QuickPickItem[] = this._treesManager.dependenciesTreeDataProvider.filterScopes.toArray().map(scope => {
+        let values: vscode.QuickPickItem[] = this._treesManager.dependenciesTreeDataProvider.filterScopes.toArray().map(scope => {
             return <vscode.QuickPickItem>{
                 label: scope.label,
                 picked: true

--- a/src/main/filter/scopeFilter.ts
+++ b/src/main/filter/scopeFilter.ts
@@ -1,0 +1,28 @@
+import * as vscode from 'vscode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { AbstractFilter } from './abstractFilter';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+
+export class ScopesFilter extends AbstractFilter {
+    constructor(private _treesManager: TreesManager) {
+        super();
+    }
+
+    /** @override */
+    public getValues(): vscode.QuickPickItem[] {
+        return this._treesManager.dependenciesTreeDataProvider.filterScopes.toArray().map(scope => {
+            return <vscode.QuickPickItem>{
+                label: scope.label,
+                picked: true
+            };
+        });
+    }
+
+    /** @override */
+    public isNodePicked(dependenciesTreeNode: DependenciesTreeNode): boolean {
+        if (!this._choice) {
+            return true;
+        }
+        return dependenciesTreeNode.generalInfo.scopes.some(scope => this.isPicked(scope));
+    }
+}

--- a/src/main/treeDataProviders/componentDetailsDataProvider.ts
+++ b/src/main/treeDataProviders/componentDetailsDataProvider.ts
@@ -53,6 +53,9 @@ export class ComponentDetailsDataProvider implements vscode.TreeDataProvider<any
             children.push(new TreeDataHolder('Stars', String(this._selectedNode.componentMetadata.stars) + ' ★'));
         }
         children.push(new TreeDataHolder('Type', this._selectedNode.generalInfo.pkgType));
+        if (this._selectedNode.generalInfo.scopes.length > 0) {
+            children.push(new TreeDataHolder('Scopes', this._selectedNode.generalInfo.scopes.join(',')));
+        }
         children.push(new TreeDataHolder('Issues count', String(this._selectedNode.issues.size())));
         let path: string = this._selectedNode.generalInfo.path;
         if (path) {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
@@ -21,7 +21,7 @@ export class GoTreeNode extends DependenciesTreeNode {
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
@@ -36,10 +36,10 @@ export class GoTreeNode extends DependenciesTreeNode {
         } catch (error) {
             this._treesManager.logManager.logError(error, !quickScan);
             this.label = this._workspaceFolder + ' [Not installed]';
-            this.generalInfo = new GeneralInfo(this.label, '', this._workspaceFolder, GoUtils.PKG_TYPE);
+            this.generalInfo = new GeneralInfo(this.label, '', [], this._workspaceFolder, GoUtils.PKG_TYPE);
             return;
         }
-        this.generalInfo = new GeneralInfo(rootPackageName, '', this._workspaceFolder, GoUtils.PKG_TYPE);
+        this.generalInfo = new GeneralInfo(rootPackageName, '', [], this._workspaceFolder, GoUtils.PKG_TYPE);
         this.label = rootPackageName;
         if (goList.length === 0) {
             return;
@@ -55,7 +55,7 @@ export class GoTreeNode extends DependenciesTreeNode {
         let directDependenciesGeneralInfos: GeneralInfo[] = [];
         for (; i < goList.length && !goList[i].includes('@'); i += 2) {
             let nameVersionTuple: string[] = this.getNameVersionTuple(goList[i + 1]);
-            directDependenciesGeneralInfos.push(new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], '', GoUtils.PKG_TYPE));
+            directDependenciesGeneralInfos.push(new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], [], '', GoUtils.PKG_TYPE));
         }
 
         // Build dependencies map
@@ -80,7 +80,7 @@ export class GoTreeNode extends DependenciesTreeNode {
             this._dependenciesMap.get(dependenciesTreeNode.generalInfo.artifactId + '@v' + dependenciesTreeNode.generalInfo.version) || [];
         childDependencies.forEach(childDependency => {
             let nameVersionTuple: string[] = this.getNameVersionTuple(childDependency);
-            let generalInfo: GeneralInfo = new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], '', GoUtils.PKG_TYPE);
+            let generalInfo: GeneralInfo = new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], [], '', GoUtils.PKG_TYPE);
             let grandchild: GoDependenciesTreeNode = new GoDependenciesTreeNode(
                 generalInfo,
                 this.getTreeCollapsibleState(generalInfo),

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
@@ -21,7 +21,7 @@ export class GoTreeNode extends DependenciesTreeNode {
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(new GeneralInfo('', '', ['None'], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
@@ -39,7 +39,7 @@ export class GoTreeNode extends DependenciesTreeNode {
             this.generalInfo = new GeneralInfo(this.label, '', [], this._workspaceFolder, GoUtils.PKG_TYPE);
             return;
         }
-        this.generalInfo = new GeneralInfo(rootPackageName, '', [], this._workspaceFolder, GoUtils.PKG_TYPE);
+        this.generalInfo = new GeneralInfo(rootPackageName, '', ['None'], this._workspaceFolder, GoUtils.PKG_TYPE);
         this.label = rootPackageName;
         if (goList.length === 0) {
             return;
@@ -55,7 +55,7 @@ export class GoTreeNode extends DependenciesTreeNode {
         let directDependenciesGeneralInfos: GeneralInfo[] = [];
         for (; i < goList.length && !goList[i].includes('@'); i += 2) {
             let nameVersionTuple: string[] = this.getNameVersionTuple(goList[i + 1]);
-            directDependenciesGeneralInfos.push(new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], [], '', GoUtils.PKG_TYPE));
+            directDependenciesGeneralInfos.push(new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], ['None'], '', GoUtils.PKG_TYPE));
         }
 
         // Build dependencies map
@@ -80,7 +80,7 @@ export class GoTreeNode extends DependenciesTreeNode {
             this._dependenciesMap.get(dependenciesTreeNode.generalInfo.artifactId + '@v' + dependenciesTreeNode.generalInfo.version) || [];
         childDependencies.forEach(childDependency => {
             let nameVersionTuple: string[] = this.getNameVersionTuple(childDependency);
-            let generalInfo: GeneralInfo = new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], [], '', GoUtils.PKG_TYPE);
+            let generalInfo: GeneralInfo = new GeneralInfo(nameVersionTuple[0], nameVersionTuple[1], ['None'], '', GoUtils.PKG_TYPE);
             let grandchild: GoDependenciesTreeNode = new GoDependenciesTreeNode(
                 generalInfo,
                 this.getTreeCollapsibleState(generalInfo),

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
@@ -17,7 +17,7 @@ export class MavenTreeNode extends DependenciesTreeNode {
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', _workspaceFolder, ''), vscode.TreeItemCollapsibleState.None, parent);
+        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.None, parent);
         MavenUtils.pathToNode.set(_workspaceFolder, this);
     }
 
@@ -32,7 +32,7 @@ export class MavenTreeNode extends DependenciesTreeNode {
      */
     public async refreshDependencies(quickScan: boolean, prototypeTree: PomTree, parentDependencies?: string[]) {
         const [group, name, version] = prototypeTree.pomGav.split(':');
-        this.generalInfo = new GavGeneralInfo(group, name, version, this._workspaceFolder, MavenUtils.PKG_TYPE);
+        this.generalInfo = new GavGeneralInfo(group, name, version, [], this._workspaceFolder, MavenUtils.PKG_TYPE);
         this.label = group + ':' + name;
         let rawDependenciesList: string[] | undefined = await prototypeTree.getRawDependencies(this._treesManager);
         if (!!rawDependenciesList && rawDependenciesList.length > 0) {
@@ -64,8 +64,8 @@ export class MavenTreeNode extends DependenciesTreeNode {
     ) {
         for (; rawDependenciesPtr.index < rawDependenciesList.length; rawDependenciesPtr.index++) {
             let dependency: string = rawDependenciesList[rawDependenciesPtr.index];
-            const [group, name, version] = MavenUtils.getDependencyInfo(dependency);
-            const gavGeneralInfo: GavGeneralInfo = new GavGeneralInfo(group, name, version, '', MavenUtils.PKG_TYPE);
+            const [group, name, version, scope] = MavenUtils.getDependencyInfo(dependency);
+            const gavGeneralInfo: GavGeneralInfo = new GavGeneralInfo(group, name, version, [scope], '', MavenUtils.PKG_TYPE);
             let treeCollapsibleState: vscode.TreeItemCollapsibleState = this.isParent(rawDependenciesList, rawDependenciesPtr.index)
                 ? vscode.TreeItemCollapsibleState.Collapsed
                 : vscode.TreeItemCollapsibleState.None;

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -38,6 +38,7 @@ export class NpmTreeNode extends DependenciesTreeNode {
                 scopedProject.loadProjectDetails(JSON.parse(error.stdout.toString()));
                 npmLsFailed = true;
             }
+            this.populateDependenciesTree(this, scopedProject.dependencies, quickScan, scopedProject.scope);
         });
         this.generalInfo = new GeneralInfo(
             npmLsFailed ? (productionScope.projectName += ' [Not installed]') : productionScope.projectName,
@@ -47,9 +48,6 @@ export class NpmTreeNode extends DependenciesTreeNode {
             NpmUtils.PKG_TYPE
         );
         this.label = productionScope.projectName ? productionScope.projectName : path.join(this._workspaceFolder, 'package.json');
-        [productionScope, developmentScope].forEach(scopedProject => {
-            this.populateDependenciesTree(this, scopedProject.dependencies, quickScan, scopedProject.scope);
-        });
     }
 
     private populateDependenciesTree(dependenciesTreeNode: DependenciesTreeNode, dependencies: any, quickScan: boolean, globalScope: string) {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -15,11 +15,11 @@ export class NugetTreeNode extends DependenciesTreeNode {
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, '');
+        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, '');
     }
 
     public async refreshDependencies(quickScan: boolean, project: any) {
-        this.generalInfo = new GeneralInfo(project.name, '', this._workspaceFolder, NugetUtils.PKG_TYPE);
+        this.generalInfo = new GeneralInfo(project.name, '', [], this._workspaceFolder, NugetUtils.PKG_TYPE);
         this.label = project.name;
         this.populateDependenciesTree(this, project.dependencies, quickScan);
     }
@@ -35,7 +35,7 @@ export class NugetTreeNode extends DependenciesTreeNode {
             let version: string = nameVersionTuple[1];
             if (version) {
                 let childDependencies: any = dependency.directDependencies;
-                let generalInfo: GeneralInfo = new GeneralInfo(name, version, '', NugetUtils.PKG_TYPE);
+                let generalInfo: GeneralInfo = new GeneralInfo(name, version, [], '', NugetUtils.PKG_TYPE);
                 let treeCollapsibleState: vscode.TreeItemCollapsibleState =
                     childDependencies.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode, '');

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -15,11 +15,11 @@ export class NugetTreeNode extends DependenciesTreeNode {
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, '');
+        super(new GeneralInfo('', '', ['None'], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, '');
     }
 
     public async refreshDependencies(quickScan: boolean, project: any) {
-        this.generalInfo = new GeneralInfo(project.name, '', [], this._workspaceFolder, NugetUtils.PKG_TYPE);
+        this.generalInfo = new GeneralInfo(project.name, '', ['None'], this._workspaceFolder, NugetUtils.PKG_TYPE);
         this.label = project.name;
         this.populateDependenciesTree(this, project.dependencies, quickScan);
     }
@@ -35,7 +35,7 @@ export class NugetTreeNode extends DependenciesTreeNode {
             let version: string = nameVersionTuple[1];
             if (version) {
                 let childDependencies: any = dependency.directDependencies;
-                let generalInfo: GeneralInfo = new GeneralInfo(name, version, [], '', NugetUtils.PKG_TYPE);
+                let generalInfo: GeneralInfo = new GeneralInfo(name, version, ['None'], '', NugetUtils.PKG_TYPE);
                 let treeCollapsibleState: vscode.TreeItemCollapsibleState =
                     childDependencies.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode, '');

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
@@ -22,7 +22,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
         private _pythonPath: string,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', _projectDir, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(new GeneralInfo('', '', [], _projectDir, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
@@ -31,7 +31,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
             pypiList = JSON.parse(
                 ScanUtils.executeCmd(this._pythonPath + ' ' + PypiUtils.PIP_DEP_TREE_SCRIPT + ' --json-tree', this._projectDir).toString()
             );
-            this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', this._projectDir, PypiUtils.PKG_TYPE);
+            this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', [], this._projectDir, PypiUtils.PKG_TYPE);
         } catch (error) {
             this._treesManager.logManager.logError(error, !quickScan);
         }
@@ -48,7 +48,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
             let version: string = dependency.installed_version;
             if (version) {
                 let childDependencies: any = dependency.dependencies;
-                let generalInfo: GeneralInfo = new GeneralInfo(dependency.key, version, '', PypiUtils.PKG_TYPE);
+                let generalInfo: GeneralInfo = new GeneralInfo(dependency.key, version, [], '', PypiUtils.PKG_TYPE);
                 let treeCollapsibleState: vscode.TreeItemCollapsibleState =
                     childDependencies && childDependencies.length > 0
                         ? vscode.TreeItemCollapsibleState.Collapsed

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
@@ -22,7 +22,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
         private _pythonPath: string,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', [], _projectDir, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(new GeneralInfo('', '', ['None'], _projectDir, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
@@ -31,7 +31,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
             pypiList = JSON.parse(
                 ScanUtils.executeCmd(this._pythonPath + ' ' + PypiUtils.PIP_DEP_TREE_SCRIPT + ' --json-tree', this._projectDir).toString()
             );
-            this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', [], this._projectDir, PypiUtils.PKG_TYPE);
+            this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', ['None'], this._projectDir, PypiUtils.PKG_TYPE);
         } catch (error) {
             this._treesManager.logManager.logError(error, !quickScan);
         }
@@ -48,7 +48,7 @@ export class PypiTreeNode extends DependenciesTreeNode {
             let version: string = dependency.installed_version;
             if (version) {
                 let childDependencies: any = dependency.dependencies;
-                let generalInfo: GeneralInfo = new GeneralInfo(dependency.key, version, [], '', PypiUtils.PKG_TYPE);
+                let generalInfo: GeneralInfo = new GeneralInfo(dependency.key, version, ['None'], '', PypiUtils.PKG_TYPE);
                 let treeCollapsibleState: vscode.TreeItemCollapsibleState =
                     childDependencies && childDependencies.length > 0
                         ? vscode.TreeItemCollapsibleState.Collapsed

--- a/src/main/types/gavGeneralinfo.ts
+++ b/src/main/types/gavGeneralinfo.ts
@@ -1,11 +1,11 @@
 import { GeneralInfo } from './generalInfo';
 
 export class GavGeneralInfo extends GeneralInfo {
-    constructor(private _groupId: string, _artifactId: string, _version: string, _path: string, _pkgType: string) {
-        super(_artifactId, _version, _path, _pkgType);
+    constructor(private _groupId: string, _artifactId: string, _version: string, _scope: string[], _path: string, _pkgType: string) {
+        super(_artifactId, _version, _scope, _path, _pkgType);
     }
 
-    public get groupId() {
+    public get groupId(): string {
         return this._groupId;
     }
 

--- a/src/main/types/generalInfo.ts
+++ b/src/main/types/generalInfo.ts
@@ -1,19 +1,23 @@
 export class GeneralInfo {
-    constructor(private _artifactId: string, private _version: string, private _path: string, private _pkgType: string) {}
+    constructor(private _artifactId: string, private _version: string, private _scopes: string[], private _path: string, private _pkgType: string) {}
 
-    public get artifactId() {
+    public get artifactId(): string {
         return this._artifactId;
     }
 
-    public get version() {
+    public get version(): string {
         return this._version;
     }
 
-    public get path() {
+    public get scopes(): string[] {
+        return this._scopes;
+    }
+
+    public get path(): string {
         return this._path;
     }
 
-    public get pkgType() {
+    public get pkgType(): string {
         return this._pkgType;
     }
 
@@ -23,6 +27,10 @@ export class GeneralInfo {
 
     public set version(version: string) {
         this._version = version;
+    }
+
+    public set scopes(scopes: string[]) {
+        this._scopes = scopes;
     }
 
     public set path(path: string) {
@@ -35,5 +43,23 @@ export class GeneralInfo {
 
     public getComponentId(): string {
         return this._artifactId + ':' + this._version;
+    }
+
+    public update(newGeneralInfo: GeneralInfo) {
+        if (newGeneralInfo._artifactId !== '') {
+            this.artifactId = newGeneralInfo.artifactId;
+        }
+        if (newGeneralInfo.path !== '') {
+            this.path = newGeneralInfo.path;
+        }
+        if (newGeneralInfo.pkgType !== '') {
+            this.pkgType = newGeneralInfo.pkgType;
+        }
+        if (newGeneralInfo.scopes.length !== 0) {
+            this.scopes = newGeneralInfo.scopes;
+        }
+        if (newGeneralInfo.version !== '') {
+            this.version = newGeneralInfo.version;
+        }
     }
 }

--- a/src/main/types/scope.ts
+++ b/src/main/types/scope.ts
@@ -1,0 +1,14 @@
+export class Scope {
+    constructor(private _label: string) {}
+
+    public get label(): string {
+        return this._label;
+    }
+    public set label(value: string) {
+        this._label = value;
+    }
+
+    public toString(): string {
+        return this._label;
+    }
+}

--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -379,7 +379,7 @@ export class MavenUtils {
     /**
      * @param rawDependency Raw dependency text
      */
-    public static getProjectInfo(rawDependency: string): [string, string, string] {
+    public static getProjectInfo(rawDependency: string): [string, string, string, string] {
         return MavenUtils.getDependencyInfo(rawDependency.replace(/\s/g, '') + ':dummyScope');
     }
 
@@ -387,11 +387,11 @@ export class MavenUtils {
      * @param rawDependency - e.g. "|  |  +- javax.mail:mail:jar:1.4:compile"
      * @returns [groupId,ArtifactId,version]
      */
-    public static getDependencyInfo(rawDependency: string): [string, string, string] {
+    public static getDependencyInfo(rawDependency: string): [string, string, string, string] {
         let result: string[] = rawDependency.split(':');
         // Skip none alphanumeric characters
         let startIndex: number = result[0].search(/\w/);
-        return [result[0].slice(startIndex), result[1], result[result.length - 2]];
+        return [result[0].slice(startIndex), result[1], result[result.length - 2], result[result.length - 1].split(' ')[0]];
     }
 
     // 'mvn dependency:tree' duplicate the parent dependencies to its child.

--- a/src/main/utils/npmUtils.ts
+++ b/src/main/utils/npmUtils.ts
@@ -105,4 +105,57 @@ export class NpmUtils {
         }
         return true;
     }
+
+    public static getDependencyScope(dep: string): string {
+        if (dep !== '' && dep[0] === '@') {
+            return dep.substring(1, dep.indexOf('/'));
+        }
+        return '';
+    }
+}
+
+export class ScopedNpmProject {
+    private _projectName: string = '';
+    private _projectVersion: string = '';
+    private _dependencies: any;
+    private _scope: NpmGlobalScopes;
+
+    constructor(scope: NpmGlobalScopes) {
+        this._scope = scope;
+    }
+
+    public get projectName(): string {
+        return this._projectName;
+    }
+
+    public set projectName(projectName: string) {
+        this._projectName = projectName;
+    }
+
+    public get projectVersion(): string {
+        return this._projectVersion;
+    }
+
+    public set projectVersion(projectVersion: string) {
+        this._projectVersion = projectVersion;
+    }
+
+    public get dependencies() {
+        return this._dependencies;
+    }
+
+    public loadProjectDetails(lsOutput: any) {
+        this._projectName = lsOutput.name;
+        this._projectVersion = lsOutput.version;
+        this._dependencies = lsOutput.dependencies;
+    }
+
+    public get scope(): NpmGlobalScopes {
+        return this._scope;
+    }
+}
+
+export enum NpmGlobalScopes {
+    PRODUCTION = 'production',
+    DEVELOPMENT = 'development'
 }

--- a/src/main/utils/translators.ts
+++ b/src/main/utils/translators.ts
@@ -11,8 +11,8 @@ export class Translators {
     public static toGeneralInfo(clientGeneral: IGeneral): GeneralInfo {
         let components: string[] = clientGeneral.component_id.split(':');
         return components.length === 2
-            ? new GeneralInfo(components[0], components[1], clientGeneral.path, clientGeneral.pkg_type)
-            : new GavGeneralInfo(components[0], components[1], components[2], clientGeneral.path, clientGeneral.pkg_type);
+            ? new GeneralInfo(components[0], components[1], [], clientGeneral.path, clientGeneral.pkg_type)
+            : new GavGeneralInfo(components[0], components[1], components[2], [], clientGeneral.path, clientGeneral.pkg_type);
     }
 
     public static toIssue(clientIssue: IIssue): Issue {

--- a/src/test/resources/npm/dependency/package.json
+++ b/src/test/resources/npm/dependency/package.json
@@ -5,7 +5,12 @@
   "scripts": {
     "start": "node app"
   },
+  "devDependencies": {
+    "has-flag": "3.0.0",
+    "@ungap/promise-all-settled": "1.1.2"
+  },
   "dependencies": {
-    "progress": "2.0.3"
+    "progress": "2.0.3",
+    "@types/node": "14.14.10"
   }
 }

--- a/src/test/tests/componentDetails.test.ts
+++ b/src/test/tests/componentDetails.test.ts
@@ -14,7 +14,7 @@ describe('Component Details Tests', () => {
     let componentDetails: ComponentDetailsDataProvider = new ComponentDetailsDataProvider();
     let dependenciesTreeNode: DependenciesTreeNode;
     before(() => {
-        let generalInfo: GeneralInfo = new GeneralInfo('artifactId', '1.2.3', __dirname, 'testPkg');
+        let generalInfo: GeneralInfo = new GeneralInfo('artifactId', '1.2.3', [], __dirname, 'testPkg');
         dependenciesTreeNode = new DependenciesTreeNode(generalInfo);
         componentDetails.selectNode(dependenciesTreeNode);
     });

--- a/src/test/tests/dependenciesTree.test.ts
+++ b/src/test/tests/dependenciesTree.test.ts
@@ -98,8 +98,9 @@ describe('Dependencies Tree Tests', () => {
     function processTree(): Collections.Set<Issue> {
         return root.processTreeIssues();
     }
+
     function createNode(label: string): DependenciesTreeNode {
-        return new DependenciesTreeNode(new GeneralInfo(label, '1.0.0', '', ''));
+        return new DependenciesTreeNode(new GeneralInfo(label, '1.0.0', [], '', ''));
     }
 
     function createDummyIssue(severity: Severity) {

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -83,7 +83,7 @@ describe('Go Utils Tests', () => {
         // Test 'resources/go/dependency/go.mod'
         let goMod: vscode.Uri = vscode.Uri.file(path.join(tmpDir.fsPath, 'dependency', 'go.mod'));
         let textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(goMod);
-        let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('github.com/jfrog/gofrog', '1.0.5', '', ''));
+        let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('github.com/jfrog/gofrog', '1.0.5', [], '', ''));
         let dependencyPos: vscode.Position[] = GoUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(6, 1));
         assert.deepEqual(dependencyPos[1], new vscode.Position(6, 31));
@@ -99,7 +99,7 @@ describe('Go Utils Tests', () => {
      * Test GoUtils.createGoDependenciesTrees.
      */
     it('Create go Dependencies Trees', async () => {
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let goCenterComponentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let res: GoTreeNode[] = await runCreateGoDependenciesTrees(componentsToScan, goCenterComponentsToScan, parent, false);

--- a/src/test/tests/issuesDataProvider.test.ts
+++ b/src/test/tests/issuesDataProvider.test.ts
@@ -14,7 +14,7 @@ describe('Issues Data Provider Tests', () => {
     let dependenciesTreeNode: DependenciesTreeNode;
 
     before(() => {
-        let generalInfo: GeneralInfo = new GeneralInfo('odin', '1.2.3', __dirname, 'asgard');
+        let generalInfo: GeneralInfo = new GeneralInfo('odin', '1.2.3', [], __dirname, 'asgard');
         dependenciesTreeNode = new DependenciesTreeNode(generalInfo);
     });
 
@@ -47,7 +47,7 @@ describe('Issues Data Provider Tests', () => {
 
     it('Second node', async () => {
         // Create a second DependenciesTreNode
-        let secondNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('thor', '1.2.4', __dirname, 'midgard'));
+        let secondNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('thor', '1.2.4', [], __dirname, 'midgard'));
         dependenciesTreeNode.addChild(secondNode);
 
         // Add a new issue to the second node

--- a/src/test/tests/maven.test.ts
+++ b/src/test/tests/maven.test.ts
@@ -152,7 +152,9 @@ describe('Maven Tests', () => {
         // Test 'resources/maven/dependency/pom.xml'
         let pomXml: vscode.Uri = vscode.Uri.file(path.join(tmpDir.fsPath, 'dependency', 'pom.xml'));
         let textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(pomXml);
-        let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('javax.servlet.jsp', 'jsp-api', '2.1', '', ''));
+        let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(
+            new GavGeneralInfo('javax.servlet.jsp', 'jsp-api', '2.1', [], '', '')
+        );
         let dependencyPos: vscode.Position[] = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(9, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(9, 48));
@@ -163,7 +165,7 @@ describe('Maven Tests', () => {
 
         pomXml = vscode.Uri.file(path.join(tmpDir.fsPath, 'multiPomDependency', 'multi1', 'pom.xml'));
         textDocument = await vscode.workspace.openTextDocument(pomXml);
-        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.apache.commons', 'commons-email', '1.1', '', ''));
+        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.apache.commons', 'commons-email', '1.1', [], '', ''));
         dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(51, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(51, 49));
@@ -172,7 +174,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[4], new vscode.Position(53, 12));
         assert.deepEqual(dependencyPos[5], new vscode.Position(53, 34));
 
-        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.codehaus.plexus', 'plexus-utils', '1.5.1', '', ''));
+        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.codehaus.plexus', 'plexus-utils', '1.5.1', [], '', ''));
         dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(57, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(57, 50));
@@ -181,7 +183,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[4], new vscode.Position(59, 12));
         assert.deepEqual(dependencyPos[5], new vscode.Position(59, 36));
 
-        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('javax.servlet.jsp', 'jsp-api', '2.1', '', ''));
+        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('javax.servlet.jsp', 'jsp-api', '2.1', [], '', ''));
         dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(62, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(62, 48));
@@ -190,7 +192,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[4], new vscode.Position(65, 12));
         assert.deepEqual(dependencyPos[5], new vscode.Position(65, 34));
 
-        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('commons-io', 'commons-io', '1.4', '', ''));
+        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('commons-io', 'commons-io', '1.4', [], '', ''));
         dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(68, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(68, 41));
@@ -199,7 +201,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[4], new vscode.Position(70, 12));
         assert.deepEqual(dependencyPos[5], new vscode.Position(70, 34));
 
-        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.springframework', 'spring-aop', '2.5.6', '', ''));
+        dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.springframework', 'spring-aop', '2.5.6', [], '', ''));
         dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(73, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(73, 50));
@@ -219,7 +221,7 @@ describe('Maven Tests', () => {
      * Test createMavenDependenciesTrees.
      */
     it('Create Maven dependencies trees', async () => {
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let res: DependenciesTreeNode[] = await runCreateMavenDependenciesTrees(componentsToScan, parent);
         let toCompare: string[] = [
@@ -261,6 +263,7 @@ describe('Maven Tests', () => {
         assert.lengthOf(res[0].children[0].children, 0);
         assert.deepEqual(res[0].children[0].parent, res[0]);
         assert.equal(res[0].children[0].componentId, 'junit:junit:3.8.1');
+        assert.deepEqual(res[0].children[0].generalInfo.scopes, ['test']);
         assert.isTrue(res[0].children[0] instanceof DependenciesTreeNode);
         assert.lengthOf(res[0].children[2].children, 3);
         assert.deepEqual(res[0].children[2].parent, res[0]);
@@ -275,32 +278,41 @@ describe('Maven Tests', () => {
         // Check grandchildren
         // First
         assert.equal(res[0].children[2].children[0].componentId, 'org.jfrog.test:multi1:3.7-SNAPSHOT');
+        assert.deepEqual(res[0].children[2].children[0].generalInfo.scopes, ['compile']);
         assert.isTrue(res[0].children[2].children[0] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[2].children[0].parent, res[0].children[2]);
         assert.equal(res[0].children[2].children[1].componentId, 'hsqldb:hsqldb:1.8.0.10');
+        assert.deepEqual(res[0].children[2].children[1].generalInfo.scopes, ['runtime']);
         assert.isTrue(res[0].children[2].children[1] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[2].children[1].parent, res[0].children[2]);
         assert.equal(res[0].children[2].children[2].componentId, 'javax.servlet:servlet-api:2.5');
+        assert.deepEqual(res[0].children[2].children[2].generalInfo.scopes, ['provided']);
         assert.isTrue(res[0].children[2].children[2] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[2].children[2].parent, res[0].children[2]);
 
         // Third
         assert.equal(res[0].children[1].children[0].componentId, 'org.apache.commons:commons-email:1.1');
+        assert.deepEqual(res[0].children[1].children[0].generalInfo.scopes, ['compile']);
         assert.isTrue(res[0].children[1].children[0] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[1].children[0].parent, res[0].children[1]);
         assert.equal(res[0].children[1].children[1].componentId, 'org.codehaus.plexus:plexus-utils:1.5.1');
+        assert.deepEqual(res[0].children[1].children[1].generalInfo.scopes, ['compile']);
         assert.isTrue(res[0].children[1].children[1] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[1].children[1].parent, res[0].children[1]);
         assert.equal(res[0].children[1].children[2].componentId, 'javax.servlet.jsp:jsp-api:2.1');
+        assert.deepEqual(res[0].children[1].children[2].generalInfo.scopes, ['compile']);
         assert.isTrue(res[0].children[1].children[2] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[1].children[2].parent, res[0].children[1]);
         assert.equal(res[0].children[1].children[3].componentId, 'commons-io:commons-io:1.4');
+        assert.deepEqual(res[0].children[1].children[3].generalInfo.scopes, ['compile']);
         assert.isTrue(res[0].children[1].children[3] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[1].children[3].parent, res[0].children[1]);
         assert.equal(res[0].children[1].children[4].componentId, 'org.springframework:spring-aop:2.5.6');
+        assert.deepEqual(res[0].children[1].children[4].generalInfo.scopes, ['compile']);
         assert.isTrue(res[0].children[1].children[4] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[1].children[4].parent, res[0].children[1]);
         assert.equal(res[0].children[1].children[5].componentId, 'org.testng:testng:5.9');
+        assert.deepEqual(res[0].children[1].children[5].generalInfo.scopes, ['test']);
         assert.isTrue(res[0].children[1].children[5] instanceof DependenciesTreeNode);
         assert.deepEqual(res[0].children[1].children[5].parent, res[0].children[1]);
     });
@@ -309,7 +321,7 @@ describe('Maven Tests', () => {
      * Test excludeDependency.
      */
     it('Exclude dependency', async () => {
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let res: DependenciesTreeNode[] = await runCreateMavenDependenciesTrees(componentsToScan, parent);
 

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -52,11 +52,11 @@ describe('Nuget Utils Tests', () => {
         }
     });
 
-        /**
+    /**
      * Test NugetUtils.createDependenciesTrees.
      */
     it('Create NuGet Dependencies Trees', async () => {
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let res: DependenciesTreeNode[] = await runCreateNugetDependenciesTrees(componentsToScan, parent);
 
@@ -96,15 +96,15 @@ describe('Nuget Utils Tests', () => {
 
     function replacePackagesPathInAssets() {
         const projects: string[] = ['api', 'core'];
-        let packagesPath: string = path.join(tmpDir.fsPath, "assets", "packagesFolder");
+        let packagesPath: string = path.join(tmpDir.fsPath, 'assets', 'packagesFolder');
         if (isWindows()) {
-            packagesPath = packagesPath.replace(/\\/g, "\\\\");
+            packagesPath = packagesPath.replace(/\\/g, '\\\\');
         }
         projects.forEach(async project => {
-            const fileToReplace: string = path.join(tmpDir.fsPath, "assets", project, "obj", "project.assets.json");
-            let content: string = fs.readFileSync(fileToReplace, {encoding: "utf8"});
+            const fileToReplace: string = path.join(tmpDir.fsPath, 'assets', project, 'obj', 'project.assets.json');
+            let content: string = fs.readFileSync(fileToReplace, { encoding: 'utf8' });
             content = content.replace(/\${PACKAGES_PATH}/g, packagesPath);
-            fs.writeFileSync(fileToReplace, content, {encoding: "utf8"});
+            fs.writeFileSync(fileToReplace, content, { encoding: 'utf8' });
         });
     }
 });

--- a/src/test/tests/pypiUtils.test.ts
+++ b/src/test/tests/pypiUtils.test.ts
@@ -74,7 +74,7 @@ describe('Pypi Utils Tests', () => {
         // Test 'resources/python/requirements'
         let requirements: vscode.Uri = vscode.Uri.file(path.join(tmpDir.fsPath, 'requirements', 'requirements.txt'));
         let textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(requirements);
-        let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('newrelic', '2.0.0.1', '', ''));
+        let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('newrelic', '2.0.0.1', [], '', ''));
         let dependencyPos: vscode.Position[] = PypiUtils.getDependencyPos(textDocument, textDocument.getText().toLowerCase(), dependenciesTreeNode);
         assert.deepEqual(dependencyPos[0], new vscode.Position(2, 0));
 
@@ -96,7 +96,7 @@ describe('Pypi Utils Tests', () => {
             new Collections.Set(),
             treesManager,
             path.join(workspaceFolders[0].uri.fsPath, localPython),
-            new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
+            new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''))
         );
         dependenciesTreeNode.refreshDependencies(true);
         assert.deepEqual(dependenciesTreeNode.label, 'requirements');
@@ -109,7 +109,7 @@ describe('Pypi Utils Tests', () => {
             new Collections.Set(),
             treesManager,
             path.join(workspaceFolders[1].uri.fsPath, localPython),
-            new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
+            new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''))
         );
         dependenciesTreeNode.refreshDependencies(true);
         assert.deepEqual(dependenciesTreeNode.label, 'setup');
@@ -125,7 +125,7 @@ describe('Pypi Utils Tests', () => {
             new Collections.Set(),
             treesManager,
             path.join(workspaceFolders[2].uri.fsPath, localPython),
-            new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', '', ''))
+            new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''))
         );
         dependenciesTreeNode.refreshDependencies(true);
         assert.deepEqual(dependenciesTreeNode.label, 'setupAndRequirements');


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
**What is it?** 
 * Add a new filter option to filter nodes in the Component Tree by dependency scopes

**How to use it?**
 * Go to:  JFrog-Extention -> Filter -> Scope -> choose the scopes to be filtered.

 **Supported Languages**
  * NPM
  * Maven