### PR TITLE
Allow update a dependency to fixed version from tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
             "view/item/context": [
                 {
                     "command": "jfrog.xray.showInProjectDesc",
-                    "when": "viewItem =~ /frog.xray.showInProjectDesc.enabled/",
+                    "when": "viewItem =~ /jfrog.xray.showInProjectDesc.enabled/",
                     "group": "inline"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
                 "command": "jfrog.xray.excludeDependency",
                 "title": "Exclude dependency",
                 "icon": "$(exclude)"
+            },
+            {
+                "command": "jfrog.xray.updateDependency",
+                "title": "Update dependency to fixed version",
+                "icon": "$(arrow-up)"
             }
         ],
         "menus": {
@@ -137,12 +142,17 @@
             "view/item/context": [
                 {
                     "command": "jfrog.xray.showInProjectDesc",
-                    "when": "viewItem == jfrog.xray.showInProjectDesc.enabled || viewItem == jfrog.xray.excludeDependency.enabled",
+                    "when": "viewItem =~ /frog.xray.showInProjectDesc.enabled/",
                     "group": "inline"
                 },
                 {
                     "command": "jfrog.xray.excludeDependency",
-                    "when": "viewItem == jfrog.xray.excludeDependency.enabled",
+                    "when": "viewItem =~ /jfrog.xray.excludeDependency.enabled/",
+                    "group": "inline"
+                },
+                {
+                    "command": "jfrog.xray.updateDependency",
+                    "when": "viewItem =~ /jfrog.xray.updateDependency.enabled/",
                     "group": "inline"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { ScanCacheManager } from './main/scanCache/scanCacheManager';
 import { TreesManager } from './main/treeDataProviders/treesManager';
 import { WatcherManager } from './main/watchers/watcherManager';
 import { LogManager } from './main/log/logManager';
+import { UpdateDependencyManager } from './main/DependencyUpdate/updateDependencyManager';
 
 /**
  * This method is called when the extension is activated.
@@ -26,10 +27,13 @@ export async function activate(context: vscode.ExtensionContext) {
     let filterManager: FilterManager = new FilterManager(treesManager).activate(context);
     let focusManager: FocusManager = new FocusManager().activate(context);
     let exclusionManager: ExclusionsManager = new ExclusionsManager(treesManager).activate(context);
+    let dependencyUpdateManager: UpdateDependencyManager = new UpdateDependencyManager(treesManager).activate(context);
 
     new DiagnosticsManager(treesManager).activate(context);
     new WatcherManager(treesManager).activate(context);
     new HoverManager(treesManager).activate(context);
     new CodeLensManager().activate(context);
-    new CommandManager(logManager, connectionManager, treesManager, filterManager, focusManager, exclusionManager).activate(context);
+    new CommandManager(logManager, connectionManager, treesManager, filterManager, focusManager, exclusionManager, dependencyUpdateManager).activate(
+        context
+    );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { ScanCacheManager } from './main/scanCache/scanCacheManager';
 import { TreesManager } from './main/treeDataProviders/treesManager';
 import { WatcherManager } from './main/watchers/watcherManager';
 import { LogManager } from './main/log/logManager';
-import { UpdateDependencyManager } from './main/DependencyUpdate/updateDependencyManager';
+import { DependencyUpdateManager } from './main/DependencyUpdate/DependencyUpdateManager';
 
 /**
  * This method is called when the extension is activated.
@@ -27,7 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let filterManager: FilterManager = new FilterManager(treesManager).activate(context);
     let focusManager: FocusManager = new FocusManager().activate(context);
     let exclusionManager: ExclusionsManager = new ExclusionsManager(treesManager).activate(context);
-    let dependencyUpdateManager: UpdateDependencyManager = new UpdateDependencyManager().activate(context);
+    let dependencyUpdateManager: DependencyUpdateManager = new DependencyUpdateManager().activate(context);
 
     new DiagnosticsManager(treesManager).activate(context);
     new WatcherManager(treesManager).activate(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let filterManager: FilterManager = new FilterManager(treesManager).activate(context);
     let focusManager: FocusManager = new FocusManager().activate(context);
     let exclusionManager: ExclusionsManager = new ExclusionsManager(treesManager).activate(context);
-    let dependencyUpdateManager: UpdateDependencyManager = new UpdateDependencyManager(treesManager).activate(context);
+    let dependencyUpdateManager: UpdateDependencyManager = new UpdateDependencyManager().activate(context);
 
     new DiagnosticsManager(treesManager).activate(context);
     new WatcherManager(treesManager).activate(context);

--- a/src/main/DependencyUpdate/abstractDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/abstractDependencyUpdate.ts
@@ -1,7 +1,7 @@
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 
 /**
- * @see UpdateDependencyManager
+ * @see DependencyUpdateManager
  */
 export abstract class AbstractUpdateDependency {
     constructor(private _pkgType: string) {}

--- a/src/main/DependencyUpdate/abstractDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/abstractDependencyUpdate.ts
@@ -1,0 +1,18 @@
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+
+/**
+ * @see UpdateDependencyManager
+ */
+export abstract class AbstractUpdateDependency {
+    constructor(private _pkgType: string) {}
+
+    public isMatched(dependenciesTreeNode: DependenciesTreeNode): boolean {
+        return dependenciesTreeNode.generalInfo.pkgType === this._pkgType;
+    }
+
+    /**
+     * Update the dependency version in the project descriptor (i.e pom.xml) file after right click on the components tree and a left click on "Update dependency to fixed version".
+     * @param dependenciesTreeNode - The dependencies tree node that the user right-clicked on
+     */
+    public abstract updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void;
+}

--- a/src/main/DependencyUpdate/dependencyUpdateManager.ts
+++ b/src/main/DependencyUpdate/dependencyUpdateManager.ts
@@ -10,7 +10,7 @@ import { GoUpdateDependency } from './goDependencyUpdate';
 /**
  * Update the dependency version in the project descriptor (i.e pom.xml) file after right click on the components tree and a left click on "Update dependency to fixed version".
  */
-export class UpdateDependencyManager implements ExtensionComponent {
+export class DependencyUpdateManager implements ExtensionComponent {
     private updateDependency: AbstractUpdateDependency[] = [];
 
     constructor() {
@@ -24,8 +24,8 @@ export class UpdateDependencyManager implements ExtensionComponent {
     public async updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode) {
         const fixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
         this.updateDependency
-            .filter(node => node.isMatched(dependenciesTreeNode))
-            .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, fixedVersion));
+        .filter(node => node.isMatched(dependenciesTreeNode))
+        .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, fixedVersion));
     }
     /**
      * Returns the version to be updated for dependenciesTreeNode. If more than one version exists,
@@ -38,19 +38,19 @@ export class UpdateDependencyManager implements ExtensionComponent {
                 issue.fixedVersions.forEach(fixedVersion => fixedVersions.add(fixedVersion));
             }
         });
-        let uniqueFixedVersions: string[] = fixedVersions.toArray();
+        let fixedVersionsArr: string[] = fixedVersions.toArray();
         switch (fixedVersions.size()) {
             case 0:
                 return '';
             case 1:
-                return uniqueFixedVersions[0];
+                return fixedVersionsArr[0];
             default:
                 let chosenFixedVersion: string =
-                    (await vscode.window.showQuickPick(uniqueFixedVersions, {
+                    (await vscode.window.showQuickPick(fixedVersionsArr, {
                         canPickMany: false,
                         placeHolder: `Choose a fixed version for '` + dependenciesTreeNode.componentId + `'`
                     })) || '';
-                return uniqueFixedVersions.indexOf(chosenFixedVersion) === -1 ? '' : chosenFixedVersion;
+                return fixedVersions.contains(chosenFixedVersion) ? chosenFixedVersion : '';
         }
     }
 }

--- a/src/main/DependencyUpdate/goDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/goDependencyUpdate.ts
@@ -1,0 +1,23 @@
+import { GoTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/goTree';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { GoUtils } from '../utils/goUtils';
+import { ScanUtils } from '../utils/scanUtils';
+import { AbstractUpdateDependency } from './abstractDependencyUpdate';
+
+export class GoUpdateDependency extends AbstractUpdateDependency {
+    constructor(private _treesManager: TreesManager) {
+        super(GoUtils.PKG_TYPE);
+    }
+    public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
+        if (!(dependenciesTreeNode.parent instanceof GoTreeNode)) {
+            return;
+        }
+        const workspace: string = (<GoTreeNode>dependenciesTreeNode.parent).workspaceFolder;
+        try {
+            ScanUtils.executeCmd('go get ' + dependenciesTreeNode.generalInfo.artifactId + '@v' + fixedVersion, workspace);
+        } catch (error) {
+            this._treesManager.logManager.logMessage(error.stdout.toString(), 'ERR');
+        }
+    }
+}

--- a/src/main/DependencyUpdate/goDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/goDependencyUpdate.ts
@@ -9,11 +9,13 @@ export class GoUpdateDependency extends AbstractUpdateDependency {
         super(GoUtils.PKG_TYPE);
     }
 
+     /** @override */
+    public isMatched(dependenciesTreeNode: DependenciesTreeNode):boolean {
+        return super.isMatched(dependenciesTreeNode) && dependenciesTreeNode.parent instanceof GoTreeNode;
+    }
+    
     /** @override */
     public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
-        if (!(dependenciesTreeNode.parent instanceof GoTreeNode)) {
-            return;
-        }
         const workspace: string = (<GoTreeNode>dependenciesTreeNode.parent).workspaceFolder;
         ScanUtils.executeCmd('go get ' + dependenciesTreeNode.generalInfo.artifactId + '@v' + fixedVersion, workspace);
         dependenciesTreeNode.generalInfo.version = fixedVersion;

--- a/src/main/DependencyUpdate/goDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/goDependencyUpdate.ts
@@ -1,23 +1,21 @@
 import { GoTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/goTree';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { TreesManager } from '../treeDataProviders/treesManager';
 import { GoUtils } from '../utils/goUtils';
 import { ScanUtils } from '../utils/scanUtils';
 import { AbstractUpdateDependency } from './abstractDependencyUpdate';
 
 export class GoUpdateDependency extends AbstractUpdateDependency {
-    constructor(private _treesManager: TreesManager) {
+    constructor() {
         super(GoUtils.PKG_TYPE);
     }
+
+    /** @override */
     public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
         if (!(dependenciesTreeNode.parent instanceof GoTreeNode)) {
             return;
         }
         const workspace: string = (<GoTreeNode>dependenciesTreeNode.parent).workspaceFolder;
-        try {
-            ScanUtils.executeCmd('go get ' + dependenciesTreeNode.generalInfo.artifactId + '@v' + fixedVersion, workspace);
-        } catch (error) {
-            this._treesManager.logManager.logMessage(error.stdout.toString(), 'ERR');
-        }
+        ScanUtils.executeCmd('go get ' + dependenciesTreeNode.generalInfo.artifactId + '@v' + fixedVersion, workspace);
+        dependenciesTreeNode.generalInfo.version = fixedVersion;
     }
 }

--- a/src/main/DependencyUpdate/mavenDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/mavenDependencyUpdate.ts
@@ -10,11 +10,12 @@ export class MavenUpdateDependency extends AbstractUpdateDependency {
     }
 
     /** @override */
-    public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
-        if (!(dependenciesTreeNode.parent instanceof MavenTreeNode) || fixedVersion === '') {
-            return;
-        }
+    public isMatched(dependenciesTreeNode: DependenciesTreeNode):boolean {
+        return super.isMatched(dependenciesTreeNode) && dependenciesTreeNode.parent instanceof MavenTreeNode;
+    }
 
+    /** @override */
+    public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
         const workspace: string = (<MavenTreeNode>dependenciesTreeNode.parent).workspaceFolder;
         const [groupId, artifactId] = MavenUtils.getGavArray(dependenciesTreeNode);
         ScanUtils.executeCmd(

--- a/src/main/DependencyUpdate/mavenDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/mavenDependencyUpdate.ts
@@ -1,14 +1,15 @@
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { TreesManager } from '../treeDataProviders/treesManager';
 import { MavenUtils } from '../utils/mavenUtils';
 import { AbstractUpdateDependency } from './abstractDependencyUpdate';
 import { MavenTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree';
 import { ScanUtils } from '../utils/scanUtils';
 
 export class MavenUpdateDependency extends AbstractUpdateDependency {
-    constructor(private _treesManager: TreesManager) {
+    constructor() {
         super(MavenUtils.PKG_TYPE);
     }
+
+    /** @override */
     public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
         if (!(dependenciesTreeNode.parent instanceof MavenTreeNode) || fixedVersion === '') {
             return;
@@ -16,14 +17,10 @@ export class MavenUpdateDependency extends AbstractUpdateDependency {
 
         const workspace: string = (<MavenTreeNode>dependenciesTreeNode.parent).workspaceFolder;
         const [groupId, artifactId] = MavenUtils.getGavArray(dependenciesTreeNode);
-        try {
-            ScanUtils.executeCmd(
-                'mvn versions:use-dep-version -DgenerateBackupPoms=false -Dincludes=' + groupId + ':' + artifactId + ' -DdepVersion=' + fixedVersion,
-                workspace
-            );
-            this._treesManager.dependenciesTreeDataProvider.removeNode(dependenciesTreeNode);
-        } catch (error) {
-            this._treesManager.logManager.logMessage(error.stdout.toString(), 'ERR');
-        }
+        ScanUtils.executeCmd(
+            'mvn versions:use-dep-version -DgenerateBackupPoms=false -Dincludes=' + groupId + ':' + artifactId + ' -DdepVersion=' + fixedVersion,
+            workspace
+        );
+        dependenciesTreeNode.generalInfo.version = fixedVersion;
     }
 }

--- a/src/main/DependencyUpdate/mavenDependencyUpdate.ts
+++ b/src/main/DependencyUpdate/mavenDependencyUpdate.ts
@@ -1,0 +1,29 @@
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { MavenUtils } from '../utils/mavenUtils';
+import { AbstractUpdateDependency } from './abstractDependencyUpdate';
+import { MavenTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree';
+import { ScanUtils } from '../utils/scanUtils';
+
+export class MavenUpdateDependency extends AbstractUpdateDependency {
+    constructor(private _treesManager: TreesManager) {
+        super(MavenUtils.PKG_TYPE);
+    }
+    public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
+        if (!(dependenciesTreeNode.parent instanceof MavenTreeNode) || fixedVersion === '') {
+            return;
+        }
+
+        const workspace: string = (<MavenTreeNode>dependenciesTreeNode.parent).workspaceFolder;
+        const [groupId, artifactId] = MavenUtils.getGavArray(dependenciesTreeNode);
+        try {
+            ScanUtils.executeCmd(
+                'mvn versions:use-dep-version -DgenerateBackupPoms=false -Dincludes=' + groupId + ':' + artifactId + ' -DdepVersion=' + fixedVersion,
+                workspace
+            );
+            this._treesManager.dependenciesTreeDataProvider.removeNode(dependenciesTreeNode);
+        } catch (error) {
+            this._treesManager.logManager.logMessage(error.stdout.toString(), 'ERR');
+        }
+    }
+}

--- a/src/main/DependencyUpdate/npmUpdateDependency.ts
+++ b/src/main/DependencyUpdate/npmUpdateDependency.ts
@@ -1,0 +1,23 @@
+import { NpmTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/npmTree';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { NpmUtils } from '../utils/npmUtils';
+import { ScanUtils } from '../utils/scanUtils';
+import { AbstractUpdateDependency } from './abstractDependencyUpdate';
+
+export class NpmUpdateDependency extends AbstractUpdateDependency {
+    constructor(private _treesManager: TreesManager) {
+        super(NpmUtils.PKG_TYPE);
+    }
+    public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
+        if (!(dependenciesTreeNode.parent instanceof NpmTreeNode)) {
+            return;
+        }
+        const workspace: string = (<NpmTreeNode>dependenciesTreeNode.parent).workspaceFolder;
+        try {
+            ScanUtils.executeCmd('npm install ' + dependenciesTreeNode.generalInfo.artifactId + '@' + fixedVersion, workspace);
+        } catch (error) {
+            this._treesManager.logManager.logMessage(error.stdout.toString(), 'ERR');
+        }
+    }
+}

--- a/src/main/DependencyUpdate/npmUpdateDependency.ts
+++ b/src/main/DependencyUpdate/npmUpdateDependency.ts
@@ -10,10 +10,12 @@ export class NpmUpdateDependency extends AbstractUpdateDependency {
     }
 
     /** @override */
+    public isMatched(dependenciesTreeNode: DependenciesTreeNode):boolean {
+        return super.isMatched(dependenciesTreeNode) && dependenciesTreeNode.parent instanceof NpmTreeNode;
+    }
+
+    /** @override */
     public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
-        if (!(dependenciesTreeNode.parent instanceof NpmTreeNode)) {
-            return;
-        }
         const workspace: string = (<NpmTreeNode>dependenciesTreeNode.parent).workspaceFolder;
         ScanUtils.executeCmd('npm install ' + dependenciesTreeNode.generalInfo.artifactId + '@' + fixedVersion, workspace);
         dependenciesTreeNode.generalInfo.version = fixedVersion;

--- a/src/main/DependencyUpdate/npmUpdateDependency.ts
+++ b/src/main/DependencyUpdate/npmUpdateDependency.ts
@@ -1,23 +1,21 @@
 import { NpmTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/npmTree';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { TreesManager } from '../treeDataProviders/treesManager';
 import { NpmUtils } from '../utils/npmUtils';
 import { ScanUtils } from '../utils/scanUtils';
 import { AbstractUpdateDependency } from './abstractDependencyUpdate';
 
 export class NpmUpdateDependency extends AbstractUpdateDependency {
-    constructor(private _treesManager: TreesManager) {
+    constructor() {
         super(NpmUtils.PKG_TYPE);
     }
+
+    /** @override */
     public updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode, fixedVersion: string): void {
         if (!(dependenciesTreeNode.parent instanceof NpmTreeNode)) {
             return;
         }
         const workspace: string = (<NpmTreeNode>dependenciesTreeNode.parent).workspaceFolder;
-        try {
-            ScanUtils.executeCmd('npm install ' + dependenciesTreeNode.generalInfo.artifactId + '@' + fixedVersion, workspace);
-        } catch (error) {
-            this._treesManager.logManager.logMessage(error.stdout.toString(), 'ERR');
-        }
+        ScanUtils.executeCmd('npm install ' + dependenciesTreeNode.generalInfo.artifactId + '@' + fixedVersion, workspace);
+        dependenciesTreeNode.generalInfo.version = fixedVersion;
     }
 }

--- a/src/main/DependencyUpdate/updateDependencyManager.ts
+++ b/src/main/DependencyUpdate/updateDependencyManager.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode';
+import * as Collections from 'typescript-collections';
+import { ExtensionComponent } from '../extensionComponent';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { AbstractUpdateDependency } from './abstractDependencyUpdate';
+import { MavenUpdateDependency } from './mavenDependencyUpdate';
+import { NpmUpdateDependency } from './npmUpdateDependency';
+
+/**
+ * Update the dependency version in the project descriptor (i.e pom.xml) file after right click on the components tree and a left click on "Update dependency to fixed version".
+ */
+export class UpdateDependencyManager implements ExtensionComponent {
+    private updateDependency: AbstractUpdateDependency[] = [];
+
+    constructor(treesManager: TreesManager) {
+        this.updateDependency.push(new MavenUpdateDependency(treesManager), new NpmUpdateDependency(treesManager));
+    }
+
+    public activate(context: vscode.ExtensionContext) {
+        return this;
+    }
+
+    public async updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode) {
+        const chosedFixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
+        this.updateDependency
+            .filter(node => node.isMatched(dependenciesTreeNode))
+            .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, chosedFixedVersion));
+    }
+    /**
+     * Returns the version to be updated for dependenciesTreeNode. If more than one version exists,
+     * a quick  pick will appear to the user and a list of versions will be shown, the chosen version will be returned.
+     */
+    public async getFixedVersion(dependenciesTreeNode: DependenciesTreeNode) {
+        let fixedVersions: Collections.Set<string> = new Collections.Set<string>();
+        dependenciesTreeNode.issues.forEach(issue => {
+            if (issue.component === dependenciesTreeNode.componentId) {
+                issue.fixedVersions.forEach(fixedVersion => fixedVersions.add(fixedVersion));
+            }
+        });
+        let uniqueFixedVersions: string[] = fixedVersions.toArray();
+        switch (fixedVersions.size()) {
+            case 0:
+                return '';
+            case 1:
+                return uniqueFixedVersions[0];
+            default:
+                let chosenFixedVersion: string =
+                    (await vscode.window.showQuickPick(uniqueFixedVersions, {
+                        canPickMany: false,
+                        placeHolder: `Choose a fixed version for '` + dependenciesTreeNode.componentId + `'`
+                    })) || '';
+                return uniqueFixedVersions.indexOf(chosenFixedVersion) === -1 ? '' : chosenFixedVersion;
+        }
+    }
+}

--- a/src/main/DependencyUpdate/updateDependencyManager.ts
+++ b/src/main/DependencyUpdate/updateDependencyManager.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 import * as Collections from 'typescript-collections';
 import { ExtensionComponent } from '../extensionComponent';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { TreesManager } from '../treeDataProviders/treesManager';
 import { AbstractUpdateDependency } from './abstractDependencyUpdate';
 import { MavenUpdateDependency } from './mavenDependencyUpdate';
 import { NpmUpdateDependency } from './npmUpdateDependency';
+import { GoUpdateDependency } from './goDependencyUpdate';
 
 /**
  * Update the dependency version in the project descriptor (i.e pom.xml) file after right click on the components tree and a left click on "Update dependency to fixed version".
@@ -13,8 +13,8 @@ import { NpmUpdateDependency } from './npmUpdateDependency';
 export class UpdateDependencyManager implements ExtensionComponent {
     private updateDependency: AbstractUpdateDependency[] = [];
 
-    constructor(treesManager: TreesManager) {
-        this.updateDependency.push(new MavenUpdateDependency(treesManager), new NpmUpdateDependency(treesManager));
+    constructor() {
+        this.updateDependency.push(new MavenUpdateDependency(), new NpmUpdateDependency(), new GoUpdateDependency());
     }
 
     public activate(context: vscode.ExtensionContext) {
@@ -22,10 +22,10 @@ export class UpdateDependencyManager implements ExtensionComponent {
     }
 
     public async updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode) {
-        const chosedFixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
+        const fixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
         this.updateDependency
             .filter(node => node.isMatched(dependenciesTreeNode))
-            .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, chosedFixedVersion));
+            .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, fixedVersion));
     }
     /**
      * Returns the version to be updated for dependenciesTreeNode. If more than one version exists,

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -7,6 +7,7 @@ import { LogManager } from '../log/logManager';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { ExclusionsManager } from '../exclusions/exclusionsManager';
+import { UpdateDependencyManager } from '../DependencyUpdate/updateDependencyManager';
 
 /**
  * Register and execute all commands in the extension.
@@ -18,12 +19,14 @@ export class CommandManager implements ExtensionComponent {
         private _treesManager: TreesManager,
         private _filterManager: FilterManager,
         private _focusManager: FocusManager,
-        private _exclusionManager: ExclusionsManager
+        private _exclusionManager: ExclusionsManager,
+        private _updateDependencyManager: UpdateDependencyManager
     ) {}
 
     public activate(context: vscode.ExtensionContext) {
         this.registerCommand(context, 'jfrog.xray.showInProjectDesc', dependenciesTreeNode => this.doShowInProjectDesc(dependenciesTreeNode));
         this.registerCommand(context, 'jfrog.xray.excludeDependency', dependenciesTreeNode => this.doExcludeDependency(dependenciesTreeNode));
+        this.registerCommand(context, 'jfrog.xray.updateDependency', dependenciesTreeNode => this.doUpdateDependencyVersion(dependenciesTreeNode));
         this.registerCommand(context, 'jfrog.xray.codeAction', dependenciesTreeNode => this.doCodeAction(dependenciesTreeNode));
         this.registerCommand(context, 'jfrog.xray.focus', dependenciesTreeNode => this.doFocus(dependenciesTreeNode));
         this.registerCommand(context, 'jfrog.xray.showOutput', () => this.showOutput());
@@ -45,6 +48,10 @@ export class CommandManager implements ExtensionComponent {
 
     private doExcludeDependency(dependenciesTreeNode: DependenciesTreeNode) {
         this._exclusionManager.excludeDependency(dependenciesTreeNode);
+    }
+
+    private doUpdateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode) {
+        this._updateDependencyManager.updateDependencyVersion(dependenciesTreeNode);
     }
 
     /**

--- a/src/main/connect/connectionManager.ts
+++ b/src/main/connect/connectionManager.ts
@@ -277,8 +277,8 @@ export class ConnectionManager implements ExtensionComponent {
         }
         // Setting the value to undefined will remove the key https://github.com/microsoft/vscode/issues/11528
         await Promise.all([
-            await this._context.globalState.update(ConnectionManager.XRAY_URL_KEY, undefined),
-            await this._context.globalState.update(ConnectionManager.XRAY_USERNAME_KEY, undefined)
+            this._context.globalState.update(ConnectionManager.XRAY_URL_KEY, undefined),
+            this._context.globalState.update(ConnectionManager.XRAY_USERNAME_KEY, undefined)
         ]);
         return true;
     }

--- a/src/main/constants/contextKeys.ts
+++ b/src/main/constants/contextKeys.ts
@@ -1,4 +1,5 @@
 export class ContextKeys {
     public static SHOW_IN_PROJECT_DESC_ENABLED: string = 'jfrog.xray.showInProjectDesc.enabled';
     public static EXCLUDE_DEPENDENCY_ENABLED: string = 'jfrog.xray.excludeDependency.enabled';
+    public static UPDATE_DEPENDENCY_ENABLED: string = 'jfrog.xray.updateDependency.enabled';
 }

--- a/src/main/diagnostics/goCodeActionProvider.ts
+++ b/src/main/diagnostics/goCodeActionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ExtensionComponent } from '../extensionComponent';
+import { FocusType } from '../focus/abstractFocus';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { GoUtils } from '../utils/goUtils';
@@ -26,7 +27,7 @@ export class GoCodeActionProvider extends AbstractCodeActionProvider implements 
             return;
         }
         goDependenciesTree.children.forEach(child => {
-            let dependencyPos: vscode.Position[] = GoUtils.getDependencyPos(document, child);
+            let dependencyPos: vscode.Position[] = GoUtils.getDependencyPos(document, child, FocusType.Dependency);
             if (dependencyPos.length === 0) {
                 return;
             }

--- a/src/main/diagnostics/mavenCodeActionProvider.ts
+++ b/src/main/diagnostics/mavenCodeActionProvider.ts
@@ -6,6 +6,7 @@ import { TreesManager } from '../treeDataProviders/treesManager';
 import { AbstractCodeActionProvider } from './abstractCodeActionProvider';
 import { MavenTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree';
 import { MavenUtils } from '../utils/mavenUtils';
+import { FocusType } from '../focus/abstractFocus';
 
 export class MavenCodeActionProvider extends AbstractCodeActionProvider implements ExtensionComponent {
     constructor(diagnosticCollection: vscode.DiagnosticCollection, treesManager: TreesManager) {
@@ -34,7 +35,7 @@ export class MavenCodeActionProvider extends AbstractCodeActionProvider implemen
             if (child instanceof MavenTreeNode) {
                 return;
             }
-            let dependencyPos: vscode.Position[] = MavenUtils.getDependencyPos(document, child);
+            let dependencyPos: vscode.Position[] = MavenUtils.getDependencyPos(document, child, FocusType.Dependency);
             if (dependencyPos.length === 0) {
                 return;
             }

--- a/src/main/diagnostics/npmCodeActionProvider.ts
+++ b/src/main/diagnostics/npmCodeActionProvider.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ExtensionComponent } from '../extensionComponent';
+import { FocusType } from '../focus/abstractFocus';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { NpmUtils } from '../utils/npmUtils';
@@ -30,7 +31,7 @@ export class NpmCodeActionProvider extends AbstractCodeActionProvider implements
             return;
         }
         npmDependenciesTree.children.forEach(child => {
-            let dependencyPos: vscode.Position[] = NpmUtils.getDependencyPos(document, child);
+            let dependencyPos: vscode.Position[] = NpmUtils.getDependencyPos(document, child, FocusType.Dependency);
             if (dependencyPos.length === 0) {
                 return;
             }

--- a/src/main/focus/abstractFocus.ts
+++ b/src/main/focus/abstractFocus.ts
@@ -14,5 +14,10 @@ export abstract class AbstractFocus {
      * Show the dependency in the project descriptor (i.e package.json) file after right click on the components tree and a left click on "Show in project descriptor".
      * @param dependenciesTreeNode - The dependencies tree node that the user right-clicked on
      */
-    public abstract focusOnDependency(dependenciesTreeNode: DependenciesTreeNode): void;
+    public abstract focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType): void;
+}
+
+export enum FocusType {
+    Dependency = 0,
+    DependencyVersion = 1
 }

--- a/src/main/focus/focusManager.ts
+++ b/src/main/focus/focusManager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ExtensionComponent } from '../extensionComponent';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { AbstractFocus } from './abstractFocus';
+import { AbstractFocus, FocusType } from './abstractFocus';
 import { GoFocus } from './goFocus';
 import { NpmFocus } from './npmFocus';
 import { PypiFocus } from './pypiFocus';
@@ -21,7 +21,11 @@ export class FocusManager implements ExtensionComponent {
         return this;
     }
 
-    public focusOnDependency(dependenciesTreeNode: DependenciesTreeNode) {
-        this._focuses.filter(focus => focus.isMatched(dependenciesTreeNode)).forEach(focus => focus.focusOnDependency(dependenciesTreeNode));
+    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType) {
+        await Promise.all(
+            this._focuses
+                .filter(focus => focus.isMatched(dependenciesTreeNode))
+                .map(async focus => focus.focusOnDependency(dependenciesTreeNode, focusType))
+        );
     }
 }

--- a/src/main/focus/focusManager.ts
+++ b/src/main/focus/focusManager.ts
@@ -21,11 +21,9 @@ export class FocusManager implements ExtensionComponent {
         return this;
     }
 
-    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType) {
-        await Promise.all(
-            this._focuses
-                .filter(focus => focus.isMatched(dependenciesTreeNode))
-                .map(async focus => focus.focusOnDependency(dependenciesTreeNode, focusType))
-        );
+    public focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType) {
+        this._focuses
+            .filter(focus => focus.isMatched(dependenciesTreeNode))
+            .forEach(focus => focus.focusOnDependency(dependenciesTreeNode, focusType));
     }
 }

--- a/src/main/focus/goFocus.ts
+++ b/src/main/focus/goFocus.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { GoUtils } from '../utils/goUtils';
-import { AbstractFocus } from './abstractFocus';
+import { AbstractFocus, FocusType } from './abstractFocus';
 
 export class GoFocus extends AbstractFocus {
     constructor() {
@@ -10,7 +10,7 @@ export class GoFocus extends AbstractFocus {
     }
 
     /** @override */
-    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode) {
+    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType) {
         while (dependenciesTreeNode.parent && dependenciesTreeNode.parent.parent && dependenciesTreeNode.parent.parent.parent) {
             dependenciesTreeNode = dependenciesTreeNode.parent;
         }
@@ -21,7 +21,7 @@ export class GoFocus extends AbstractFocus {
         if (dependenciesTreeNode.isDependenciesTreeRoot()) {
             return;
         }
-        let pos: vscode.Position[] = GoUtils.getDependencyPos(textEditor.document, dependenciesTreeNode);
+        let pos: vscode.Position[] = GoUtils.getDependencyPos(textEditor.document, dependenciesTreeNode, focusType);
         if (!pos) {
             return;
         }

--- a/src/main/focus/mavenFocus.ts
+++ b/src/main/focus/mavenFocus.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { AbstractFocus } from './abstractFocus';
+import { AbstractFocus, FocusType } from './abstractFocus';
 import { MavenUtils } from '../utils/mavenUtils';
 
 export class MavenFocus extends AbstractFocus {
@@ -9,7 +9,7 @@ export class MavenFocus extends AbstractFocus {
     }
 
     /** @override */
-    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode) {
+    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType) {
         const textDocument: vscode.TextDocument | undefined = await MavenUtils.openPomXml(dependenciesTreeNode);
         if (!textDocument) {
             return;
@@ -18,7 +18,7 @@ export class MavenFocus extends AbstractFocus {
         if (dependenciesTreeNode.isDependenciesTreeRoot()) {
             return;
         }
-        let [startPos, endPosition] = MavenUtils.getDependencyPos(textEditor.document, dependenciesTreeNode);
+        let [startPos, endPosition] = MavenUtils.getDependencyPos(textEditor.document, dependenciesTreeNode, focusType);
         if (!startPos || !endPosition) {
             return;
         }

--- a/src/main/focus/npmFocus.ts
+++ b/src/main/focus/npmFocus.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { NpmUtils } from '../utils/npmUtils';
-import { AbstractFocus } from './abstractFocus';
+import { AbstractFocus, FocusType } from './abstractFocus';
 
 export class NpmFocus extends AbstractFocus {
     constructor() {
@@ -10,7 +10,7 @@ export class NpmFocus extends AbstractFocus {
     }
 
     /** @override */
-    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode) {
+    public async focusOnDependency(dependenciesTreeNode: DependenciesTreeNode, focusType: FocusType) {
         while (dependenciesTreeNode.parent && dependenciesTreeNode.parent.parent && dependenciesTreeNode.parent.parent.parent) {
             dependenciesTreeNode = dependenciesTreeNode.parent;
         }
@@ -21,7 +21,7 @@ export class NpmFocus extends AbstractFocus {
         if (dependenciesTreeNode.isDependenciesTreeRoot()) {
             return;
         }
-        let pos: vscode.Position[] = NpmUtils.getDependencyPos(textEditor.document, dependenciesTreeNode);
+        let pos: vscode.Position[] = NpmUtils.getDependencyPos(textEditor.document, dependenciesTreeNode, focusType);
         if (!pos) {
             return;
         }

--- a/src/main/hover/goHover.ts
+++ b/src/main/hover/goHover.ts
@@ -7,6 +7,7 @@ import { GoUtils } from '../utils/goUtils';
 import { GoDependenciesTreeNode } from '../treeDataProviders/dependenciesTree/goDependenciesTreeNode';
 import { Severity, SeverityUtils } from '../types/severity';
 import { ISeverityCount } from '../goCenterClient/model/SeverityCount';
+import { FocusType } from '../focus/abstractFocus';
 
 export class GoHover extends AbstractHoverProvider {
     constructor(treesManager: TreesManager) {
@@ -23,7 +24,7 @@ export class GoHover extends AbstractHoverProvider {
             return;
         }
         for (const child of dependenciesTree.children) {
-            let pos: vscode.Position[] = GoUtils.getDependencyPos(document, child);
+            let pos: vscode.Position[] = GoUtils.getDependencyPos(document, child, FocusType.Dependency);
             let range: vscode.Range = new vscode.Range(pos[0], pos[1]);
             if (range.contains(cursorPosition)) {
                 return child;

--- a/src/main/hover/mavenHover.ts
+++ b/src/main/hover/mavenHover.ts
@@ -4,6 +4,7 @@ import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/depe
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { AbstractHoverProvider } from './abstractHoverProvider';
 import { MavenUtils } from '../utils/mavenUtils';
+import { FocusType } from '../focus/abstractFocus';
 
 export class MavenHover extends AbstractHoverProvider {
     constructor(treesManager: TreesManager) {
@@ -20,7 +21,7 @@ export class MavenHover extends AbstractHoverProvider {
             return;
         }
         for (const child of dependenciesTree.children) {
-            let positionList: vscode.Position[] = MavenUtils.getDependencyPos(document, child);
+            let positionList: vscode.Position[] = MavenUtils.getDependencyPos(document, child, FocusType.Dependency);
             for (let i: number = 0; i < positionList.length; i += 2) {
                 let range: vscode.Range = new vscode.Range(positionList[i], positionList[i + 1]);
                 if (range.contains(cursorPosition)) {

--- a/src/main/hover/npmHover.ts
+++ b/src/main/hover/npmHover.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { FocusType } from '../focus/abstractFocus';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { NpmUtils } from '../utils/npmUtils';
@@ -20,7 +21,7 @@ export class NpmHover extends AbstractHoverProvider {
             return;
         }
         for (const child of dependenciesTree.children) {
-            let pos: vscode.Position[] = NpmUtils.getDependencyPos(document, child);
+            let pos: vscode.Position[] = NpmUtils.getDependencyPos(document, child, FocusType.Dependency);
             let range: vscode.Range = new vscode.Range(pos[0], pos[1]);
             if (range.contains(cursorPosition)) {
                 return child;

--- a/src/main/log/logManager.ts
+++ b/src/main/log/logManager.ts
@@ -27,10 +27,13 @@ export class LogManager implements ExtensionComponent {
      * @param message - The message to log
      * @param level - The log level
      */
-    public logMessage(message: string, level: LogLevel): void {
+    public logMessage(message: string, level: LogLevel, focusOutput: boolean = false): void {
         if (!!message) {
             const title: string = new Date().toLocaleTimeString();
             this._outputChannel.appendLine(`[${level} - ${title}] ${message}`);
+            if (focusOutput) {
+                this.showOutput();
+            }
         }
     }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -238,7 +238,7 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
                 }
             }
             this._onDidChangeTreeData.fire();
-        });
+        }, 'Scanning project dependencies ');
     }
 
     private clearTree() {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -16,6 +16,7 @@ import { GoDependenciesTreeNode } from './goDependenciesTreeNode';
 import { GoTreeNode } from './dependenciesRoot/goTree';
 import { ISeverityCount } from '../../goCenterClient/model/SeverityCount';
 import { Scope } from '../../types/scope';
+import { RootNode } from './dependenciesRoot/rootTree';
 
 export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<DependenciesTreeNode> {
     private static readonly CANCELLATION_ERROR: Error = new Error('Xray Scan cancelled');
@@ -200,33 +201,38 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
     private async repopulateTree(quickScan: boolean, credentialsSet: boolean) {
         await ScanUtils.scanWithProgress(async (progress: vscode.Progress<{ message?: string; increment?: number }>, checkCanceled: () => void) => {
             this.clearTree();
-            let dependenciesTree: DependenciesTreeNode = <DependenciesTreeNode>this.dependenciesTree;
+            let workspaceRoot: DependenciesTreeNode = <DependenciesTreeNode>this.dependenciesTree;
             await DependenciesTreesFactory.createDependenciesTrees(
                 this._workspaceFolders,
                 this._componentsToScan,
                 this._goCenterComponentsToScan,
                 this._treesManager,
-                dependenciesTree,
+                workspaceRoot,
                 quickScan
             );
             if (credentialsSet) {
                 // Xray + GoCenter users
                 vscode.commands.executeCommand('setContext', 'isGoCenterMode', false);
                 await this.scanAndCacheComponents(progress, checkCanceled);
-                for (let dependenciesTreeNode of dependenciesTree.children) {
+                for (let dependenciesTreeNode of workspaceRoot.children) {
                     this.addXrayInfoToTree(dependenciesTreeNode);
                     if (dependenciesTreeNode instanceof GoTreeNode) {
                         this.addGoCenterInfoToTree(dependenciesTreeNode, credentialsSet);
                     }
                     dependenciesTreeNode.issues = dependenciesTreeNode.processTreeIssues();
                 }
-            } else if (this.isGoCenterMode(dependenciesTree)) {
+                workspaceRoot.children.forEach(node => {
+                    if (node instanceof RootNode) {
+                        node.setUpgradableDependencies();
+                    }
+                });
+            } else if (this.isGoCenterMode(workspaceRoot)) {
                 // GoCenter users
                 vscode.commands.executeCommand('setContext', 'isGoCenterMode', true);
                 const totalComponents: number = this._goCenterComponentsToScan.size();
                 progress.report({ message: `${totalComponents} components` });
                 await this.scanAndCache(progress, checkCanceled, totalComponents, Source.GoCenter, this._goCenterComponentsToScan.toArray());
-                for (let dependenciesTreeNode of dependenciesTree.children) {
+                for (let dependenciesTreeNode of workspaceRoot.children) {
                     this.addGoCenterInfoToTree(dependenciesTreeNode, credentialsSet);
                     dependenciesTreeNode.issues = dependenciesTreeNode.processTreeIssues();
                 }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -112,8 +112,8 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
         }
         progress.report({ message: `${totalComponents} components` });
         await Promise.all([
-            await this.scanAndCache(progress, checkCanceled, totalComponents, Source.Xray, this._componentsToScan.toArray()),
-            await this.scanAndCache(progress, checkCanceled, totalComponents, Source.GoCenter, this._goCenterComponentsToScan.toArray())
+            this.scanAndCache(progress, checkCanceled, totalComponents, Source.Xray, this._componentsToScan.toArray()),
+            this.scanAndCache(progress, checkCanceled, totalComponents, Source.GoCenter, this._goCenterComponentsToScan.toArray())
         ]);
     }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
@@ -8,38 +8,39 @@ import { TreesManager } from '../../treesManager';
 import { DependenciesTreeNode } from '../dependenciesTreeNode';
 import { ScanUtils } from '../../../utils/scanUtils';
 import { GoDependenciesTreeNode } from '../goDependenciesTreeNode';
+import { RootNode } from './rootTree';
 
-export class GoTreeNode extends DependenciesTreeNode {
+export class GoTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'go://';
 
     private _dependenciesMap: Map<string, string[]> = new Map();
 
     constructor(
-        private _workspaceFolder: string,
+        workspaceFolder: string,
         private _componentsToScan: Collections.Set<ComponentDetails>,
         private _goCenterComponentsToScan: Collections.Set<ComponentDetails>,
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', ['None'], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(workspaceFolder, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
         let goList: string[] = [];
         let rootPackageName: string = '';
         try {
-            goList = ScanUtils.executeCmd('go mod graph', this._workspaceFolder)
+            goList = ScanUtils.executeCmd('go mod graph', this.workspaceFolder)
                 .toString()
                 .split(/\s+/);
             goList.pop(); // Remove the last new line
             rootPackageName = this.getModuleName();
         } catch (error) {
             this._treesManager.logManager.logError(error, !quickScan);
-            this.label = this._workspaceFolder + ' [Not installed]';
-            this.generalInfo = new GeneralInfo(this.label, '', [], this._workspaceFolder, GoUtils.PKG_TYPE);
+            this.label = this.workspaceFolder + ' [Not installed]';
+            this.generalInfo = new GeneralInfo(this.label, '', [], this.workspaceFolder, GoUtils.PKG_TYPE);
             return;
         }
-        this.generalInfo = new GeneralInfo(rootPackageName, '', ['None'], this._workspaceFolder, GoUtils.PKG_TYPE);
+        this.generalInfo = new GeneralInfo(rootPackageName, '', ['None'], this.workspaceFolder, GoUtils.PKG_TYPE);
         this.label = rootPackageName;
         if (goList.length === 0) {
             return;
@@ -104,7 +105,7 @@ export class GoTreeNode extends DependenciesTreeNode {
 
     private getModuleName(): string {
         return exec
-            .execSync('go list -m', { cwd: this._workspaceFolder })
+            .execSync('go list -m', { cwd: this.workspaceFolder })
             .toString()
             .trim();
     }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -7,17 +7,18 @@ import { TreesManager } from '../../treesManager';
 import { GeneralInfo } from '../../../types/generalInfo';
 import { ScanUtils } from '../../../utils/scanUtils';
 import { NpmGlobalScopes, ScopedNpmProject, NpmUtils } from '../../../utils/npmUtils';
+import { RootNode } from './rootTree';
 
-export class NpmTreeNode extends DependenciesTreeNode {
+export class NpmTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'npm://';
 
     constructor(
-        private _workspaceFolder: string,
+        workspaceFolder: string,
         private _componentsToScan: Collections.Set<ComponentDetails>,
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(workspaceFolder, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
@@ -31,7 +32,7 @@ export class NpmTreeNode extends DependenciesTreeNode {
                 this._treesManager.logManager.logError(error, !quickScan);
                 this._treesManager.logManager.logMessage(
                     'Possible cause: The project needs to be installed by npm. Install it by running "npm install" from "' +
-                        this._workspaceFolder +
+                        this.workspaceFolder +
                         '",.',
                     'INFO'
                 );
@@ -44,10 +45,10 @@ export class NpmTreeNode extends DependenciesTreeNode {
             npmLsFailed ? (productionScope.projectName += ' [Not installed]') : productionScope.projectName,
             productionScope.projectVersion,
             [],
-            this._workspaceFolder,
+            this.workspaceFolder,
             NpmUtils.PKG_TYPE
         );
-        this.label = productionScope.projectName ? productionScope.projectName : path.join(this._workspaceFolder, 'package.json');
+        this.label = productionScope.projectName ? productionScope.projectName : path.join(this.workspaceFolder, 'package.json');
     }
 
     private populateDependenciesTree(dependenciesTreeNode: DependenciesTreeNode, dependencies: any, quickScan: boolean, globalScope: string) {
@@ -76,6 +77,6 @@ export class NpmTreeNode extends DependenciesTreeNode {
     }
 
     private runNpmLs(scope: NpmGlobalScopes): any {
-        return JSON.parse(ScanUtils.executeCmd('npm ls --json --only=' + scope, this._workspaceFolder).toString());
+        return JSON.parse(ScanUtils.executeCmd('npm ls --json --only=' + scope, this.workspaceFolder).toString());
     }
 }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -5,21 +5,22 @@ import { DependenciesTreeNode } from '../dependenciesTreeNode';
 import { TreesManager } from '../../treesManager';
 import { GeneralInfo } from '../../../types/generalInfo';
 import { NugetUtils } from '../../../utils/nugetUtils';
+import { RootNode } from './rootTree';
 
-export class NugetTreeNode extends DependenciesTreeNode {
+export class NugetTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'nuget://';
 
     constructor(
-        private _workspaceFolder: string,
+        workspaceFolder: string,
         private _componentsToScan: Collections.Set<ComponentDetails>,
         private _treesManager: TreesManager,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', ['None'], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, '');
+        super(workspaceFolder, parent, '');
     }
 
     public async refreshDependencies(quickScan: boolean, project: any) {
-        this.generalInfo = new GeneralInfo(project.name, '', ['None'], this._workspaceFolder, NugetUtils.PKG_TYPE);
+        this.generalInfo = new GeneralInfo(project.name, '', ['None'], this.workspaceFolder, NugetUtils.PKG_TYPE);
         this.label = project.name;
         this.populateDependenciesTree(this, project.dependencies, quickScan);
     }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
@@ -6,32 +6,33 @@ import { TreesManager } from '../../treesManager';
 import { GeneralInfo } from '../../../types/generalInfo';
 import { ScanUtils } from '../../../utils/scanUtils';
 import { PypiUtils } from '../../../utils/pypiUtils';
+import { RootNode } from './rootTree';
 
 /**
  * Pypi packages can be installed in two different ways:
  * 1. 'pip install [Path to setup.py]' - With this method, the top level in the tree would be the project name.
  * 2. 'pip install -r [Path to requirements.txt]' - With this method, the top level in the tree would be the dependencies of the project.
  */
-export class PypiTreeNode extends DependenciesTreeNode {
+export class PypiTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'pypi://';
 
     constructor(
-        private _projectDir: string,
+        workspaceFolder: string,
         private _componentsToScan: Collections.Set<ComponentDetails>,
         private _treesManager: TreesManager,
         private _pythonPath: string,
         parent?: DependenciesTreeNode
     ) {
-        super(new GeneralInfo('', '', ['None'], _projectDir, ''), vscode.TreeItemCollapsibleState.Expanded, parent);
+        super(workspaceFolder, parent);
     }
 
     public async refreshDependencies(quickScan: boolean) {
         let pypiList: any;
         try {
             pypiList = JSON.parse(
-                ScanUtils.executeCmd(this._pythonPath + ' ' + PypiUtils.PIP_DEP_TREE_SCRIPT + ' --json-tree', this._projectDir).toString()
+                ScanUtils.executeCmd(this._pythonPath + ' ' + PypiUtils.PIP_DEP_TREE_SCRIPT + ' --json-tree', this.workspaceFolder).toString()
             );
-            this.generalInfo = new GeneralInfo(this._projectDir.replace(/^.*[\\\/]/, ''), '', ['None'], this._projectDir, PypiUtils.PKG_TYPE);
+            this.generalInfo = new GeneralInfo(this.workspaceFolder.replace(/^.*[\\\/]/, ''), '', ['None'], this.workspaceFolder, PypiUtils.PKG_TYPE);
         } catch (error) {
             this._treesManager.logManager.logError(error, !quickScan);
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
@@ -4,7 +4,7 @@ import { GeneralInfo } from '../../../types/generalInfo';
 import { DependenciesTreeNode } from '../dependenciesTreeNode';
 export class RootNode extends DependenciesTreeNode {
     constructor(private _workspaceFolder: string, parent?: DependenciesTreeNode, contextValue?: string) {
-        super(new GeneralInfo('', '',[], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, contextValue);
+        super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, contextValue);
     }
 
     get workspaceFolder() {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
@@ -7,7 +7,7 @@ export class RootNode extends DependenciesTreeNode {
         super(new GeneralInfo('', '', [], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, contextValue);
     }
 
-    get workspaceFolder() {
+    public get workspaceFolder() {
         return this._workspaceFolder;
     }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import { ContextKeys } from '../../../constants/contextKeys';
+import { GeneralInfo } from '../../../types/generalInfo';
+import { DependenciesTreeNode } from '../dependenciesTreeNode';
+export class RootNode extends DependenciesTreeNode {
+    constructor(private _workspaceFolder: string, parent?: DependenciesTreeNode, contextValue?: string) {
+        super(new GeneralInfo('', '',[], _workspaceFolder, ''), vscode.TreeItemCollapsibleState.Expanded, parent, contextValue);
+    }
+
+    get workspaceFolder() {
+        return this._workspaceFolder;
+    }
+
+    /**
+     * Sets the root nodes' context to show the update dependency icon if available.
+     */
+    public setUpgradableDependencies() {
+        this.children.forEach(child => this.upgradableDependencies(child));
+    }
+    protected upgradableDependencies(node: DependenciesTreeNode) {
+        // Node include issues (not including for transitive children) with a fixed version.
+        const isRootUpgradable: boolean = node.issues.toArray().some(issue => issue.component === node.componentId && issue.fixedVersions.length > 0);
+        if (isRootUpgradable && node.contextValue !== '') {
+            node.contextValue += ContextKeys.UPDATE_DEPENDENCY_ENABLED;
+        }
+    }
+}

--- a/src/main/treeDataProviders/issuesDataProvider.ts
+++ b/src/main/treeDataProviders/issuesDataProvider.ts
@@ -68,7 +68,7 @@ export class IssuesDataProvider implements vscode.TreeDataProvider<IssueNode> {
         ];
         let fixedVersions: string[] | undefined = element.fixedVersions;
         if (fixedVersions && fixedVersions.length > 0) {
-            children.push(new TreeDataHolder('Fixed Versions', fixedVersions.toString()));
+            children.push(new TreeDataHolder('Fixed Versions', fixedVersions.join(', ')));
         }
         return Promise.resolve(children);
     }

--- a/src/main/types/issue.ts
+++ b/src/main/types/issue.ts
@@ -11,7 +11,14 @@ export class Issue {
         private _issueType: string,
         private _fixedVersions: string[] = [],
         private _gocenter_security_url?: string
-    ) {}
+    ) {
+        this._fixedVersions = this._fixedVersions.map(version => {
+            if (version.charAt(0) === '[' && version.charAt(version.length - 1) === ']') {
+                return version.substring(1, version.length - 1);
+            }
+            return version;
+        });
+    }
 
     public get description(): string {
         return this._description;

--- a/src/main/utils/goUtils.ts
+++ b/src/main/utils/goUtils.ts
@@ -42,7 +42,7 @@ export class GoUtils {
     ): vscode.Position[] {
         let res: vscode.Position[] = [];
         let goModContent: string = document.getText();
-        let dependencyMatch: RegExpMatchArray | null = goModContent.match(dependenciesTreeNode.generalInfo.artifactId + 's* vs*.*');
+        let dependencyMatch: RegExpMatchArray | null = goModContent.match('(' + dependenciesTreeNode.generalInfo.artifactId + 's* )vs*.*');
         if (!dependencyMatch) {
             return res;
         }
@@ -51,7 +51,7 @@ export class GoUtils {
                 res.push(document.positionAt(<number>dependencyMatch.index));
                 break;
             case FocusType.DependencyVersion:
-                res.push(document.positionAt(<number>dependencyMatch.index + dependenciesTreeNode.generalInfo.artifactId.length));
+                res.push(document.positionAt(<number>dependencyMatch.index + dependencyMatch[1].length));
                 break;
         }
         res.push(new vscode.Position(res[0].line, res[0].character + dependencyMatch[0].length));

--- a/src/main/utils/goUtils.ts
+++ b/src/main/utils/goUtils.ts
@@ -8,6 +8,7 @@ import { GoTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRo
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { ScanUtils } from './scanUtils';
 import { LogManager } from '../log/logManager';
+import { FocusType } from '../focus/abstractFocus';
 
 export class GoUtils {
     public static readonly DOCUMENT_SELECTOR: vscode.DocumentSelector = { scheme: 'file', pattern: '**/go.mod' };
@@ -34,14 +35,25 @@ export class GoUtils {
      * @param document             - go.mod file
      * @param dependenciesTreeNode - dependencies tree node
      */
-    public static getDependencyPos(document: vscode.TextDocument, dependenciesTreeNode: DependenciesTreeNode): vscode.Position[] {
+    public static getDependencyPos(
+        document: vscode.TextDocument,
+        dependenciesTreeNode: DependenciesTreeNode,
+        focusType: FocusType
+    ): vscode.Position[] {
         let res: vscode.Position[] = [];
         let goModContent: string = document.getText();
         let dependencyMatch: RegExpMatchArray | null = goModContent.match(dependenciesTreeNode.generalInfo.artifactId + 's* vs*.*');
         if (!dependencyMatch) {
             return res;
         }
-        res.push(document.positionAt(<number>dependencyMatch.index));
+        switch (focusType) {
+            case FocusType.Dependency:
+                res.push(document.positionAt(<number>dependencyMatch.index));
+                break;
+            case FocusType.DependencyVersion:
+                res.push(document.positionAt(<number>dependencyMatch.index + dependenciesTreeNode.generalInfo.artifactId.length));
+                break;
+        }
         res.push(new vscode.Position(res[0].line, res[0].character + dependencyMatch[0].length));
         return res;
     }

--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -216,7 +216,7 @@ export class MavenUtils {
             node.contextValue = '';
         } else if (!(node.parent instanceof MavenTreeNode) && node.parent?.label) {
             // Enable 'Exclude dependency' and 'Show in project descriptor' in right click menu on the dependency
-            node.contextValue = ContextKeys.EXCLUDE_DEPENDENCY_ENABLED;
+            node.contextValue += ContextKeys.EXCLUDE_DEPENDENCY_ENABLED;
         }
         // Prepare the closer pom.xml for the children.
         if (node instanceof MavenTreeNode) {

--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -227,7 +227,7 @@ export class MavenUtils {
         let nodeCanReachPom: boolean = this.isPomReachable(node, dependenciesMatch, parentCanReachPom);
         if (!nodeCanReachPom) {
             // Disable right click menu on the dependency
-            node.contextValue = '';
+            node.contextValue?.replace(ContextKeys.SHOW_IN_PROJECT_DESC_ENABLED, '');
         } else if (!(node.parent instanceof MavenTreeNode) && node.parent?.label) {
             // Enable 'Exclude dependency' and 'Show in project descriptor' in right click menu on the dependency
             node.contextValue += ContextKeys.EXCLUDE_DEPENDENCY_ENABLED;

--- a/src/main/utils/npmUtils.ts
+++ b/src/main/utils/npmUtils.ts
@@ -42,7 +42,7 @@ export class NpmUtils {
     ): vscode.Position[] {
         let res: vscode.Position[] = [];
         let packageJsonContent: string = document.getText();
-        let dependencyMatch: RegExpMatchArray | null = packageJsonContent.match('"' + dependenciesTreeNode.generalInfo.artifactId + '"s*:s*.*"');
+        let dependencyMatch: RegExpMatchArray | null = packageJsonContent.match('("' + dependenciesTreeNode.generalInfo.artifactId + '"\\s*:\\s*).*"');
         if (!dependencyMatch) {
             return res;
         }
@@ -51,7 +51,7 @@ export class NpmUtils {
                 res.push(document.positionAt(<number>dependencyMatch.index));
                 break;
             case FocusType.DependencyVersion:
-                res.push(document.positionAt(<number>dependencyMatch.index + dependenciesTreeNode.generalInfo.artifactId.length + 3));
+                res.push(document.positionAt(<number>dependencyMatch.index +dependencyMatch[1].length));
                 break;
         }
         res.push(new vscode.Position(res[0].line, res[0].character + dependencyMatch[0].length));

--- a/src/main/utils/npmUtils.ts
+++ b/src/main/utils/npmUtils.ts
@@ -8,6 +8,7 @@ import { NpmTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesR
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { ScanUtils } from './scanUtils';
 import { LogManager } from '../log/logManager';
+import { FocusType } from '../focus/abstractFocus';
 
 export class NpmUtils {
     public static readonly DOCUMENT_SELECTOR: vscode.DocumentSelector = { scheme: 'file', pattern: '**/package.json' };
@@ -34,14 +35,25 @@ export class NpmUtils {
      * @param document             - package.json file
      * @param dependenciesTreeNode - dependencies tree node
      */
-    public static getDependencyPos(document: vscode.TextDocument, dependenciesTreeNode: DependenciesTreeNode): vscode.Position[] {
+    public static getDependencyPos(
+        document: vscode.TextDocument,
+        dependenciesTreeNode: DependenciesTreeNode,
+        focusType: FocusType
+    ): vscode.Position[] {
         let res: vscode.Position[] = [];
         let packageJsonContent: string = document.getText();
         let dependencyMatch: RegExpMatchArray | null = packageJsonContent.match('"' + dependenciesTreeNode.generalInfo.artifactId + '"s*:s*.*"');
         if (!dependencyMatch) {
             return res;
         }
-        res.push(document.positionAt(<number>dependencyMatch.index));
+        switch (focusType) {
+            case FocusType.Dependency:
+                res.push(document.positionAt(<number>dependencyMatch.index));
+                break;
+            case FocusType.DependencyVersion:
+                res.push(document.positionAt(<number>dependencyMatch.index + dependenciesTreeNode.generalInfo.artifactId.length + 3));
+                break;
+        }
         res.push(new vscode.Position(res[0].line, res[0].character + dependencyMatch[0].length));
         return res;
     }

--- a/src/main/utils/pomTree.ts
+++ b/src/main/utils/pomTree.ts
@@ -86,7 +86,7 @@ export class PomTree {
                 'ERR'
             );
         } finally {
-            ScanUtils.removeFolder(path.join(dependencyTreeFile, '..'));
+            await ScanUtils.removeFolder(path.join(dependencyTreeFile, '..'));
         }
         return;
     }

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -8,12 +8,13 @@ export class ScanUtils {
     public static readonly SPAWN_PROCESS_BUFFER_SIZE: number = 104857600;
 
     public static async scanWithProgress(
-        scanCbk: (progress: vscode.Progress<{ message?: string; increment?: number }>, checkCanceled: () => void) => Promise<void>
+        scanCbk: (progress: vscode.Progress<{ message?: string; increment?: number }>, checkCanceled: () => void) => Promise<void>,
+        title: string
     ) {
         await vscode.window.withProgress(
             <vscode.ProgressOptions>{
                 location: vscode.ProgressLocation.Notification,
-                title: 'Scanning project dependencies ',
+                title: title,
                 cancellable: true
             },
             async (progress: vscode.Progress<{ message?: string; increment?: number }>, token: vscode.CancellationToken) => {

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -22,6 +22,7 @@ import { Severity } from '../../main/types/severity';
 import { TestMemento } from './utils/testMemento.test';
 import { GoUpdateDependency } from '../../main/DependencyUpdate/goDependencyUpdate';
 import { getNodeByArtifactId } from './utils/utils.test';
+import { FocusType } from '../../main/focus/abstractFocus';
 
 /**
  * Test functionality of @class GoUtils.
@@ -33,7 +34,7 @@ describe('Go Utils Tests', () => {
     } as vscode.ExtensionContext);
     let treesManager: TreesManager = new TreesManager([], new ConnectionManager(logManager), dummyScanCacheManager, logManager);
     let projectDirs: string[] = ['dependency', 'empty'];
-    let goDependencyUpdate: GoUpdateDependency = new GoUpdateDependency(treesManager);
+    let goDependencyUpdate: GoUpdateDependency = new GoUpdateDependency();
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'go'));
 
@@ -87,19 +88,19 @@ describe('Go Utils Tests', () => {
         let goMod: vscode.Uri = vscode.Uri.file(path.join(tmpDir.fsPath, 'dependency', 'go.mod'));
         let textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(goMod);
         let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('github.com/jfrog/gofrog', '1.0.5', [], '', ''));
-        let dependencyPos: vscode.Position[] = GoUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        let dependencyPos: vscode.Position[] = GoUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(6, 1));
         assert.deepEqual(dependencyPos[1], new vscode.Position(6, 31));
 
         // Test 'resources/go/empty/go.mod'
         goMod = vscode.Uri.file(path.join(tmpDir.fsPath, 'empty', 'go.mod'));
         textDocument = await vscode.workspace.openTextDocument(goMod);
-        dependencyPos = GoUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = GoUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.isEmpty(dependencyPos);
     });
 
     it('Update fixed version', async () => {
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0',[], '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let goCenterComponentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         await runCreateGoDependenciesTrees(componentsToScan, goCenterComponentsToScan, parent, false);
@@ -113,7 +114,7 @@ describe('Go Utils Tests', () => {
         goDependencyUpdate.updateDependencyVersion(node!, '1.0.6');
 
         // Recalculate the dependency tree.
-        parent = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0',[], '', ''));
+        parent = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         await runCreateGoDependenciesTrees(componentsToScan, goCenterComponentsToScan, parent, false);
 
         // Verify the node's version was modified.
@@ -125,7 +126,7 @@ describe('Go Utils Tests', () => {
         goDependencyUpdate.updateDependencyVersion(node!, '1.0.5');
 
         // Recalculate the dependency tree.
-        parent = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0',[], '', ''));
+        parent = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         await runCreateGoDependenciesTrees(componentsToScan, goCenterComponentsToScan, parent, false);
 
         node = getNodeByArtifactId(parent, 'github.com/jfrog/gofrog');

--- a/src/test/tests/maven.test.ts
+++ b/src/test/tests/maven.test.ts
@@ -18,6 +18,7 @@ import { MavenTreeNode } from '../../main/treeDataProviders/dependenciesTree/dep
 import { MavenExclusion } from '../../main/exclusions/mavenExclusion';
 import { MavenUpdateDependency } from '../../main/DependencyUpdate/mavenDependencyUpdate';
 import { getNodeByArtifactId } from './utils/utils.test';
+import { FocusType } from '../../main/focus/abstractFocus';
 
 /**
  * Test functionality of Maven.
@@ -29,7 +30,7 @@ describe('Maven Tests', () => {
     } as vscode.ExtensionContext);
     let treesManager: TreesManager = new TreesManager([], new ConnectionManager(logManager), dummyScanCacheManager, logManager);
     let mavenExclusion: MavenExclusion = new MavenExclusion(treesManager);
-    let mavenDependencyUpdate: MavenUpdateDependency = new MavenUpdateDependency(treesManager);
+    let mavenDependencyUpdate: MavenUpdateDependency = new MavenUpdateDependency();
     let projectDirs: string[] = ['dependency', 'empty', 'multiPomDependency'];
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'maven'));
@@ -158,7 +159,7 @@ describe('Maven Tests', () => {
         let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(
             new GavGeneralInfo('javax.servlet.jsp', 'jsp-api', '2.1', [], '', '')
         );
-        let dependencyPos: vscode.Position[] = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        let dependencyPos: vscode.Position[] = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(9, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(9, 48));
         assert.deepEqual(dependencyPos[2], new vscode.Position(10, 12));
@@ -169,7 +170,7 @@ describe('Maven Tests', () => {
         pomXml = vscode.Uri.file(path.join(tmpDir.fsPath, 'multiPomDependency', 'multi1', 'pom.xml'));
         textDocument = await vscode.workspace.openTextDocument(pomXml);
         dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.apache.commons', 'commons-email', '1.1', [], '', ''));
-        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(51, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(51, 49));
         assert.deepEqual(dependencyPos[2], new vscode.Position(52, 12));
@@ -178,7 +179,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[5], new vscode.Position(53, 34));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.codehaus.plexus', 'plexus-utils', '1.5.1', [], '', ''));
-        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(57, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(57, 50));
         assert.deepEqual(dependencyPos[2], new vscode.Position(58, 12));
@@ -187,7 +188,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[5], new vscode.Position(59, 36));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('javax.servlet.jsp', 'jsp-api', '2.1', [], '', ''));
-        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(62, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(62, 48));
         assert.deepEqual(dependencyPos[2], new vscode.Position(63, 12));
@@ -196,7 +197,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[5], new vscode.Position(65, 34));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('commons-io', 'commons-io', '1.4', [], '', ''));
-        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(68, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(68, 41));
         assert.deepEqual(dependencyPos[2], new vscode.Position(69, 12));
@@ -205,7 +206,7 @@ describe('Maven Tests', () => {
         assert.deepEqual(dependencyPos[5], new vscode.Position(70, 34));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GavGeneralInfo('org.springframework', 'spring-aop', '2.5.6', [], '', ''));
-        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(73, 12));
         assert.deepEqual(dependencyPos[1], new vscode.Position(73, 50));
         assert.deepEqual(dependencyPos[2], new vscode.Position(74, 12));
@@ -216,7 +217,7 @@ describe('Maven Tests', () => {
         // Test 'resources/maven/empty/pom.xml'
         pomXml = vscode.Uri.file(path.join(tmpDir.fsPath, 'empty', 'pom.xml'));
         textDocument = await vscode.workspace.openTextDocument(pomXml);
-        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = MavenUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.isEmpty(dependencyPos);
     });
 
@@ -322,7 +323,7 @@ describe('Maven Tests', () => {
 
     it('Update fixed version', async () => {
         // Create dependencies tree.
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0',[], '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let res: DependenciesTreeNode[] = await runCreateMavenDependenciesTrees(componentsToScan, parent);
 

--- a/src/test/tests/npmUtils.test.ts
+++ b/src/test/tests/npmUtils.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
 import { ConnectionManager } from '../../main/connect/connectionManager';
 import { NpmUpdateDependency } from '../../main/DependencyUpdate/npmUpdateDependency';
+import { FocusType } from '../../main/focus/abstractFocus';
 import { LogManager } from '../../main/log/logManager';
 import { ScanCacheManager } from '../../main/scanCache/scanCacheManager';
 import { NpmTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree';
@@ -26,7 +27,7 @@ describe('Npm Utils Tests', () => {
     } as vscode.ExtensionContext);
     let treesManager: TreesManager = new TreesManager([], new ConnectionManager(logManager), dummyScanCacheManager, logManager);
     let projectDirs: string[] = ['dependency', 'dependencyPackageLock', 'empty'];
-    let npmDependencyUpdate: NpmUpdateDependency = new NpmUpdateDependency(treesManager);
+    let npmDependencyUpdate: NpmUpdateDependency = new NpmUpdateDependency();
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'npm'));
 
@@ -85,36 +86,36 @@ describe('Npm Utils Tests', () => {
         let packageJson: vscode.Uri = vscode.Uri.file(path.join(tmpDir.fsPath, 'dependency', 'package.json'));
         let textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(packageJson);
         let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('@types/node', '14.14.10', [], '', ''));
-        let dependencyPos: vscode.Position[] = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        let dependencyPos: vscode.Position[] = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(13, 4));
         assert.deepEqual(dependencyPos[1], new vscode.Position(13, 29));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('@ungap/promise-all-settled', '1.1.2', [], '', ''));
-        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(9, 4));
         assert.deepEqual(dependencyPos[1], new vscode.Position(9, 41));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('has-flag', '3.0.0', [], '', ''));
-        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(8, 4));
         assert.deepEqual(dependencyPos[1], new vscode.Position(8, 23));
 
         dependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('progress', '2.0.3', [], '', ''));
-        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(12, 4));
         assert.deepEqual(dependencyPos[1], new vscode.Position(12, 23));
 
         // Test 'resources/npm/dependencyPackageLock/package.json'
         packageJson = vscode.Uri.file(path.join(tmpDir.fsPath, 'dependencyPackageLock', 'package.json'));
         textDocument = await vscode.workspace.openTextDocument(packageJson);
-        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0], new vscode.Position(8, 4));
         assert.deepEqual(dependencyPos[1], new vscode.Position(8, 23));
 
         // Test 'resources/npm/empty/package.json'
         packageJson = vscode.Uri.file(path.join(tmpDir.fsPath, 'empty', 'package.json'));
         textDocument = await vscode.workspace.openTextDocument(packageJson);
-        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode);
+        dependencyPos = NpmUtils.getDependencyPos(textDocument, dependenciesTreeNode, FocusType.Dependency);
         assert.isEmpty(dependencyPos);
     });
 
@@ -139,7 +140,7 @@ describe('Npm Utils Tests', () => {
 
     it('Update fixed version', async () => {
         installAllProjects();
-        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0',[], '', ''));
+        let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', ''));
         let componentsToScan: Collections.Set<ComponentDetails> = new Collections.Set();
         let res: DependenciesTreeNode[] = await runCreateNpmDependenciesTrees(componentsToScan, parent);
         let dependencyProject: DependenciesTreeNode | undefined = res.find(

--- a/src/test/tests/utils/utils.test.ts
+++ b/src/test/tests/utils/utils.test.ts
@@ -3,6 +3,7 @@ import { IComponentMetadata } from '../../../main/goCenterClient/model/Component
 import { ConnectionManager } from '../../../main/connect/connectionManager';
 import { LogManager } from '../../../main/log/logManager';
 import * as os from 'os';
+import { DependenciesTreeNode } from '../../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 
 export const TestArtifact: IArtifact[] = [
     {
@@ -151,4 +152,20 @@ export function createGoCenterConfig(): IClientConfig {
 
 export function isWindows(): boolean {
     return os.platform() === 'win32';
+}
+
+export function getNodeByArtifactId(root: DependenciesTreeNode, artifactId: string): DependenciesTreeNode | null {
+    if (root === null) {
+        return null;
+    }
+    for (let i: number = 0; i < root.children.length; i++) {
+        if (root.children[i].generalInfo.artifactId === artifactId) {
+            return root.children[i];
+        }
+        const res: DependenciesTreeNode | null = getNodeByArtifactId(root.children[i], artifactId);
+        if (res !== null) {
+            return res;
+        }
+    }
+    return null;
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
**What is it?** 
 * Allow update a dependency to fixed version from tree

**How to use it?**
 * Go to:  JFrog-Extention -> Tree -> Chose a node which includes fixed version -> Click on the arrow-up.
 
 **Supported Languages**
  * NPM
  * Maven
  * Go