### PR TITLE
Update dependency should stop when non selected

### DIFF
--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -65,7 +65,9 @@ export class CommandManager implements ExtensionComponent {
     private async doUpdateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode) {
         await ScanUtils.scanWithProgress(async (): Promise<void> => {
             try {
-                await this._DependencyUpdateManager.updateDependencyVersion(dependenciesTreeNode);
+                if (!(await this._DependencyUpdateManager.updateDependencyVersion(dependenciesTreeNode))) {
+                    return;
+                }
                 this._focusManager.focusOnDependency(dependenciesTreeNode, FocusType.DependencyVersion);
                 this._treesManager.dependenciesTreeDataProvider.removeNode(dependenciesTreeNode);
             } catch (error) {

--- a/src/main/dependencyUpdate/dependencyUpdateManager.ts
+++ b/src/main/dependencyUpdate/dependencyUpdateManager.ts
@@ -21,11 +21,15 @@ export class DependencyUpdateManager implements ExtensionComponent {
         return this;
     }
 
-    public async updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode) {
+    public async updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode): Promise<boolean> {
         const fixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
+        if (!fixedVersion) {
+            return false;
+        }
         this._dependencyUpdaters
             .filter(node => node.isMatched(dependenciesTreeNode))
             .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, fixedVersion));
+        return true;
     }
     /**
      * Returns the version to be updated for dependenciesTreeNode. If more than one version exists,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Steps to reproduce:
1. Click on the `Update dependency` on a dependency that has more than one fixed version.
2. Instead of choosing a version, click on `Esc` or click the background.
3. Instead of stopping the update, the extension will try to update to the same version.