### PR TITLE
Allow disabling scan upon changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
                 },
                 "jfrog.xray.watchers": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": "false",
                     "scope": "application",
                     "markdownDescription": "Automatically trigger a scan upon code changes in go.sum or package-lock.json. Change will take effect after reload."
                 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
                     "default": "**/*{test,venv,node_modules,target}*",
                     "scope": "resource",
                     "markdownDescription": "A [glob pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern) used to exclude specific paths from being scanned by JFrog Xray. For example, go.mod files under directories named testdata will not be scanned."
+                },
+                "jfrog.xray.watchers": {
+                    "type": "boolean",
+                    "default": "true",
+                    "scope": "application",
+                    "markdownDescription": "Automatically trigger a scan upon code changes in go.sum or package-lock.json. Change will take effect after reload."
                 }
             }
         },

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+
+export class Configuration {
+    /**
+     * Get scan exclude pattern. This pattern is used to exclude specific file descriptors (go.mod, package.json, etc.) from being scanned by Xray.
+     * Descriptor files which are under a directory which matches the pattern will not be scanned.
+     * @param workspaceFolder - The workspace folder
+     */
+    public static getScanExcludePattern(workspaceFolder?: vscode.WorkspaceFolder): string | undefined {
+        let resource: vscode.Uri | null = workspaceFolder ? workspaceFolder.uri : null;
+        return vscode.workspace.getConfiguration('jfrog', resource).get('xray.exclusions');
+    }
+
+    /**
+     * Return true if should watch for changes in go.sum and package-lock.json files.
+     */
+    public static isWatchEnabled(): boolean | undefined {
+        return vscode.workspace.getConfiguration('jfrog').get('xray.watchers');
+    }
+}

--- a/src/main/utils/goUtils.ts
+++ b/src/main/utils/goUtils.ts
@@ -6,9 +6,9 @@ import { ComponentDetails } from 'xray-client-js';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { GoTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/goTree';
 import { TreesManager } from '../treeDataProviders/treesManager';
-import { ScanUtils } from './scanUtils';
 import { LogManager } from '../log/logManager';
 import { FocusType } from '../focus/abstractFocus';
+import { Configuration } from './configuration';
 
 export class GoUtils {
     public static readonly DOCUMENT_SELECTOR: vscode.DocumentSelector = { scheme: 'file', pattern: '**/go.mod' };
@@ -69,7 +69,7 @@ export class GoUtils {
             logManager.logMessage('Locating go.mod files in workspace "' + workspace.name + '".', 'INFO');
             let wsGoMods: vscode.Uri[] = await vscode.workspace.findFiles(
                 { base: workspace.uri.fsPath, pattern: '**/go.mod' },
-                ScanUtils.getScanExcludePattern(workspace)
+                Configuration.getScanExcludePattern(workspace)
             );
             wsGoMods.forEach(goMod => goMods.add(goMod));
         }

--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -3,14 +3,15 @@ import * as path from 'path';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
-import { LogManager } from '../log/logManager';
-import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { TreesManager } from '../treeDataProviders/treesManager';
-import { PomTree } from './pomTree';
-import { ScanUtils } from './scanUtils';
-import { MavenTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree';
 import { ContextKeys } from '../constants/contextKeys';
 import { FocusType } from '../focus/abstractFocus';
+import { LogManager } from '../log/logManager';
+import { MavenTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { Configuration } from './configuration';
+import { PomTree } from './pomTree';
+import { ScanUtils } from './scanUtils';
 
 export class MavenUtils {
     public static readonly DOCUMENT_SELECTOR: any = { scheme: 'file', pattern: '**/pom.xml' };
@@ -121,7 +122,7 @@ export class MavenUtils {
             logManager.logMessage('Locating pom.xml files in workspace "' + workspace.name + '".', 'INFO');
             let wsPomXmls: vscode.Uri[] = await vscode.workspace.findFiles(
                 { base: workspace.uri.fsPath, pattern: '**/pom.xml' },
-                ScanUtils.getScanExcludePattern(workspace)
+                Configuration.getScanExcludePattern(workspace)
             );
             wsPomXmls.forEach(pomXml => pomXmls.add(pomXml));
         }

--- a/src/main/utils/npmUtils.ts
+++ b/src/main/utils/npmUtils.ts
@@ -3,12 +3,12 @@ import * as path from 'path';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
-import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { NpmTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/npmTree';
-import { TreesManager } from '../treeDataProviders/treesManager';
-import { ScanUtils } from './scanUtils';
-import { LogManager } from '../log/logManager';
 import { FocusType } from '../focus/abstractFocus';
+import { LogManager } from '../log/logManager';
+import { NpmTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/npmTree';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { Configuration } from './configuration';
 
 export class NpmUtils {
     public static readonly DOCUMENT_SELECTOR: vscode.DocumentSelector = { scheme: 'file', pattern: '**/package.json' };
@@ -71,7 +71,7 @@ export class NpmUtils {
             logManager.logMessage('Locating package json files in workspace "' + workspace.name + '".', 'INFO');
             let wsPackageJsons: vscode.Uri[] = await vscode.workspace.findFiles(
                 { base: workspace.uri.fsPath, pattern: '**/package.json' },
-                ScanUtils.getScanExcludePattern(workspace)
+                Configuration.getScanExcludePattern(workspace)
             );
             wsPackageJsons.forEach(packageJson => packageJsons.add(packageJson));
         }

--- a/src/main/utils/nugetUtils.ts
+++ b/src/main/utils/nugetUtils.ts
@@ -1,13 +1,13 @@
+import { NugetDepsTree } from 'nuget-deps-tree';
 import * as path from 'path';
 import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
-import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
-import { NugetTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree';
-import { TreesManager } from '../treeDataProviders/treesManager';
-import { ScanUtils } from './scanUtils';
 import { LogManager } from '../log/logManager';
-import { NugetDepsTree } from 'nuget-deps-tree';
+import { NugetTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
+import { TreesManager } from '../treeDataProviders/treesManager';
+import { Configuration } from './configuration';
 
 export class NugetUtils {
     public static readonly PKG_TYPE: string = 'nuget';
@@ -23,7 +23,7 @@ export class NugetUtils {
             logManager.logMessage('Locating *.sln files in workspace "' + workspace.name + '".', 'INFO');
             let wsSolutions: vscode.Uri[] = await vscode.workspace.findFiles(
                 { base: workspace.uri.fsPath, pattern: '**/*.sln' },
-                ScanUtils.getScanExcludePattern(workspace)
+                Configuration.getScanExcludePattern(workspace)
             );
             wsSolutions.forEach(solution => solutions.add(solution));
         }

--- a/src/main/utils/pypiUtils.ts
+++ b/src/main/utils/pypiUtils.ts
@@ -4,10 +4,10 @@ import * as Collections from 'typescript-collections';
 import * as vscode from 'vscode';
 import { ComponentDetails } from 'xray-client-js';
 import { LogManager } from '../log/logManager';
-import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { PypiTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree';
+import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
-import { ScanUtils } from './scanUtils';
+import { Configuration } from './configuration';
 
 export class PypiUtils {
     public static readonly DOCUMENT_SELECTOR: vscode.DocumentSelector = { scheme: 'file', pattern: '**/*requirements*.txt' };
@@ -63,7 +63,7 @@ export class PypiUtils {
 
         let wsPythonFiles: vscode.Uri[] = await vscode.workspace.findFiles(
             { base: workspaceFolder.uri.fsPath, pattern: '**/*{setup.py,requirements*.txt}' },
-            ScanUtils.getScanExcludePattern(workspaceFolder)
+            Configuration.getScanExcludePattern(workspaceFolder)
         );
         if (logManager && wsPythonFiles.length > 0) {
             logManager.logMessage('Detected python files in workspace ' + workspaceFolder.name + ': [' + wsPythonFiles.toString() + ']', 'DEBUG');
@@ -166,6 +166,6 @@ export class PypiUtils {
      * @param fsPath - The base path to search
      */
     public static async getRequirementsFiles(fsPath: string): Promise<vscode.Uri[]> {
-        return await vscode.workspace.findFiles({ base: fsPath, pattern: '**/*requirements*.txt' }, ScanUtils.getScanExcludePattern());
+        return await vscode.workspace.findFiles({ base: fsPath, pattern: '**/*requirements*.txt' }, Configuration.getScanExcludePattern());
     }
 }

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -33,16 +33,6 @@ export class ScanUtils {
         return path.join(os.homedir(), '.jfrog-vscode-extension');
     }
 
-    /**
-     * Get scan exclude pattern. This pattern is used to exclude specific file descriptors (go.mod, package.json, etc.) from being scanned by Xray.
-     * Descriptor files which are under a directory which matches the pattern will not be scanned.
-     * @param workspaceFolder - The workspace folder
-     */
-    public static getScanExcludePattern(workspaceFolder?: vscode.WorkspaceFolder): string | undefined {
-        let resource: vscode.Uri | null = workspaceFolder ? workspaceFolder.uri : null;
-        return vscode.workspace.getConfiguration('jfrog', resource).get('xray.exclusions');
-    }
-
     static readFileIfExists(filePath: string): string | undefined {
         if (fse.pathExistsSync(filePath)) {
             return fse.readFileSync(filePath).toString();

--- a/src/main/watchers/abstractWatcher.ts
+++ b/src/main/watchers/abstractWatcher.ts
@@ -8,21 +8,15 @@ import { TreesManager } from '../treeDataProviders/treesManager';
 export abstract class AbstractWatcher implements ExtensionComponent {
     constructor(protected _treesManager: TreesManager, private _globPattern: vscode.GlobPattern) {}
 
-    onDidCreate(): void {
-        this.onDidChange();
-    }
     onDidChange(): void {
         this._treesManager.dependenciesTreeDataProvider.refresh(true);
     }
-    onDidDelete(): void {
-        this.onDidChange();
-    }
 
     public activate(context: vscode.ExtensionContext) {
-        let watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher(this._globPattern, false, false, false);
-        context.subscriptions.push(watcher.onDidCreate(() => this.onDidCreate()));
+        let watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher(this._globPattern);
+        context.subscriptions.push(watcher.onDidCreate(() => this.onDidChange()));
         context.subscriptions.push(watcher.onDidChange(() => this.onDidChange()));
-        context.subscriptions.push(watcher.onDidDelete(() => this.onDidDelete()));
+        context.subscriptions.push(watcher.onDidDelete(() => this.onDidChange()));
         context.subscriptions.push(watcher);
     }
 }

--- a/src/main/watchers/watcherManager.ts
+++ b/src/main/watchers/watcherManager.ts
@@ -4,6 +4,7 @@ import { NpmWatcher } from './npmWatcher';
 import { TreesManager } from '../treeDataProviders/treesManager';
 import { ExtensionComponent } from '../extensionComponent';
 import { GoWatcher } from './goWatcher';
+import { Configuration } from '../utils/configuration';
 
 /**
  * Listen to project descriptor (i.e package-lock.json) changes and perform Xray scan on a change.
@@ -12,7 +13,9 @@ export class WatcherManager implements ExtensionComponent {
     private _watchers: AbstractWatcher[] = [];
 
     constructor(treesManager: TreesManager) {
-        this._watchers.push(new NpmWatcher(treesManager), new GoWatcher(treesManager));
+        if (Configuration.isWatchEnabled()) {
+            this._watchers.push(new NpmWatcher(treesManager), new GoWatcher(treesManager));
+        }
     }
 
     public activate(context: vscode.ExtensionContext): WatcherManager {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Resolves #84 

Allow disabling watchers for `go.sum` and `package-lock.json`. The code watches for changes in these files and automatically triggers a scan upon changes. This feature allows unchecking file watchers through configuration.
<img width="828" alt="image" src="https://user-images.githubusercontent.com/11367982/103455181-77774080-4cf3-11eb-8321-7bb87ff41475.png">
