### PR TITLE
Allow disabling scan upon changes - readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Proxy Configuration](#proxy-configuration)
     - [Proxy Authorization](#proxy-authorization)
   - [Exclude Paths from Scan](#exclude-paths-from-scan)
+  - [Scan after dependencies change](#scan-after-dependencies-change)
   - [Extension Settings](#extension-settings)
 - [Go Projects](#go-projects)
 - [Maven Projects](#maven-projects)
@@ -123,6 +124,10 @@ settings.json:
    "http.proxyAuthorization": "Basic Zm9vOmJhcg=="
 }
 ```
+
+### Scan after dependencies change
+The JFrog VS-Code extension can trigger an Xray scan after a change in go.sum and package-lock.json.
+This feature is disabled by default. You can enable it in the [Extension Settings](#extension-settings).
 
 ### Exclude Paths from Scan
 By default, paths containing the words `test`, `venv` and `node_modules` are excluded from Xray scan.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ settings.json:
 ```
 
 ### Scan after dependencies change
-The JFrog VS-Code extension can trigger an Xray scan after a change in go.sum and package-lock.json.
+The JFrog VS-Code extension can trigger an Xray scan after a change in go.sum or package-lock.json.
 This feature is disabled by default. You can enable it in the [Extension Settings](#extension-settings).
 
 ### Exclude Paths from Scan

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -12,7 +12,7 @@ export class Configuration {
     }
 
     /**
-     * Return true if should watch for changes in go.sum and package-lock.json files.
+     * Return true if should watch for changes in go.sum or package-lock.json files.
      */
     public static isWatchEnabled(): boolean | undefined {
         return vscode.workspace.getConfiguration('jfrog').get('xray.watchers');


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Readme updates for #90 