### PR TITLE
Support npm 7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
               if: runner.os == 'macOS'
             - uses: actions/setup-python@v1
             - name: Setup NodeJS
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v2
               with:
-                  node-version: '10.x'
+                  node-version: '14'
             - name: Install
               run: npm i
               # Make sure no new dependencies were installed after running 'npm i'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: '14'
+                  check-latest: true
             - name: Install
               run: npm i
               # Make sure no new dependencies were installed after running 'npm i'

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -77,6 +77,6 @@ export class NpmTreeNode extends RootNode {
     }
 
     private runNpmLs(scope: NpmGlobalScopes): any {
-        return JSON.parse(ScanUtils.executeCmd('npm ls --json --only=' + scope, this.workspaceFolder).toString());
+        return JSON.parse(ScanUtils.executeCmd('npm ls --json --all --only=' + scope, this.workspaceFolder).toString());
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

In npm 7, running `npm ls` produces a flat dependency tree with direct dependencies only (see https://github.com/npm/cli/blob/v7.0.0/CHANGELOG.md#npm-ls).
To get the transitive dependency tree like in versions prior to 6, we should add the `--all` flag. 
Fortunately, npm commands do not fail when providing unknown flags. Therefore we can add the `--all` flag also when running with npm<7.