### PR TITLE
Apply filespec schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The JFrog VS Code Extension adds JFrog Xray scanning of project dependencies to 
 It allows developers to view panels displaying vulnerability information about the components and their dependencies directly in their VS Code IDE.
 With this information, a developer can make an informed decision on whether to use a component or not before it gets entrenched into the organization’s product.
 
+The extension also applies [JFrog File Spec JSON schema](https://raw.githubusercontent.com/jfrog/jfrog-cli/master/schema/filespec-schema.json) on the following file patterns: `**/filespecs/*.json`, `*filespec*.json` and `*.filespec`. Read more about JFrog File specs [here](https://www.jfrog.com/confluence/display/JFROG/FileSpec).
+
 Don't have JFrog Xray? [Start for free](https://jfrog.com/xray/start-free).
 
 ### Supported Features

--- a/package.json
+++ b/package.json
@@ -164,7 +164,17 @@
                     "command": "jfrog.xray.copyToClipboard"
                 }
             ]
-        }
+        },
+        "jsonValidation": [
+            {
+                "fileMatch": [
+                    "**/filespecs/*.json",
+                    "*filespec*.json",
+                    "*.filespec"
+                ],
+                "url": "https://github.com/jfrog/jfrog-cli/raw/master/schema/filespec-schema.json"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

applies [JFrog File Spec JSON schema](https://raw.githubusercontent.com/jfrog/jfrog-cli/master/schema/filespec-schema.json) on the following file patterns: `**/filespecs/*.json`, `*filespec*.json` and `*.filespec`.