### PR TITLE
Fix Proxy authorization header test

### DIFF
--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -35,7 +35,7 @@ describe('Connection Manager Tests', () => {
             proxy: {} as IProxyConfig
         } as IClientConfig;
 
-        await vscode.workspace.getConfiguration().update('http.proxyAuthorization', 'testProxyAuthorization');
+        await vscode.workspace.getConfiguration().update('http.proxyAuthorization', 'testProxyAuthorization', true);
         ConnectionUtils.addProxyAuthHeader(clientConfig);
         let proxyAuthorization: string | undefined = clientConfig.headers!['Proxy-Authorization'];
         assert.isDefined(proxyAuthorization);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fix the following error in test:
> Error: Unable to write http.proxyAuthorization to Workspace Settings. This setting can be written only into User settings.
