### PR TITLE
Bugfix: unresponsive extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "Other"
     ],
     "activationEvents": [
-        "*"
+        "onStartupFinished"
     ],
     "main": "./out/extension.js",
     "contributes": {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

May resolve #109 

* Change activation event from `*` to `onStartupFinished`
* Make scan async