### PR TITLE
Don't hold components to scan after scan finished

### DIFF
--- a/src/main/scanCache/scanCacheManager.ts
+++ b/src/main/scanCache/scanCacheManager.ts
@@ -14,7 +14,7 @@ import { ScanCacheObject } from './scanCacheObject';
  * 1. Scan cache - contains general information about components and the IDs of the issues and licenses. This cache stored in the RAM.
  * 2. Issues cache - consists of files. Each file contains information about an Xray issue.
  * 3. Licenses cache - consists of files. Each file contains information about an Xray license.
- * 
+ *
  * Usage:
  * For each artifact received from the Xray scan:
  * 1. Add a scan cache object, including issue IDs and licenses names.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

May help with #109 

During refresh dependencies, the extension populates `componentsToScan` set to be used during the Xray scan.
This object is a class variable, although we don't really need it after the scan ends.
Let's make it a local variable to allow the GC to clear it at the end of the scan.