### PR TITLE
Blank dialog box when connection details are wrong

### DIFF
--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -92,7 +92,7 @@ export class ConnectionUtils {
             let xrayVersion: string = await ConnectionUtils.testXrayVersion(jfrogClient);
             vscode.window.showInformationMessage(xrayVersion);
         } catch (error) {
-            vscode.window.showErrorMessage(error.message, <vscode.MessageOptions>{ modal: true });
+            vscode.window.showErrorMessage(error.message || error, <vscode.MessageOptions>{ modal: true });
             return Promise.resolve(false);
         }
         return Promise.resolve(true);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Resolves #113 