### PR TITLE
Fix npm ls scope to be compatible with all npm verisons

### DIFF
--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -77,6 +77,6 @@ export class NpmTreeNode extends RootNode {
     }
 
     private runNpmLs(scope: NpmGlobalScopes): any {
-        return JSON.parse(ScanUtils.executeCmd('npm ls --json --all --only=' + scope, this.workspaceFolder).toString());
+        return JSON.parse(ScanUtils.executeCmd('npm ls --json --all --' + scope, this.workspaceFolder).toString());
     }
 }

--- a/src/main/utils/npmUtils.ts
+++ b/src/main/utils/npmUtils.ts
@@ -145,7 +145,8 @@ export class ScopedNpmProject {
     }
 }
 
+// For compatibility with npm 6,7,8, scope must be one of: 'dev' or 'prod'!
 export enum NpmGlobalScopes {
-    PRODUCTION = 'production',
-    DEVELOPMENT = 'development'
+    PRODUCTION = 'prod',
+    DEVELOPMENT = 'dev'
 }

--- a/src/test/tests/npmUtils.test.ts
+++ b/src/test/tests/npmUtils.test.ts
@@ -218,25 +218,25 @@ describe('Npm Utils Tests', () => {
         assert.deepEqual(child?.label, res[2].children[0].label);
         assert.deepEqual(child?.componentId, 'progress:2.0.3');
         assert.deepEqual(child?.description, '2.0.3');
-        assert.deepEqual(child?.generalInfo.scopes, ['production']);
+        assert.deepEqual(child?.generalInfo.scopes, ['prod']);
         assert.deepEqual(child?.parent, res[1]);
 
         child = res[1].children.find(component => component.label === 'has-flag');
         assert.deepEqual(child?.componentId, 'has-flag:3.0.0');
         assert.deepEqual(child?.description, '3.0.0');
-        assert.deepEqual(child?.generalInfo.scopes, ['development']);
+        assert.deepEqual(child?.generalInfo.scopes, ['dev']);
         assert.deepEqual(child?.parent, res[1]);
 
         child = res[1].children.find(component => component.label === '@types/node');
         assert.deepEqual(child?.componentId, '@types/node:14.14.10');
         assert.deepEqual(child?.description, '14.14.10');
-        assert.deepEqual(child?.generalInfo.scopes, ['production', 'types']);
+        assert.deepEqual(child?.generalInfo.scopes, ['prod', 'types']);
         assert.deepEqual(child?.parent, res[1]);
 
         child = res[1].children.find(component => component.label === '@ungap/promise-all-settled');
         assert.deepEqual(child?.componentId, '@ungap/promise-all-settled:1.1.2');
         assert.deepEqual(child?.description, '1.1.2');
-        assert.deepEqual(child?.generalInfo.scopes, ['development', 'ungap']);
+        assert.deepEqual(child?.generalInfo.scopes, ['dev', 'ungap']);
         assert.deepEqual(child?.parent, res[1]);
     });
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
