### PR TITLE
Bug fix - unable to upgrade dependency to a fixed version

### DIFF
--- a/src/main/dependencyUpdate/dependencyUpdateManager.ts
+++ b/src/main/dependencyUpdate/dependencyUpdateManager.ts
@@ -24,10 +24,11 @@ export class DependencyUpdateManager implements ExtensionComponent {
     }
 
     public async updateDependencyVersion(dependenciesTreeNode: DependenciesTreeNode): Promise<boolean> {
-        const fixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
+        let fixedVersion: string = await this.getFixedVersion(dependenciesTreeNode);
         if (!fixedVersion) {
             return false;
         }
+        fixedVersion = fixedVersion.replace(/[\][]/g, '')
         this._dependencyUpdaters
             .filter(node => node.isMatched(dependenciesTreeNode))
             .forEach(node => node.updateDependencyVersion(dependenciesTreeNode, fixedVersion));
@@ -45,7 +46,7 @@ export class DependencyUpdateManager implements ExtensionComponent {
                 if (!issue) {
                     return;
                 }
-                issue.fixedVersions.forEach(fixedVersion => fixedVersions.add(fixedVersion));
+                issue.fixedVersions?.forEach(fixedVersion => fixedVersions.add(fixedVersion));
             }
         });
         let fixedVersionsArr: string[] = fixedVersions.toArray();

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
@@ -29,7 +29,7 @@ export class RootNode extends DependenciesTreeNode {
             .map(issueKey => scanCacheManager.getIssue(issueKey.issue_id))
             .filter(issue => issue)
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            .some(issue => issue!.fixedVersions.length > 0);
+            .some(issue => issue!.fixedVersions?.length > 0);
         if (isRootUpgradable) {
             node.contextValue += ContextKeys.UPDATE_DEPENDENCY_ENABLED;
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fix the following errors:
1. > Exception has occurred: TypeError: Cannot read property 'length' of undefined
t /Users/yahavi/code/jfrog-vscode-extension/dist/extension.js:74287:48
	at Array.some (<anonymous>)
	at GoTreeNode.upgradableDependencies (/Users/yahavi/code/jfrog-vscode-extension/dist/extension.js:74287:14)

2. > Command failed: mvn versions:use-dep-version -DgenerateBackupPoms=false -Dincludes=com.thoughtworks.xstream:xstream -DdepVersion=[1.4.18]
