### PR TITLE
Fix user agent header test

### DIFF
--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -38,7 +38,7 @@ describe('Connection Manager Tests', () => {
         ConnectionUtils.addUserAgentHeader(clientConfig);
         let userAgent: string | undefined = clientConfig.headers!['User-Agent'];
         assert.isDefined(userAgent);
-        assert.match(userAgent, new RegExp(/^jfrog-vscode-extension\/\d.\d.\d$/));
+        assert.match(userAgent, new RegExp(/^jfrog-vscode-extension\/\d+.\d+.\d+$/));
     });
 
     it('Proxy authorization header', async () => {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fix the following error:
> AssertionError: expected 'jfrog-vscode-extension/1.10.0' to match /^jfrog-vscode-extension\/\d.\d.\d$/