### PR TITLE
Add "Applying Your Xray Policies" to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Getting Started](#getting-started)
 - [Set Up a FREE JFrog Environment in the Cloud](#set-up-a-free-jfrog-environment-in-the-cloud)
 - [Connecting VS Code to Your JFrog Environment](#connecting-vs-code-to-your-jfrog-environment)
+- [Applying Your Xray Policies](#applying-your-xray-policies)
 - [Proxy Configuration](#proxy-configuration)
   - [Proxy Authorization](#proxy-authorization)
 - [Extension Settings](#extension-settings)
@@ -79,6 +80,13 @@ Note: For security reasons, it is recommended to unset the environment variables
 - `JFROG_IDE_PASSWORD` - JFrog password
 - `JFROG_IDE_ACCESS_TOKEN` - JFrog access token
 - `JFROG_IDE_STORE_CONNECTION` - Set the value of this environment variable to **true**, if you'd like VS Code to store the connection details after reading them from the environment variables.
+
+## Applying Your Xray Policies
+To configure JFrog VS-Code extension to reflect the Security Policies required by your organization, follow these steps.
+1. Create a [JFrog Project](https://www.jfrog.com/confluence/display/JFROG/Projects), or obtain the relevant JFrog Project key.
+1. Create a [Policy](https://www.jfrog.com/confluence/display/JFROG/Creating+Xray+Policies+and+Rules) on JFrog Xray.
+1. Create a [Watch](https://www.jfrog.com/confluence/display/JFROG/Configuring+Xray+Watches) on JFrog Xray and assign your Policy and Project as resources to it.
+1. Configure your Project key in the [Extension Settings](#extension-settings).
 
 ## Proxy Configuration
 If your JFrog environment is behind an HTTP/S proxy, follow these steps to configure the proxy server:


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

![image](https://user-images.githubusercontent.com/11367982/148184314-ed80fbc6-acca-4d9f-a87e-d0ed9019890a.png)


See:
https://github.com/yahavi/jfrog-vscode-extension/tree/readme2#applying-your-xray-policies