### PR TITLE
CI - Build not found issues

### DIFF
--- a/src/main/utils/builds/ciManager.ts
+++ b/src/main/utils/builds/ciManager.ts
@@ -31,7 +31,11 @@ export class CiManager {
     private root: DependenciesTreeNode;
 
     constructor(private _treesManager: TreesManager, root?: DependenciesTreeNode) {
-        this.buildsCache = new BuildsScanCache(Configuration.getBuildsPattern(), this._treesManager.logManager);
+        this.buildsCache = new BuildsScanCache(
+            Configuration.getProjectKey(),
+            this._treesManager.connectionManager.url,
+            this._treesManager.logManager
+        );
         if (!root) {
             this.root = new DependenciesTreeNode(new GeneralInfo('', '', ['None'], '', ''), vscode.TreeItemCollapsibleState.Expanded, undefined, '');
         } else {
@@ -375,11 +379,11 @@ export class CiManager {
             let build: any =
                 buildsCache.loadBuildInfo(timestamp, buildName, buildNumber, projectKey) ||
                 (await this.downloadBuildInfo(searchEntry, buildsCache, projectKey));
-            let buildGeneralInfo: BuildGeneralInfo = BuildsUtils.createBuildGeneralInfo(build, this._treesManager.logManager);
             if (!build) {
                 progress.report({ message: `${buildsNum} builds`, increment: 100 / (buildsNum * 2) });
                 return;
             }
+            let buildGeneralInfo: BuildGeneralInfo = BuildsUtils.createBuildGeneralInfo(build, this._treesManager.logManager);
             this.addResults(buildGeneralInfo);
             consumerQueue.add(() =>
                 this.handleXrayBuildDetails(buildGeneralInfo, buildsCache, progress, checkCanceled, buildsNum, xraySupported, projectKey)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Support long build name and numbers by encoding with sha1 instead of base64 (same as https://github.com/jfrog/ide-plugins-common/pull/59)
* In some rare cases, the AQL results may return a path to a file that doesn't actually exist. Make sure not to crash in these cases.
* After replacing the project key or platform URL, the cache dir must be replaced too. Otherwise, the builds in the cache may be mixed up.