### PR TITLE
CI - Build info not loaded properly from cache

### DIFF
--- a/src/main/utils/builds/ciManager.ts
+++ b/src/main/utils/builds/ciManager.ts
@@ -370,7 +370,7 @@ export class CiManager {
                 throw new Error('unexpected build artifact name');
             }
             const buildNumber: string = split[0];
-            const timestamp: string = split[1];
+            const timestamp: string = split[1].replace(/.json$/, '');
 
             let build: any =
                 buildsCache.loadBuildInfo(timestamp, buildName, buildNumber, projectKey) ||


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Currently all attempt to look for the build in the cache fails, because the timestamp string contains .json in the end.

**Explanation:**
The results of the AQL query are: `repo`, `file`, `path` triple.

The `projectkey` is the first part of the repository name.
`buildName` is path, since it is the build-info directory name.
The file is: `buildNumber`-`timestamp`.json. 

|           |          Repo          |          Path          |            Name            |
|-----------|:----------------------:|:----------------------:|:--------------------------:|
| pattern   | `projectKey`-build-info            | `buildName`              | `buildNumber`-`timestamp`.json |
| example-1 | artifactory-build-info | jfrog-vscode-extension | 1-1639300304168.json       |
| example-2 | ecosys-build-info      | jfrog-idea-plugin      | 1-1639300304169.json       |
