### PR TITLE
Bugfix - Incorrect dependencies location on pom.xml

### DIFF
--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -90,9 +90,11 @@ export class MavenUtils {
      * @param artifactId  - The dependency's artifact ID
      */
     public static getDependencyTag(pomXmlContent: string, groupId: string, artifactId: string): string {
+        let groupIdRegex:RegExp = new RegExp(`<groupId>\\s*${groupId}\\s*</groupId>`, 'gi');
+        let artifactIdRegex:RegExp = new RegExp(`<artifactId>\\s*${artifactId}\\s*</artifactId>`, 'gi');
         let dependencyMatch: string[] | undefined = pomXmlContent
             .match(/<dependency>(.|\s)*?<\/dependency>/gi)
-            ?.filter(group => group.includes(groupId) && group.includes(artifactId));
+            ?.filter(group => group.match(groupIdRegex) && group.match(artifactIdRegex));
         if (dependencyMatch && dependencyMatch.length > 0) {
             return dependencyMatch[0];
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Mismatch position on pom.xml for two or more dependencies with the same `groupId `. The following dependencies, for example, will override each other's position:
```
...
  <dependency>
      <groupId>org.jenkins-ci.plugins</groupId>
      <artifactId>ssh-credentials</artifactId>
      <version>1.15</version>
  </dependency>
    <dependency>
      <groupId>org.jenkins-ci.plugins</groupId>
      <artifactId>credentials</artifactId>
      <version>2.2.1</version>
  </dependency>
...
```
