### PR TITLE
Add connection status

### DIFF
--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -298,7 +298,7 @@ export class CommandManager implements ExtensionComponent {
     }
 
     private connectedMessage(): string {
-        let message: string = 'Connected To Xray ' + this._connectionManager.xrayUrl;
+        let message: string = 'Connected To JFrog Xray ' + this._connectionManager.xrayUrl;
         if (this._connectionManager.xrayVersion !== '') {
             message += ' version ' + this._connectionManager.xrayVersion;
         }

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -290,21 +290,28 @@ export class CommandManager implements ExtensionComponent {
     }
 
     private async showConnectionStatus() {
-        if (this._connectionManager.areXrayCredentialsSet()) {
-            vscode.window.showInformationMessage(this.connectedMessage());
-        } else {
-            vscode.window.showErrorMessage('No connection to JFrog Xray');
+        if (this._connectionManager.xrayUrl) {
+            vscode.window.showInformationMessage(this.xrayConnectionDetails());
+            if (this._connectionManager.rtUrl) {
+                return vscode.window.showInformationMessage(this.artifactoryConnectionDetails());
+            }
+            return;
         }
+        return vscode.window.showErrorMessage('No connection to JFrog server');
     }
 
-    private connectedMessage(): string {
-        let message: string = 'Connected To JFrog Xray ' + this._connectionManager.xrayUrl;
-        if (this._connectionManager.xrayVersion !== '') {
-            message += ' version ' + this._connectionManager.xrayVersion;
-        }
-        return message;
+    private xrayConnectionDetails(): string {
+        return this.createServerDetailsMessage('Xray', this._connectionManager.xrayUrl, this._connectionManager.xrayVersion);
     }
 
+    private artifactoryConnectionDetails(): string {
+        return this.createServerDetailsMessage('Artifactory', this._connectionManager.rtUrl, this._connectionManager.artifactoryVersion);
+    }
+
+    private createServerDetailsMessage(name: string, url: string, version?: string): string {
+        return `${name} ${url} ${version ? `v${version}` : ''}`;
+    }
+    
     /**
      * Show the filter menu.
      */

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -49,6 +49,7 @@ export class CommandManager implements ExtensionComponent {
         this.registerCommand(context, 'jfrog.xray.copyToClipboard', node => this.doCopyToClipboard(node));
         this.registerCommand(context, 'jfrog.xray.openLink', url => this.doOpenLink(url));
         this.registerCommand(context, 'jfrog.xray.disconnect', () => this.doDisconnect());
+        this.registerCommand(context, 'jfrog.show.connectionStatus', () => this.showConnectionStatus());
         this.registerCommand(context, 'jfrog.xray.showOutput', () => this.showOutput());
         this.registerCommand(context, 'jfrog.xray.refresh', () => this.doRefresh());
         this.registerCommand(context, 'jfrog.source.code.scan.refresh', () => this.doCodeScanRefresh());
@@ -286,6 +287,22 @@ export class CommandManager implements ExtensionComponent {
         if (await this._connectionManager.disconnect()) {
             await this.doRefresh(true);
         }
+    }
+
+    private async showConnectionStatus() {
+        if (this._connectionManager.areXrayCredentialsSet()) {
+            vscode.window.showInformationMessage(this.connectedMessage());
+        } else {
+            vscode.window.showErrorMessage('No connection to JFrog Xray');
+        }
+    }
+
+    private connectedMessage(): string {
+        let message: string = 'Connected To Xray ' + this._connectionManager.xrayUrl;
+        if (this._connectionManager.xrayVersion !== '') {
+            message += ' version ' + this._connectionManager.xrayVersion;
+        }
+        return message;
     }
 
     /**

--- a/src/main/connect/connectionManager.ts
+++ b/src/main/connect/connectionManager.ts
@@ -60,8 +60,8 @@ export class ConnectionManager implements ExtensionComponent {
 
     constructor(private _logManager: LogManager) {
         this._statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-        this._statusBar.tooltip = 'JFrog Xray connection details status';
-        this._statusBar.text = '🐸 JFrog Status';
+        this._statusBar.tooltip = 'JFrog connection details';
+        this._statusBar.text = '🔴 JFrog';
         this._statusBar.command = 'jfrog.show.connectionStatus';
     }
 

--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -1,5 +1,13 @@
 import * as http2 from 'http2';
-import { ComponentDetails, IJfrogClientConfig, IProxyConfig, ISummaryRequestModel, IXrayVersion, JfrogClient } from 'jfrog-client-js';
+import {
+    ComponentDetails,
+    IArtifactoryVersion,
+    IJfrogClientConfig,
+    IProxyConfig,
+    ISummaryRequestModel,
+    IXrayVersion,
+    JfrogClient
+} from 'jfrog-client-js';
 import * as semver from 'semver';
 import { SemVer } from 'semver';
 import { URL } from 'url';
@@ -204,6 +212,14 @@ export class ConnectionUtils {
             .system()
             .version();
         return xrayVersion.xray_version;
+    }
+
+    public static async getArtifactoryVersion(jfrogClient: JfrogClient): Promise<string> {
+        let artifactoryVersion: IArtifactoryVersion = await jfrogClient
+            .artifactory()
+            .system()
+            .version();
+        return artifactoryVersion.version;
     }
 
     public static async testComponentPermission(jfrogClient: JfrogClient): Promise<any> {

--- a/src/main/log/logManager.ts
+++ b/src/main/log/logManager.ts
@@ -8,18 +8,10 @@ type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERR';
  * Log to the "OUTPUT" channel. Add date and log level.
  */
 export class LogManager implements ExtensionComponent {
-    private _statusBar!: vscode.StatusBarItem;
     private _outputChannel!: vscode.OutputChannel;
-
-    constructor() {
-        this._statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-        this._statusBar.tooltip = 'JFrog Xray vulnerabilities scanning status';
-        this._statusBar.command = 'jfrog.xray.showOutput';
-    }
 
     activate(): LogManager {
         this._outputChannel = vscode.window.createOutputChannel('JFrog');
-        this._statusBar.show();
         return this;
     }
 
@@ -49,7 +41,6 @@ export class LogManager implements ExtensionComponent {
      * @param shouldToast - True iff toast should be shown
      */
     public logError(error: Error, shouldToast: boolean) {
-        this.setFailed();
         let logMessage: string = error.name;
         if (error.message) {
             logMessage += ': ' + error.message;
@@ -69,20 +60,6 @@ export class LogManager implements ExtensionComponent {
      */
     public showOutput() {
         this._outputChannel.show(true);
-    }
-
-    /**
-     * Set success in the JFrog status bar.
-     */
-    public setSuccess() {
-        this._statusBar.text = 'JFrog: $(check)';
-    }
-
-    /**
-     * Set failure in the JFrog status bar.
-     */
-    private setFailed() {
-        this._statusBar.text = 'JFrog: $(error)';
     }
 
     private logLevelToNumber(level: LogLevel): number {

--- a/src/main/treeDataProviders/dependenciesTree/buildsDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/buildsDataProvider.ts
@@ -54,7 +54,6 @@ export class BuildsDataProvider implements vscode.TreeDataProvider<DependenciesT
             this.sendUsageReport();
             await this.repopulateTree(quickScan, credentialsSet, onChangeFire);
             vscode.commands.executeCommand('jfrog.xray.focus');
-            this._treesManager.logManager.setSuccess();
             this._treesManager.logManager.logMessage('Done loading builds details.', 'INFO');
         } catch (error) {
             if (!(error instanceof ScanCancellationError)) {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -71,7 +71,6 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
         this.repopulateTree(quickScan, onChangeFire)
             .then(() => {
                 vscode.commands.executeCommand('jfrog.xray.focus');
-                this._treesManager.logManager.setSuccess();
             })
             .catch(error => {
                 this.clearTree();


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
The connection status to Xray is added in this PR.

<img width="441" alt="Screen Shot 2022-08-18 at 21 16 28" src="https://user-images.githubusercontent.com/9606235/185467285-e1fe4629-c5b7-49cd-911a-48bc04a58b86.png">

