### PR TITLE
Fix ConnectionManager tests

### DIFF
--- a/src/main/connect/connectionManager.ts
+++ b/src/main/connect/connectionManager.ts
@@ -78,11 +78,11 @@ export class ConnectionManager implements ExtensionComponent {
         return this;
     }
 
-    private async isSignedIn():Promise<boolean> {
+    private async isSignedIn(): Promise<boolean> {
         const status: SessionStatus | undefined = await this.getConnectionStatus();
         return status === SessionStatus.SignedIn || status === undefined;
     }
-    
+
     public async connect(): Promise<boolean> {
         if (await this.populateCredentials(true)) {
             this.setConnectionStatus(SessionStatus.SignedIn);

--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -137,7 +137,7 @@ export class MavenUtils {
         } catch (error) {
             logManager.logMessage(
                 'Could not get parse pom.xml GAV.\n' + 'Try to install it by running "mvn clean install" from ' + path.resolve(pathToPomXml) ||
-                pathToPomXml + '.',
+                    pathToPomXml + '.',
                 'ERR'
             );
             logManager.logMessage((<any>error).stdout?.toString().replace(/(\[.*?\])/g, ''), 'ERR');

--- a/src/test/tests/scanLogic.test.ts
+++ b/src/test/tests/scanLogic.test.ts
@@ -65,7 +65,7 @@ describe('Scan Logic Tests', () => {
         nodeInfo = scanCacheManager.getNodeInfo('org.apache.commons:commons-lang3:3.12.0');
         assert.isDefined(nodeInfo);
         if (nodeInfo) {
-            assert.equal(nodeInfo.top_severity, Severity.Unknown);
+            assert.equal(nodeInfo.top_severity, Severity.Normal);
             assert.isEmpty(nodeInfo.issues);
             assert.lengthOf(nodeInfo.licenses, 1);
             assert.deepEqual(nodeInfo.licenses[0], { licenseName: 'Apache-2.0', violated: licenseViolated } as ILicenseKey);
@@ -75,7 +75,11 @@ describe('Scan Logic Tests', () => {
         nodeInfo = scanCacheManager.getNodeInfo('commons-io:commons-io:2.11.0');
         assert.isDefined(nodeInfo);
         if (nodeInfo) {
-            assert.equal(nodeInfo.top_severity, Severity.Unknown);
+            if (scanLogic instanceof ComponentSummaryScanLogic) {
+                assert.equal(nodeInfo.top_severity, Severity.Normal);
+            } else {
+                assert.equal(nodeInfo.top_severity, Severity.Unknown);
+            }
             assert.isEmpty(nodeInfo.issues);
             assert.isEmpty(nodeInfo.licenses);
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Top severity of an existing component in Xray should be normal
* Top severity of a non-existed component in Xray in summary/component should be normal (old logic)