### PR TITLE
Handle connection lost

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
                 "when": "jfrog.connection.status == signedOut || !jfrog.connection.status"
             },
             {
+                "view": "jfrog.xray",
+                "contents": "Couldn't connect to your JFrog Platform. \n[Reconnect](command:jfrog.xray.reConnect)\n[Reset your connection details](command:jfrog.xray.resetConnection)",
+                "when": "jfrog.connection.status == connectionLost "
+            },
+            {
                 "view": "jfrog.source.code.scan",
                 "contents": "This view displays the results of applicability scanning of CVEs in the code. Python, npm, and yarn are currently supported."
             }
@@ -138,7 +143,7 @@
                 "command": "jfrog.xray.disconnect",
                 "title": "Disconnect",
                 "icon": "$(debug-disconnect)",
-                "enablement": "jfrog.connection.status == signedIn && !jfrog.scanInProgress"
+                "enablement": "jfrog.connection.status != signedOut && !jfrog.scanInProgress"
             },
             {
                 "command": "jfrog.xray.filter",
@@ -194,7 +199,7 @@
                     "light": "resources/light/ci.png",
                     "dark": "resources/dark/ci.png"
                 },
-                "enablement": "jfrog.connection.status == signedIn && jfrog.connection.status == signedIn && !jfrog.scanInProgress"
+                "enablement": "jfrog.connection.status == signedIn && !jfrog.scanInProgress"
             },
             {
                 "command": "jfrog.xray.export",
@@ -207,7 +212,7 @@
             "view/title": [
                 {
                     "command": "jfrog.xray.disconnect",
-                    "when": "view == jfrog.xray && jfrog.connection.status == signedIn",
+                    "when": "view == jfrog.xray && jfrog.connection.status != signedOut",
                     "group": "navigation@0"
                 },
                 {

--- a/src/main/constants/contextKeys.ts
+++ b/src/main/constants/contextKeys.ts
@@ -10,6 +10,7 @@ export class ContextKeys {
 
 export enum SessionStatus {
     SignedOut = 'signedOut',
+    connectionLost = 'connectionLost',
     SignedIn = 'signedIn'
 }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts
@@ -54,7 +54,7 @@ export class DependenciesTreeDataProvider implements vscode.TreeDataProvider<Dep
     }
 
     public async refresh(quickScan: boolean, onChangeFire: () => void) {
-        if (!this._treesManager.connectionManager.areXrayCredentialsSet()) {
+        if (!this._treesManager.connectionManager.isSignedIn()) {
             this.clearTree();
             onChangeFire();
             return;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Add a new state option to handle connection loss situations.