### PR TITLE
Add new debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,19 @@
             "preLaunchTask": "npm: webpack"
         },
         {
+            "name": "Run Extension dev mode (without webpack)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm: compile"
+        },
+        {
             "name": "Launch Tests",
             "type": "extensionHost",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "activationEvents": [
         "onStartupFinished"
     ],
-    "main": "./dist/extension",
+    "main": "./dist/extension.js",
     "contributes": {
         "viewsWelcome": [
             {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es2018",
-        "outDir": "out",
+        "outDir": "dist",
         "lib": ["es2018"],
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
The new debug mode compiles the source code without using Webpack. By doing this, we can debug the actual source code rather than the Webpack-transformed source code.