### PR TITLE
Adding tests for FileTreeNode

### DIFF
--- a/src/main/treeDataProviders/issuesTree/fileTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/fileTreeNode.ts
@@ -39,7 +39,7 @@ export abstract class FileTreeNode extends vscode.TreeItem {
      */
     public apply() {
         // If no description is set, show the full path of the file or the relative path base on the path of the parent workspace if exists
-        if (this.description === undefined) {
+        // if (this.description === undefined) {
             let description: string | undefined = this._fullPath;
             if (this._parent && this._fullPath.startsWith(this._parent.workSpace.uri.fsPath)) {
                 let localPath: string = this._fullPath.substring(this._parent.workSpace.uri.fsPath.length + 1);
@@ -50,7 +50,7 @@ export abstract class FileTreeNode extends vscode.TreeItem {
                 }
             }
             this.description = description;
-        }
+        // }
 
         // Set collapsible state and severity base on children count
         let topSeverity: Severity = this.issues.length > 0 ? Severity.NotApplicableUnknown : Severity.Unknown;

--- a/src/main/treeDataProviders/issuesTree/fileTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/fileTreeNode.ts
@@ -39,18 +39,16 @@ export abstract class FileTreeNode extends vscode.TreeItem {
      */
     public apply() {
         // If no description is set, show the full path of the file or the relative path base on the path of the parent workspace if exists
-        // if (this.description === undefined) {
-            let description: string | undefined = this._fullPath;
-            if (this._parent && this._fullPath.startsWith(this._parent.workSpace.uri.fsPath)) {
-                let localPath: string = this._fullPath.substring(this._parent.workSpace.uri.fsPath.length + 1);
-                if (localPath !== this.name) {
-                    description = './' + localPath;
-                } else {
-                    description = undefined;
-                }
+        let description: string | undefined = this._fullPath;
+        if (this._parent && this._fullPath.startsWith(this._parent.workSpace.uri.fsPath)) {
+            let localPath: string = this._fullPath.substring(this._parent.workSpace.uri.fsPath.length + 1);
+            if (localPath !== this.name) {
+                description = './' + localPath;
+            } else {
+                description = undefined;
             }
-            this.description = description;
-        // }
+        }
+        this.description = description;
 
         // Set collapsible state and severity base on children count
         let topSeverity: Severity = this.issues.length > 0 ? Severity.NotApplicableUnknown : Severity.Unknown;

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { IssuesRootTreeNode } from '../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
+import { assert } from 'chai';
+import { FileTreeNode } from '../../main/treeDataProviders/issuesTree/fileTreeNode';
+import { Severity } from '../../main/types/severity';
+
+/**
+ * Test functionality of @class FileTreeNode.
+ */
+describe('File Node Tests', () => {
+    let testWorkspace: vscode.WorkspaceFolder = {
+        uri: vscode.Uri.file(path.join(__dirname, '..', 'resources')),
+        name: 'pom.xml-test',
+        index: 0
+    } as vscode.WorkspaceFolder;
+    let root: IssuesRootTreeNode;
+
+    let testCases: any[] = [
+        {
+            test: 'No issues',
+            data: { path: 'path', issues: [] },
+            expectedSeverity: Severity.Unknown,
+            expectedDescription: ""
+        },
+        {
+            test: 'One issue',
+            data: { path: 'path', issues: [Severity.Low] },
+            expectedSeverity: Severity.Low,
+            expectedDescription: ""
+        },
+        {
+            test: 'Multiple issues',
+            data: { path: 'path', issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.High] },
+            expectedSeverity: Severity.High,
+            expectedDescription: ""
+        }
+    ];
+    
+    beforeEach(() => {
+        root = new IssuesRootTreeNode(testWorkspace);
+    });
+
+    testCases.forEach(testCase => {
+        it('Top severity test - ' + testCase.test, () => {
+            //
+        });
+    });
+
+    testCases.forEach(testCase => {
+        it('Get issue by id test - ' + testCase.test, () => {
+            //
+        });
+    });
+
+    testCases.forEach(testCase => {
+        it('label test - ' + testCase.test, () => {
+            // include test on tooltip (full path)
+        });
+    });
+
+    testCases.forEach(testCase => {
+        it('Description test - ' + testCase.test, () => {
+            // include test on tooltip (full path)
+        });
+    });
+
+    testCases.forEach(testCase => {
+        it('Collapsible state test - ' + testCase.test, () => {
+            //
+        });
+    });
+
+    testCases.forEach(testCase => {
+        it('Tooltip test - ' + testCase.test, () => {
+            // issues count
+            // timestamp
+            // top severity
+        });
+    });
+
+    [
+        {
+            test: 'Failed node without reason',
+            data: FileTreeNode.createFailedScanNode('folder/path'),
+            expectedName: 'path - [Fail to scan]'
+        },
+        {
+            test: 'Failed node with reason',
+            data: FileTreeNode.createFailedScanNode('path', 'reason'),
+            expectedName: 'path - reason'
+        }
+    ].forEach(testCase => {
+        it(testCase.test, () => {
+            assert.exists(testCase.data);
+            assert.deepEqual(testCase.data.severity, Severity.Unknown);
+
+            assert.equal(testCase.data.name, testCase.expectedName);
+            root.addChild(testCase.data);
+            root.apply();
+            assert.equal(testCase.data.name, testCase.expectedName);
+        });
+    });
+
+});

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -16,18 +16,18 @@ describe('File Node Tests', () => {
     let testCases: any[] = [
         {
             test: 'No issues',
-            data: { path: path.join("root","folder","path"), issues: [] },
+            data: { path: path.join('root', 'folder', 'path'), issues: [] },
             expectedSeverity: Severity.Unknown
         } as FileNodeTestCase,
         {
             test: 'One issue',
-            data: { path: path.join("root","folder","path"), issues: [Severity.Medium] } as FileNodeTestData,
+            data: { path: path.join('root', 'folder', 'path'), issues: [Severity.Medium] } as FileNodeTestData,
             expectedSeverity: Severity.Medium
         } as FileNodeTestCase,
         {
             test: 'Multiple issues',
             data: {
-                path: path.join("root","folder","path"),
+                path: path.join('root', 'folder', 'path'),
                 issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.NotApplicableHigh, Severity.High]
             } as FileNodeTestData,
             expectedSeverity: Severity.High
@@ -46,7 +46,7 @@ describe('File Node Tests', () => {
         it('Get issue by id test', () => {
             let testNode: FileTreeNode = createAndPopulateTestNode(testCase);
             let toSearchIssue: IssueTreeNode = createDummyIssue(Severity.Unknown);
-            // Search non existed
+            // Search issue not exist as child
             assert.notExists(testNode.getIssueById(toSearchIssue.issueId));
             // Add and search
             testNode.issues.push(toSearchIssue);
@@ -73,13 +73,13 @@ describe('File Node Tests', () => {
             testNode.apply();
             assert.equal(testNode.description, testNode.fullPath);
             // Parent in path, parent is root
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join("root","folder") } as vscode.Uri } as vscode.WorkspaceFolder);
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join('root', 'folder') } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
             assert.equal(testNode.description, undefined);
             // Parent in path and parent is not root
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join("root") } as vscode.Uri } as vscode.WorkspaceFolder);
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join('root') } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description, './' + path.join("folder", "path"));
+            assert.equal(testNode.description, './' + path.join('folder', 'path'));
         });
     });
 
@@ -119,7 +119,7 @@ describe('File Node Tests', () => {
     [
         {
             test: 'Failed node without reason',
-            data: FileTreeNode.createFailedScanNode(path.join("folder","path")),
+            data: FileTreeNode.createFailedScanNode(path.join('folder', 'path')),
             expectedName: 'path - [Fail to scan]'
         },
         {

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -4,6 +4,7 @@ import { FileTreeNode } from '../../main/treeDataProviders/issuesTree/fileTreeNo
 import { IssuesRootTreeNode } from '../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
 import { Severity, SeverityUtils } from '../../main/types/severity';
 import { createTestNode, FileNodeTestCase, FileNodeTestData } from './utils/treeNodeUtils.test';
+import { Utils } from '../../main/treeDataProviders/utils/utils';
 
 /**
  * Test functionality of @class FileTreeNode.
@@ -12,20 +13,20 @@ describe('File Node Tests', () => {
     let testCases: any[] = [
         {
             test: 'No issues',
-            data: { path: 'folder/path', issues: [] },
+            data: { path: '/root/folder/path', issues: [] },
             expectedSeverity: Severity.Unknown,
             expectedDescription: ''
         } as FileNodeTestCase,
         {
             test: 'One issue',
-            data: { path: 'folder/path', issues: [Severity.Medium] } as FileNodeTestData,
+            data: { path: '/root/folder/path', issues: [Severity.Medium] } as FileNodeTestData,
             expectedSeverity: Severity.Medium,
             expectedDescription: ''
         } as FileNodeTestCase,
         {
             test: 'Multiple issues',
             data: {
-                path: 'folder/path',
+                path: '/root/folder/path',
                 issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.NotApplicableHigh, Severity.High]
             } as FileNodeTestData,
             expectedSeverity: Severity.High,
@@ -48,24 +49,30 @@ describe('File Node Tests', () => {
     });
 
     testCases.forEach(testCase => {
-        it('label test - ' + testCase.test, () => {
-            //
+        it('label/name test - ' + testCase.test, () => {
+            let testNode: FileTreeNode = createTestNode(testCase);
+            assert.equal(testNode.name, Utils.getLastSegment(testCase.data.path));
+            assert.equal(testNode.label, Utils.getLastSegment(testCase.data.path));
         });
     });
 
     testCases.forEach(testCase => {
         it('Description test - ' + testCase.test, () => {
             let testNode: FileTreeNode = createTestNode(testCase);
-            // Before parent
+            // No parent
             assert.equal(testNode.description,testNode.fullPath);
-            // Parent not in path
-            testNode.parent = new IssuesRootTreeNode({} as vscode.WorkspaceFolder);
+            // Local path not in parent path
+            testNode.parent = new IssuesRootTreeNode({uri: { fsPath: "nowhere"} as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
             assert.equal(testNode.description,testNode.fullPath);
-            // Parent in path
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: "folder" } as vscode.Uri } as vscode.WorkspaceFolder);
+            // file in root
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: "/root/folder"} as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description,"./path");
+            assert.equal(testNode.description,undefined);
+            // Parent in path and file not in root
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: "/root"} as vscode.Uri } as vscode.WorkspaceFolder);
+            testNode.apply();
+            assert.equal(testNode.description,"./folder/path");
         });
     });
 
@@ -77,9 +84,16 @@ describe('File Node Tests', () => {
 
     testCases.forEach(testCase => {
         it('Tooltip test - ' + testCase.test, () => {
-            // issues count
-            // timestamp
-            // top severity
+            let testNode: FileTreeNode = createTestNode(testCase);
+            assert.equal(testNode.fullPath,testCase.data.path);
+            assert.include(testNode.tooltip, "Full path: " + testNode.fullPath);
+            assert.equal(testNode.issues.length,testCase.data.issues.length);
+            assert.include(testNode.tooltip, "Issues count: " + testNode.issues.length);
+            // timestamp - not set
+            assert.notInclude(testNode.tooltip, "Last scan completed at");
+            testNode.timeStamp = Date.now();
+            testNode.apply();
+            assert.include(testNode.tooltip, "Last scan completed at");
         });
     });
 
@@ -91,8 +105,8 @@ describe('File Node Tests', () => {
         },
         {
             test: 'Failed node with reason',
-            data: FileTreeNode.createFailedScanNode('path', 'reason'),
-            expectedName: 'path - reason'
+            data: FileTreeNode.createFailedScanNode('path', '[reason]'),
+            expectedName: 'path - [reason]'
         }
     ].forEach(testCase => {
         it(testCase.test, () => {

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -1,49 +1,40 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { IssuesRootTreeNode } from '../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
 import { assert } from 'chai';
 import { FileTreeNode } from '../../main/treeDataProviders/issuesTree/fileTreeNode';
 import { Severity } from '../../main/types/severity';
+import { createTestNode, FileNodeTestCase, FileNodeTestData } from './utils/treeNodeUtils.test';
 
 /**
  * Test functionality of @class FileTreeNode.
  */
 describe('File Node Tests', () => {
-    let testWorkspace: vscode.WorkspaceFolder = {
-        uri: vscode.Uri.file(path.join(__dirname, '..', 'resources')),
-        name: 'pom.xml-test',
-        index: 0
-    } as vscode.WorkspaceFolder;
-    let root: IssuesRootTreeNode;
-
-    let testCases: any[] = [
+    let testCases: FileNodeTestCase[] = [
         {
             test: 'No issues',
             data: { path: 'path', issues: [] },
             expectedSeverity: Severity.Unknown,
-            expectedDescription: ""
-        },
+            expectedDescription: ''
+        } as FileNodeTestCase,
         {
             test: 'One issue',
-            data: { path: 'path', issues: [Severity.Low] },
+            data: { path: 'path', issues: [Severity.Medium] } as FileNodeTestData,
             expectedSeverity: Severity.Low,
-            expectedDescription: ""
-        },
+            expectedDescription: ''
+        } as FileNodeTestCase,
         {
             test: 'Multiple issues',
-            data: { path: 'path', issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.High] },
+            data: {
+                path: 'path',
+                issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.High]
+            } as FileNodeTestData,
             expectedSeverity: Severity.High,
-            expectedDescription: ""
-        }
+            expectedDescription: ''
+        } as FileNodeTestCase
     ];
-    
-    beforeEach(() => {
-        root = new IssuesRootTreeNode(testWorkspace);
-    });
 
     testCases.forEach(testCase => {
         it('Top severity test - ' + testCase.test, () => {
-            //
+            let testNode: FileTreeNode = createTestNode(testCase);
+            assert.deepEqual(testNode.severity, testCase.expectedSeverity);
         });
     });
 
@@ -55,13 +46,13 @@ describe('File Node Tests', () => {
 
     testCases.forEach(testCase => {
         it('label test - ' + testCase.test, () => {
-            // include test on tooltip (full path)
+            //
         });
     });
 
     testCases.forEach(testCase => {
         it('Description test - ' + testCase.test, () => {
-            // include test on tooltip (full path)
+            //
         });
     });
 
@@ -92,14 +83,13 @@ describe('File Node Tests', () => {
         }
     ].forEach(testCase => {
         it(testCase.test, () => {
+            // Before apply
             assert.exists(testCase.data);
             assert.deepEqual(testCase.data.severity, Severity.Unknown);
-
             assert.equal(testCase.data.name, testCase.expectedName);
-            root.addChild(testCase.data);
-            root.apply();
+            // After apply
+            testCase.data.apply();
             assert.equal(testCase.data.name, testCase.expectedName);
         });
     });
-
 });

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -17,7 +17,7 @@ describe('File Node Tests', () => {
         {
             test: 'One issue',
             data: { path: 'path', issues: [Severity.Medium] } as FileNodeTestData,
-            expectedSeverity: Severity.Low,
+            expectedSeverity: Severity.Medium,
             expectedDescription: ''
         } as FileNodeTestCase,
         {

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -119,7 +119,7 @@ describe('File Node Tests', () => {
     [
         {
             test: 'Failed node without reason',
-            data: FileTreeNode.createFailedScanNode('folder/path'),
+            data: FileTreeNode.createFailedScanNode(path.join("folder","path")),
             expectedName: 'path - [Fail to scan]'
         },
         {

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -3,8 +3,9 @@ import { assert } from 'chai';
 import { FileTreeNode } from '../../main/treeDataProviders/issuesTree/fileTreeNode';
 import { IssuesRootTreeNode } from '../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
 import { Severity, SeverityUtils } from '../../main/types/severity';
-import { createTestNode, FileNodeTestCase, FileNodeTestData } from './utils/treeNodeUtils.test';
+import { createAndPopulateTestNode, createDummyIssue, createTestNode, FileNodeTestCase, FileNodeTestData } from './utils/treeNodeUtils.test';
 import { Utils } from '../../main/treeDataProviders/utils/utils';
+import { IssueTreeNode } from '../../main/treeDataProviders/issuesTree/issueTreeNode';
 
 /**
  * Test functionality of @class FileTreeNode.
@@ -14,14 +15,12 @@ describe('File Node Tests', () => {
         {
             test: 'No issues',
             data: { path: '/root/folder/path', issues: [] },
-            expectedSeverity: Severity.Unknown,
-            expectedDescription: ''
+            expectedSeverity: Severity.Unknown
         } as FileNodeTestCase,
         {
             test: 'One issue',
             data: { path: '/root/folder/path', issues: [Severity.Medium] } as FileNodeTestData,
-            expectedSeverity: Severity.Medium,
-            expectedDescription: ''
+            expectedSeverity: Severity.Medium
         } as FileNodeTestCase,
         {
             test: 'Multiple issues',
@@ -29,28 +28,34 @@ describe('File Node Tests', () => {
                 path: '/root/folder/path',
                 issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.NotApplicableHigh, Severity.High]
             } as FileNodeTestData,
-            expectedSeverity: Severity.High,
-            expectedDescription: ''
+            expectedSeverity: Severity.High
         } as FileNodeTestCase
     ];
 
     testCases.forEach(testCase => {
         it('Top severity test - ' + testCase.test, () => {
-            let testNode: FileTreeNode = createTestNode(testCase);
+            let testNode: FileTreeNode = createAndPopulateTestNode(testCase);
             assert.deepEqual(testNode.severity, testCase.expectedSeverity);
-            assert.include(testNode.tooltip, "Top severity: " + SeverityUtils.getString(testCase.expectedSeverity));
+            assert.include(testNode.tooltip, 'Top severity: ' + SeverityUtils.getString(testCase.expectedSeverity));
         });
     });
 
     testCases.forEach(testCase => {
-        it('Get issue by id test - ' + testCase.test, () => {
-            //
+        it('Get issue by id test', () => {
+            let testNode: FileTreeNode = createAndPopulateTestNode(testCase);
+            let toSearchIssue: IssueTreeNode = createDummyIssue(Severity.Unknown);
+            // Search non existed
+            assert.notExists(testNode.getIssueById(toSearchIssue.issueId));
+            // Add and search
+            testNode.issues.push(toSearchIssue);
+            testNode.apply();
+            assert.deepEqual(testNode.getIssueById(toSearchIssue.issueId), toSearchIssue);
         });
     });
 
     testCases.forEach(testCase => {
         it('label/name test - ' + testCase.test, () => {
-            let testNode: FileTreeNode = createTestNode(testCase);
+            let testNode: FileTreeNode = createAndPopulateTestNode(testCase);
             assert.equal(testNode.name, Utils.getLastSegment(testCase.data.path));
             assert.equal(testNode.label, Utils.getLastSegment(testCase.data.path));
         });
@@ -58,42 +63,54 @@ describe('File Node Tests', () => {
 
     testCases.forEach(testCase => {
         it('Description test - ' + testCase.test, () => {
-            let testNode: FileTreeNode = createTestNode(testCase);
+            let testNode: FileTreeNode = createAndPopulateTestNode(testCase);
             // No parent
-            assert.equal(testNode.description,testNode.fullPath);
+            assert.equal(testNode.description, testNode.fullPath);
             // Local path not in parent path
-            testNode.parent = new IssuesRootTreeNode({uri: { fsPath: "nowhere"} as vscode.Uri } as vscode.WorkspaceFolder);
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: 'nowhere' } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description,testNode.fullPath);
-            // file in root
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: "/root/folder"} as vscode.Uri } as vscode.WorkspaceFolder);
+            assert.equal(testNode.description, testNode.fullPath);
+            // Parent in path, parent is root
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: '/root/folder' } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description,undefined);
-            // Parent in path and file not in root
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: "/root"} as vscode.Uri } as vscode.WorkspaceFolder);
+            assert.equal(testNode.description, undefined);
+            // Parent in path and parent is not root
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: '/root' } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description,"./folder/path");
+            assert.equal(testNode.description, './folder/path');
         });
     });
 
-    testCases.forEach(testCase => {
-        it('Collapsible state test - ' + testCase.test, () => {
-            //
-        });
+    it('Collapsible state test', () => {
+        let testNode: FileTreeNode = createTestNode('path');
+        // No issues, no parent
+        testNode.apply();
+        assert.deepEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.None);
+        // One issue, no parent
+        testNode.issues.push(createDummyIssue(Severity.Critical));
+        testNode.apply();
+        assert.deepEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
+        // One issue, with parent
+        new IssuesRootTreeNode({ uri: { fsPath: 'nowhere' } as vscode.Uri } as vscode.WorkspaceFolder).addChildAndApply(testNode);
+        assert.deepEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.Expanded);
+        // Multiple issues, with parent
+        testNode.issues.push(createDummyIssue(Severity.NotApplicableCritical));
+        testNode.apply();
+        assert.deepEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
     });
 
     testCases.forEach(testCase => {
         it('Tooltip test - ' + testCase.test, () => {
-            let testNode: FileTreeNode = createTestNode(testCase);
-            assert.equal(testNode.fullPath,testCase.data.path);
-            assert.include(testNode.tooltip, "Full path: " + testNode.fullPath);
-            assert.equal(testNode.issues.length,testCase.data.issues.length);
-            assert.include(testNode.tooltip, "Issues count: " + testNode.issues.length);
+            let testNode: FileTreeNode = createAndPopulateTestNode(testCase);
+            assert.equal(testNode.fullPath, testCase.data.path);
+            assert.include(testNode.tooltip, 'Full path: ' + testNode.fullPath);
+            assert.equal(testNode.issues.length, testCase.data.issues.length);
+            assert.include(testNode.tooltip, 'Issues count: ' + testNode.issues.length);
             // timestamp - not set
-            assert.notInclude(testNode.tooltip, "Last scan completed at");
+            assert.notInclude(testNode.tooltip, 'Last scan completed at');
             testNode.timeStamp = Date.now();
             testNode.apply();
-            assert.include(testNode.tooltip, "Last scan completed at");
+            assert.include(testNode.tooltip, 'Last scan completed at');
         });
     });
 

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+
 import { assert } from 'chai';
 import { FileTreeNode } from '../../main/treeDataProviders/issuesTree/fileTreeNode';
 import { IssuesRootTreeNode } from '../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
@@ -14,18 +16,18 @@ describe('File Node Tests', () => {
     let testCases: any[] = [
         {
             test: 'No issues',
-            data: { path: '/root/folder/path', issues: [] },
+            data: { path: path.join("root","folder","path"), issues: [] },
             expectedSeverity: Severity.Unknown
         } as FileNodeTestCase,
         {
             test: 'One issue',
-            data: { path: '/root/folder/path', issues: [Severity.Medium] } as FileNodeTestData,
+            data: { path: path.join("root","folder","path"), issues: [Severity.Medium] } as FileNodeTestData,
             expectedSeverity: Severity.Medium
         } as FileNodeTestCase,
         {
             test: 'Multiple issues',
             data: {
-                path: '/root/folder/path',
+                path: path.join("root","folder","path"),
                 issues: [Severity.Low, Severity.Low, Severity.NotApplicableCritical, Severity.NotApplicableHigh, Severity.High]
             } as FileNodeTestData,
             expectedSeverity: Severity.High
@@ -71,13 +73,13 @@ describe('File Node Tests', () => {
             testNode.apply();
             assert.equal(testNode.description, testNode.fullPath);
             // Parent in path, parent is root
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: '/root/folder' } as vscode.Uri } as vscode.WorkspaceFolder);
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join("root","folder") } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
             assert.equal(testNode.description, undefined);
             // Parent in path and parent is not root
-            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: '/root' } as vscode.Uri } as vscode.WorkspaceFolder);
+            testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join("root") } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description, './folder/path');
+            assert.equal(testNode.description, './' + path.join("folder", "path"));
         });
     });
 

--- a/src/test/tests/utils/treeNodeUtils.test.ts
+++ b/src/test/tests/utils/treeNodeUtils.test.ts
@@ -6,8 +6,6 @@ import { Severity } from '../../../main/types/severity';
 export interface FileNodeTestCase {
     test: string;
     data: FileNodeTestData;
-    // expectedSeverity: Severity;
-    // expectedDescription: string;
 }
 
 export interface FileNodeTestData {
@@ -20,7 +18,7 @@ export interface FileNodeTestData {
  * @param testCase - the test we want to prepare
  * @returns node prepared base on test case
  */
-export function createTestNode(testCase: FileNodeTestCase): FileTreeNode {
+export function createTestNode(pathOfFile: string): FileTreeNode {
     let fileNode: FileTreeNode = new (class extends FileTreeNode {
         _issues: IssueTreeNode[] = [];
         constructor(fullPath: string, parent?: IssuesRootTreeNode, timeStamp?: number) {
@@ -30,9 +28,21 @@ export function createTestNode(testCase: FileNodeTestCase): FileTreeNode {
         public get issues(): IssueTreeNode[] {
             return this._issues;
         }
-    })(testCase.data.path);
-    testCase.data.issues.forEach(issue => fileNode.issues.push(createDummyIssue(issue)));
-    // After changes apply must be called
+    })(pathOfFile);
+    return fileNode;
+}
+
+/**
+ * Create file node and populate it with issues base on test case
+ * @param testCase - the test we want to prepare
+ * @returns node prepared base on test case
+ */
+export function createAndPopulateTestNode(testCase: FileNodeTestCase): FileTreeNode {
+    let fileNode: FileTreeNode = createTestNode(testCase.data.path);
+    testCase.data.issues.forEach(issueSeverity => {
+        let issue: IssueTreeNode = createDummyIssue(issueSeverity);
+        fileNode.issues.push(issue);
+    });
     fileNode.apply();
     return fileNode;
 }

--- a/src/test/tests/utils/treeNodeUtils.test.ts
+++ b/src/test/tests/utils/treeNodeUtils.test.ts
@@ -1,0 +1,49 @@
+import { FileTreeNode } from '../../../main/treeDataProviders/issuesTree/fileTreeNode';
+import { IssuesRootTreeNode } from '../../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
+import { IssueTreeNode } from '../../../main/treeDataProviders/issuesTree/issueTreeNode';
+import { Severity } from '../../../main/types/severity';
+
+export interface FileNodeTestCase {
+    test: string;
+    data: FileNodeTestData;
+    expectedSeverity: Severity;
+    expectedDescription: string;
+}
+
+export interface FileNodeTestData {
+    path: string;
+    issues: Severity[];
+}
+
+/**
+ * Create file node base on test case
+ * @param testCase - the test we want to prepare
+ * @returns node prepared base on test case
+ */
+export function createTestNode(testCase: FileNodeTestCase): FileTreeNode {
+    let fileNode: FileTreeNode = new (class extends FileTreeNode {
+        _issues: IssueTreeNode[] = [];
+        constructor(fullPath: string, parent?: IssuesRootTreeNode, timeStamp?: number) {
+            super(fullPath, parent, timeStamp);
+        }
+        /** @override */
+        public get issues(): IssueTreeNode[] {
+            return this._issues;
+        }
+    })(testCase.data.path);
+    testCase.data.issues.forEach(issue => fileNode.issues.push(createDummyIssue(issue)));
+    // After changes apply must be called
+    fileNode.apply();
+    return fileNode;
+}
+
+let issueCounter: number = 0;
+/**
+ * Create dummy issue node with given severity
+ * @param severity - severity that the dummy node will have
+ * @returns - dummy issue node
+ */
+export function createDummyIssue(severity: Severity): IssueTreeNode {
+    let issueID: string = '' + issueCounter++;
+    return new IssueTreeNode(issueID, severity, issueID);
+}

--- a/src/test/tests/utils/treeNodeUtils.test.ts
+++ b/src/test/tests/utils/treeNodeUtils.test.ts
@@ -6,8 +6,8 @@ import { Severity } from '../../../main/types/severity';
 export interface FileNodeTestCase {
     test: string;
     data: FileNodeTestData;
-    expectedSeverity: Severity;
-    expectedDescription: string;
+    // expectedSeverity: Severity;
+    // expectedDescription: string;
 }
 
 export interface FileNodeTestData {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
