### PR TITLE
Add running Eos scan if no descriptor exists

### DIFF
--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -37,6 +37,18 @@ export class ScanUtils {
         );
     }
 
+    public static getUniqueDirectories(filePaths: vscode.Uri[]): string[] {
+        let roots: string[] = [];
+        for (const filePath of filePaths) {
+            let directory: string = path.dirname(filePath.fsPath);
+            if (!roots.includes(directory)) {
+                roots.push(directory);
+            }
+        }
+
+        return roots;
+    }
+
     /**
      * Find go.mod, pom.xml, package.json, *.sln, setup.py, and requirements*.txt files in workspaces.
      * @param workspaceFolders - Base workspace folders to search


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
