### PR TITLE
Restructuring code

### DIFF
--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -230,18 +230,11 @@ export class CommandManager implements ExtensionComponent {
     }
 
     private async askYesNo(message: string): Promise<boolean> {
-        const answer: string | undefined = await vscode.window.showInformationMessage(message, 'Yes', 'No');
-        if (answer === 'Yes') {
-            return true;
-        }
-        return false;
+        return (await vscode.window.showInformationMessage(message, 'Yes', 'No')) === 'Yes';
     }
+    
     private async askRescan(message: string): Promise<boolean> {
-        const answer: string | undefined = await vscode.window.showInformationMessage(message, 'Rescan project');
-        if (answer === 'Rescan project') {
-            return true;
-        }
-        return false;
+        return (await vscode.window.showInformationMessage(message, 'Rescan project')) === 'Rescan project';
     }
 
     private async showConnectionStatus() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Left over from https://github.com/jfrog/jfrog-vscode-extension/pull/262