### PR TITLE
Nuget improvements

### DIFF
--- a/src/main/dependencyUpdate/dependencyUpdateManager.ts
+++ b/src/main/dependencyUpdate/dependencyUpdateManager.ts
@@ -32,7 +32,7 @@ export class DependencyUpdateManager implements ExtensionComponent {
         const manager: AbstractDependencyUpdate | undefined = this.getUpdateManager(dependency);
         try {
             if (manager) {
-                await manager.update(dependency, version);
+                manager.update(dependency, version);
                 return true;
             }
         } catch (error) {

--- a/src/main/dependencyUpdate/dependencyUpdateManager.ts
+++ b/src/main/dependencyUpdate/dependencyUpdateManager.ts
@@ -6,6 +6,7 @@ import { NpmDependencyUpdate } from './npmDependencyUpdate';
 import { DependencyIssuesTreeNode } from '../treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode';
 import { LogManager } from '../log/logManager';
 import { YarnDependencyUpdate } from './yarnDependencyUpdate';
+import { NugetDependencyUpdate } from './nugetDependencyUpdate';
 
 /**
  * Update the dependency version in the project descriptor (e.g. pom.xml) file after right click on the components tree and a left click on "Update dependency to fixed version".
@@ -14,7 +15,13 @@ export class DependencyUpdateManager implements ExtensionComponent {
     private _dependencyUpdaters: AbstractDependencyUpdate[] = [];
 
     constructor(private _logManager: LogManager) {
-        this._dependencyUpdaters.push(new MavenDependencyUpdate(), new NpmDependencyUpdate(), new YarnDependencyUpdate(), new GoDependencyUpdate());
+        this._dependencyUpdaters.push(
+            new MavenDependencyUpdate(),
+            new NpmDependencyUpdate(),
+            new YarnDependencyUpdate(),
+            new GoDependencyUpdate(),
+            new NugetDependencyUpdate()
+        );
     }
 
     public activate() {
@@ -25,7 +32,7 @@ export class DependencyUpdateManager implements ExtensionComponent {
         const manager: AbstractDependencyUpdate | undefined = this.getUpdateManager(dependency);
         try {
             if (manager) {
-                manager.update(dependency, version);
+                await manager.update(dependency, version);
                 return true;
             }
         } catch (error) {

--- a/src/main/dependencyUpdate/goDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/goDependencyUpdate.ts
@@ -15,7 +15,7 @@ export class GoDependencyUpdate extends AbstractDependencyUpdate {
 
     /** @override */
     public update(dependency: DependencyIssuesTreeNode, version: string): void {
-        const workspace: string = dependency.getSourcePath();
+        const workspace: string = dependency.getProjectPath();
         ScanUtils.executeCmd('go get ' + dependency.name + '@v' + version, workspace);
     }
 }

--- a/src/main/dependencyUpdate/mavenDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/mavenDependencyUpdate.ts
@@ -16,7 +16,7 @@ export class MavenDependencyUpdate extends AbstractDependencyUpdate {
 
     /** @override */
     public update(dependency: DependencyIssuesTreeNode, version: string): void {
-        const workspace: string = dependency.getSourcePath();
+        const workspace: string = dependency.getProjectPath();
         const [groupId, artifactId] = MavenUtils.getGavArray(dependency);
         ScanUtils.executeCmd(
             'mvn versions:use-dep-version -DgenerateBackupPoms=false -Dincludes=' + groupId + ':' + artifactId + ' -DdepVersion=' + version,

--- a/src/main/dependencyUpdate/npmDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/npmDependencyUpdate.ts
@@ -15,7 +15,7 @@ export class NpmDependencyUpdate extends AbstractDependencyUpdate {
 
     /** @override */
     public update(dependency: DependencyIssuesTreeNode, version: string): void {
-        const workspace: string = dependency.getSourcePath();
+        const workspace: string = dependency.getProjectPath();
         ScanUtils.executeCmd('npm install ' + dependency.name + '@' + version, workspace);
     }
 }

--- a/src/main/dependencyUpdate/nugetDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/nugetDependencyUpdate.ts
@@ -16,7 +16,7 @@ export class NugetDependencyUpdate extends AbstractDependencyUpdate {
 
     /** @override */
     public update(dependency: DependencyIssuesTreeNode, version: string): void {
-        const workspace: string = dependency.getWorkspace();
+        const workspace: string = dependency.getProjectPath();
         let descriptorFile: string = dependency.parent.fullPath;
         if (descriptorFile.endsWith(NugetUtils.PROJECT_SUFFIX)) {
             ScanUtils.executeCmd('dotnet add package ' + dependency.name + ' --version ' + version, workspace);

--- a/src/main/dependencyUpdate/nugetDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/nugetDependencyUpdate.ts
@@ -1,0 +1,27 @@
+import { DependencyIssuesTreeNode } from '../treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode';
+import { PackageType } from '../types/projectType';
+import { NugetUtils } from '../utils/nugetUtils';
+import { ScanUtils } from '../utils/scanUtils';
+import { AbstractDependencyUpdate } from './abstractDependencyUpdate';
+
+export class NugetDependencyUpdate extends AbstractDependencyUpdate {
+    constructor() {
+        super(PackageType.Nuget);
+    }
+
+    /** @override */
+    public isMatched(dependency: DependencyIssuesTreeNode): boolean {
+        return super.isMatched(dependency);
+    }
+
+    /** @override */
+    public async update(dependency: DependencyIssuesTreeNode, version: string): Promise<void> {
+        const workspace: string = dependency.getWorkspace();
+        let descriptorFile: string = dependency.parent.fullPath;
+        if (descriptorFile.endsWith(NugetUtils.PROJECT_SUFFIX)) {
+            ScanUtils.executeCmd('dotnet add package ' + dependency.name + ' --version ' + version, workspace);
+        } else {
+            ScanUtils.executeCmd('nuget update ' + dependency.parent.fullPath + ' -Id ' + dependency.name + ' -Version ' + version, workspace);
+        }
+    }
+}

--- a/src/main/dependencyUpdate/nugetDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/nugetDependencyUpdate.ts
@@ -15,7 +15,7 @@ export class NugetDependencyUpdate extends AbstractDependencyUpdate {
     }
 
     /** @override */
-    public async update(dependency: DependencyIssuesTreeNode, version: string): Promise<void> {
+    public update(dependency: DependencyIssuesTreeNode, version: string): void {
         const workspace: string = dependency.getWorkspace();
         let descriptorFile: string = dependency.parent.fullPath;
         if (descriptorFile.endsWith(NugetUtils.PROJECT_SUFFIX)) {

--- a/src/main/dependencyUpdate/yarnDependencyUpdate.ts
+++ b/src/main/dependencyUpdate/yarnDependencyUpdate.ts
@@ -15,7 +15,7 @@ export class YarnDependencyUpdate extends AbstractDependencyUpdate {
 
     /** @override */
     public update(dependenciesTreeNode: DependencyIssuesTreeNode, version: string): void {
-        const workspace: string = dependenciesTreeNode.getSourcePath();
+        const workspace: string = dependenciesTreeNode.getProjectPath();
         ScanUtils.executeCmd('yarn upgrade ' + dependenciesTreeNode.name + '@' + version, workspace);
     }
 }

--- a/src/main/diagnostics/descriptorActionProvider.ts
+++ b/src/main/diagnostics/descriptorActionProvider.ts
@@ -35,7 +35,7 @@ interface DirectDependencyIssue {
 export class DescriptorActionProvider extends AbstractFileActionProvider implements vscode.CodeActionProvider {
     public static readonly DESCRIPTOR_SELECTOR: vscode.DocumentSelector = {
         scheme: 'file',
-        pattern: '**/{go.mod,package.json,pom.xml,*requirements*.txt,yarn.lock}'
+        pattern: '**/{go.mod,package.json,pom.xml,*requirements*.txt,yarn.lock,*.csproj,packages.config}'
     };
 
     private _processedMap: Map<vscode.Uri, Map<string, DirectDependencyInfo>> = new Map<vscode.Uri, Map<string, DirectDependencyInfo>>();

--- a/src/main/diagnostics/descriptorActionProvider.ts
+++ b/src/main/diagnostics/descriptorActionProvider.ts
@@ -8,6 +8,7 @@ import { TreesManager } from '../treeDataProviders/treesManager';
 import { DependencyUtils } from '../treeDataProviders/utils/dependencyUtils';
 import { PackageType } from '../types/projectType';
 import { Severity, SeverityUtils } from '../types/severity';
+import { ScanUtils } from '../utils/scanUtils';
 import { AbstractFileActionProvider } from './abstractFileActionProvider';
 
 /**
@@ -35,7 +36,7 @@ interface DirectDependencyIssue {
 export class DescriptorActionProvider extends AbstractFileActionProvider implements vscode.CodeActionProvider {
     public static readonly DESCRIPTOR_SELECTOR: vscode.DocumentSelector = {
         scheme: 'file',
-        pattern: '**/{go.mod,package.json,pom.xml,*requirements*.txt,yarn.lock,*.csproj,packages.config}'
+        pattern: ScanUtils.DESCRIPTOR_SELECTOR_PATTERN
     };
 
     private _processedMap: Map<vscode.Uri, Map<string, DirectDependencyInfo>> = new Map<vscode.Uri, Map<string, DirectDependencyInfo>>();

--- a/src/main/scanLogic/scanGraphLogic.ts
+++ b/src/main/scanLogic/scanGraphLogic.ts
@@ -26,7 +26,7 @@ export class GraphScanLogic {
             component_id: graphRoot.generalInfo.artifactId,
             nodes: this.getFlattenRequestModelNodes(graphRoot, new Set<string>())
         } as IGraphRequestModel;
-        if (!graphRequest.nodes || graphRequest.nodes.length ===0) {
+        if (!graphRequest.nodes || graphRequest.nodes.length === 0) {
             // No dependencies to scan
             return {} as IGraphResponse;
         }

--- a/src/main/scanLogic/scanGraphLogic.ts
+++ b/src/main/scanLogic/scanGraphLogic.ts
@@ -26,7 +26,10 @@ export class GraphScanLogic {
             component_id: graphRoot.generalInfo.artifactId,
             nodes: this.getFlattenRequestModelNodes(graphRoot, new Set<string>())
         } as IGraphRequestModel;
-
+        if (!graphRequest.nodes || graphRequest.nodes.length ===0) {
+            // No dependencies to scan
+            return {} as IGraphResponse;
+        }
         return this._connectionManager.scanWithGraph(
             graphRequest,
             progress,

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
@@ -9,8 +9,8 @@ import { SemVer } from 'semver';
 
 export class GoTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'go://';
-    constructor(tmpWorkspaceFolder: string, private _treesManager: TreesManager, parent?: DependenciesTreeNode) {
-        super(tmpWorkspaceFolder, PackageType.Go, parent);
+    constructor(tmpFullPath: string, private _treesManager: TreesManager, parent?: DependenciesTreeNode) {
+        super(tmpFullPath, PackageType.Go, parent);
     }
 
     public refreshDependencies(goVersion: SemVer) {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
@@ -11,9 +11,9 @@ import { ProjectDetails } from '../../../types/projectDetails';
 export class MavenTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'gav://';
 
-    constructor(workspaceFolder: string, private _treesManager: TreesManager, parent?: DependenciesTreeNode) {
-        super(workspaceFolder, PackageType.Maven, parent);
-        MavenUtils.pathToNode.set(workspaceFolder, this);
+    constructor(fullPath: string, private _treesManager: TreesManager, parent?: DependenciesTreeNode) {
+        super(fullPath, PackageType.Maven, parent);
+        MavenUtils.pathToNode.set(fullPath, this);
     }
 
     /**

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -11,8 +11,8 @@ import { Severity } from '../../../types/severity';
 export class NpmTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'npm://';
 
-    constructor(workspaceFolder: string, private _treesManager: TreesManager, parent?: DependenciesTreeNode) {
-        super(workspaceFolder, PackageType.Npm, parent);
+    constructor(fullPath: string, private _treesManager: TreesManager, parent?: DependenciesTreeNode) {
+        super(fullPath, PackageType.Npm, parent);
     }
 
     public async refreshDependencies() {
@@ -24,7 +24,7 @@ export class NpmTreeNode extends RootNode {
                 scopedProject.loadProjectDetails(NpmUtils.runNpmLs(scopedProject.scope, this.workspaceFolder));
             } catch (error) {
                 this._treesManager.logManager.logError(<any>error, false);
-                scopedProject.loadProjectDetailsFromFile(path.join(this.workspaceFolder, 'package.json'));
+                scopedProject.loadProjectDetailsFromFile(path.join(this.fullPath));
                 npmLsFailed = true;
             }
             this.populateDependenciesTree(this, scopedProject.dependencies, scopedProject.scope);
@@ -39,13 +39,13 @@ export class NpmTreeNode extends RootNode {
             npmLsFailed ? (productionScope.projectName += ' [Not installed]') : productionScope.projectName,
             productionScope.projectVersion,
             [],
-            this.workspaceFolder,
+            this.fullPath,
             PackageType.Npm
         );
         if (npmLsFailed) {
             this.topSeverity = Severity.Unknown;
         }
-        this.projectDetails.name = productionScope.projectName ? productionScope.projectName : path.join(this.workspaceFolder, 'package.json');
+        this.projectDetails.name = productionScope.projectName ? productionScope.projectName : this.fullPath;
         this.label = this.projectDetails.name;
     }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -7,8 +7,8 @@ import { PackageType } from '../../../types/projectType';
 export class NugetTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'nuget://';
 
-    constructor(workspaceFolder: string, parent?: DependenciesTreeNode) {
-        super(workspaceFolder, PackageType.Nuget, parent, '');
+    constructor(fullPath: string, parent?: DependenciesTreeNode) {
+        super(fullPath, PackageType.Nuget, parent, '');
     }
 
     public setName(name: string) {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -11,10 +11,14 @@ export class NugetTreeNode extends RootNode {
         super(workspaceFolder, PackageType.Nuget, parent, '');
     }
 
+    public setName(name: string) {
+        this.generalInfo = new GeneralInfo(name, '', ['None'], this.workspaceFolder, PackageType.Nuget);
+        this.label = name;
+        this.projectDetails.name = name;
+    }
+
     public refreshDependencies(project: any) {
-        this.generalInfo = new GeneralInfo(project.name, '', ['None'], this.workspaceFolder, PackageType.Nuget);
-        this.label = project.name;
-        this.projectDetails.name = project.name;
+        this.setName(project.name);
         this.populateDependenciesTree(this, project.dependencies);
     }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
@@ -13,9 +13,9 @@ import { PipDepTree } from '../../../types/pipDepTree';
 export class PypiTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'pypi://';
 
-    constructor(workspaceFolder: string, parent?: DependenciesTreeNode) {
-        super(workspaceFolder, PackageType.Python, parent);
-        this.generalInfo = new GeneralInfo(this.workspaceFolder.replace(/^.*[\\/]/, ''), '', ['None'], this.workspaceFolder, PackageType.Python);
+    constructor(filePath: string, parent?: DependenciesTreeNode) {
+        super(filePath, PackageType.Python, parent);
+        this.generalInfo = new GeneralInfo(this.fullPath.replace(/^.*[\\/]/, ''), '', ['None'], this.fullPath, PackageType.Python);
         this.projectDetails.name = this.generalInfo.artifactId;
         this.label = this.projectDetails.name;
     }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ContextKeys } from '../../../constants/contextKeys';
 import { ScanCacheManager } from '../../../cache/scanCacheManager';
 import { GeneralInfo } from '../../../types/generalInfo';
@@ -7,12 +8,12 @@ import { PackageType } from '../../../types/projectType';
 import { DependenciesTreeNode } from '../dependenciesTreeNode';
 export class RootNode extends DependenciesTreeNode {
     private _projectDetails: ProjectDetails;
-    private _fullPath: string;
+    private _workspaceFolder: string;
 
-    constructor(private _workspaceFolder: string, packageType: PackageType, parent?: DependenciesTreeNode, contextValue?: string) {
-        super(new GeneralInfo('', '', [], _workspaceFolder, packageType), vscode.TreeItemCollapsibleState.Expanded, parent, contextValue);
-        this._projectDetails = new ProjectDetails(_workspaceFolder, packageType);
-        this._fullPath = _workspaceFolder;
+    constructor(private _fullPath: string, packageType: PackageType, parent?: DependenciesTreeNode, contextValue?: string) {
+        super(new GeneralInfo('', '', [], _fullPath, packageType), vscode.TreeItemCollapsibleState.Expanded, parent, contextValue);
+        this._projectDetails = new ProjectDetails(_fullPath, packageType);
+        this._workspaceFolder = path.dirname(_fullPath);
     }
 
     public get projectDetails(): ProjectDetails {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/virtualEnvPypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/virtualEnvPypiTree.ts
@@ -29,7 +29,7 @@ export class VirtualEnvPypiTree extends PypiTreeNode {
     public toEnvironmentTreeNode() {
         return new EnvironmentTreeNode(this.virtualEnvironmentPath, this.generalInfo.pkgType);
     }
-    
+
     public toDependencyScanResults() {
         return {
             type: this.generalInfo.pkgType,

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
@@ -59,17 +59,7 @@ export class DependenciesTreesFactory {
             );
             typesDone++;
             progressManager.reportProgress();
-
-            projectDescriptors.set(
-                PackageType.Nuget,
-                await NugetUtils.createDependenciesTrees(
-                    projectDescriptors.get(PackageType.Nuget),
-                    componentsToScan,
-                    treesManager,
-                    parent,
-                    checkCanceled
-                )
-            );
+            await NugetUtils.createDependenciesTrees(projectDescriptors.get(PackageType.Nuget), treesManager, parent, checkCanceled);
         } finally {
             progressManager.reportProgress((getNumberOfSupportedPackageTypes() - typesDone) * progressManager.getStepIncValue);
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts
@@ -59,12 +59,16 @@ export class DependenciesTreesFactory {
             );
             typesDone++;
             progressManager.reportProgress();
-            await NugetUtils.createDependenciesTrees(
-                projectDescriptors.get(PackageType.Nuget),
-                componentsToScan,
-                treesManager,
-                parent,
-                checkCanceled
+
+            projectDescriptors.set(
+                PackageType.Nuget,
+                await NugetUtils.createDependenciesTrees(
+                    projectDescriptors.get(PackageType.Nuget),
+                    componentsToScan,
+                    treesManager,
+                    parent,
+                    checkCanceled
+                )
             );
         } finally {
             progressManager.reportProgress((getNumberOfSupportedPackageTypes() - typesDone) * progressManager.getStepIncValue);

--- a/src/main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode.ts
@@ -121,10 +121,7 @@ export class DependencyIssuesTreeNode extends vscode.TreeItem {
         return this._type;
     }
 
-    /**
-     * @returns the file system path to the project descriptor directory or to the Python virtual environment
-     */
-    public getSourcePath(): string {
+    public getProjectPath(): string {
         return this.parent.getProjectPath();
     }
 

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -340,7 +340,11 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
 
                 let descriptorNode: DescriptorTreeNode = new DescriptorTreeNode(descriptorData.fullPath, descriptorData.type);
                 // Search for the dependency graph of the descriptor
-                let descriptorGraph: RootNode | undefined = DependencyUtils.getDependencyGraph(workspaceDependenciesTree, descriptorPath.fsPath, descriptorData.type);
+                let descriptorGraph: RootNode | undefined = DependencyUtils.getDependencyGraph(
+                    workspaceDependenciesTree,
+                    descriptorPath.fsPath,
+                    descriptorData.type
+                );
                 if (!descriptorGraph) {
                     progressManager.reportProgress(2 * progressManager.getStepIncValue);
                     this._logManager.logMessage("Can't find descriptor graph for " + descriptorPath.fsPath, 'DEBUG');

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -278,10 +278,6 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
         // Scan workspace to prepare the needed information for the scans and progress
         progress.report({ message: '👷 Preparing workspace' });
         let workspaceDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors([root.workSpace], this._logManager);
-        let descriptorsCount: number = 0;
-        for (let descriptorPaths of workspaceDescriptors.values()) {
-            descriptorsCount += descriptorPaths.length;
-        }
         checkCanceled();
         let graphSupported: boolean = await this._scanManager.validateGraphSupported();
         checkCanceled();
@@ -297,6 +293,10 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
             checkCanceled
         );
 
+        let descriptorsCount: number = 0;
+        for (let descriptorPaths of workspaceDescriptors.values()) {
+            descriptorsCount += descriptorPaths.length;
+        }
         progressManager.startStep('🔎 Scanning for issues', graphSupported ? 2 * descriptorsCount + 1 : 1);
         let scansPromises: Promise<any>[] = [];
         scansPromises.push(AnalyzerUtils.runEos(scanResults, root, workspaceDescriptors, this._scanManager, progressManager));

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -340,7 +340,7 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
 
                 let descriptorNode: DescriptorTreeNode = new DescriptorTreeNode(descriptorData.fullPath, descriptorData.type);
                 // Search for the dependency graph of the descriptor
-                let descriptorGraph: RootNode | undefined = DependencyUtils.getDependencyGraph(workspaceDependenciesTree, descriptorPath.fsPath);
+                let descriptorGraph: RootNode | undefined = DependencyUtils.getDependencyGraph(workspaceDependenciesTree, descriptorPath.fsPath, descriptorData.type);
                 if (!descriptorGraph) {
                     progressManager.reportProgress(2 * progressManager.getStepIncValue);
                     this._logManager.logMessage("Can't find descriptor graph for " + descriptorPath.fsPath, 'DEBUG');

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -18,6 +18,7 @@ import { FocusType } from '../../constants/contextKeys';
 import { DependencyScanResults } from '../../types/workspaceIssuesDetails';
 import { EnvironmentTreeNode } from '../issuesTree/descriptorTree/environmentTreeNode';
 import { ProjectDependencyTreeNode } from '../issuesTree/descriptorTree/projectDependencyTreeNode';
+import { NugetUtils } from '../../utils/nugetUtils';
 
 export class DependencyUtils {
     /**

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -181,12 +181,13 @@ export class DependencyUtils {
      * Get the dependency graph of a descriptor base on a given path
      * @param workspaceDependenciesTree - the dependencies graph for all the descriptors in the workspace
      * @param descriptorPath - the descriptor we want to fetch its sub tree graph
+     * @param descriptorType - the package type of the descriptor
      * @returns the descriptor dependencies tree if exists the provided workspace tree, undefined otherwise
      */
-    public static getDependencyGraph(workspaceDependenciesTree: DependenciesTreeNode, descriptorPath: string): RootNode | undefined {
+    public static getDependencyGraph(workspaceDependenciesTree: DependenciesTreeNode, descriptorPath: string, descriptorType: PackageType): RootNode | undefined {
         // Search for the dependency graph of the descriptor
         for (const child of workspaceDependenciesTree.children) {
-            if (child instanceof RootNode) {
+            if (child instanceof RootNode && child.projectDetails.type === descriptorType) {
                 let graph: RootNode | undefined = this.searchDependencyGraph(descriptorPath, child);
                 if (graph) {
                     return graph;

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -256,7 +256,10 @@ export class DependencyUtils {
      * @returns the list of positions in the document this dependency appears in
      */
     public static getDependencyPosition(document: vscode.TextDocument, packageType: PackageType, dependencyId: string): vscode.Range[] {
-        let dependencyName: string = packageType == PackageType.Maven ? dependencyId : dependencyId.substring(0, dependencyId.lastIndexOf(':'));
+        let dependencyName: string =
+            packageType == PackageType.Maven || packageType == PackageType.Nuget
+                ? dependencyId
+                : dependencyId.substring(0, dependencyId.lastIndexOf(':'));
 
         switch (packageType) {
             case PackageType.Go:
@@ -269,6 +272,8 @@ export class DependencyUtils {
                 return PypiUtils.getDependencyPosition(document, dependencyName);
             case PackageType.Yarn:
                 return YarnUtils.getDependencyPosition(document, dependencyName);
+            case PackageType.Nuget:
+                return NugetUtils.getDependencyPosition(document, dependencyName);
             default:
                 return [];
         }

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -184,7 +184,11 @@ export class DependencyUtils {
      * @param descriptorType - the package type of the descriptor
      * @returns the descriptor dependencies tree if exists the provided workspace tree, undefined otherwise
      */
-    public static getDependencyGraph(workspaceDependenciesTree: DependenciesTreeNode, descriptorPath: string, descriptorType: PackageType): RootNode | undefined {
+    public static getDependencyGraph(
+        workspaceDependenciesTree: DependenciesTreeNode,
+        descriptorPath: string,
+        descriptorType: PackageType
+    ): RootNode | undefined {
         // Search for the dependency graph of the descriptor
         for (const child of workspaceDependenciesTree.children) {
             if (child instanceof RootNode && child.projectDetails.type === descriptorType) {

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -193,22 +193,19 @@ export class DependencyUtils {
         // Search for the dependency graph of the descriptor
         for (const child of workspaceDependenciesTree.children) {
             if (child instanceof RootNode && child.projectDetails.type === descriptorType) {
-                let graph: RootNode | undefined = this.searchDependencyGraph(descriptorPath, child);
-                if (graph) {
-                    return graph;
-                }
+                return this.searchDependencyGraph(descriptorPath, child);
             }
         }
         return undefined;
     }
 
-    private static searchDependencyGraph(descriptorDir: string, node: RootNode): RootNode | undefined {
-        if (node.fullPath == descriptorDir || node.projectDetails.path == descriptorDir) {
+    private static searchDependencyGraph(descriptorPath: string, node: RootNode): RootNode | undefined {
+        if (node.fullPath == descriptorPath || node.projectDetails.path == descriptorPath) {
             return node;
         }
         for (const child of node.children) {
             if (child instanceof RootNode) {
-                let graph: RootNode | undefined = this.searchDependencyGraph(descriptorDir, child);
+                let graph: RootNode | undefined = this.searchDependencyGraph(descriptorPath, child);
                 if (graph) {
                     return graph;
                 }

--- a/src/main/utils/goUtils.ts
+++ b/src/main/utils/goUtils.ts
@@ -103,10 +103,10 @@ export class GoUtils {
             checkCanceled();
             treesManager.logManager.logMessage('Analyzing go.mod file ' + goMod.fsPath, 'INFO');
             let projectDir: string = path.dirname(goMod.fsPath);
-            let tmpWorkspace: string = '';
+            let tmpGoModPath: string = '';
             try {
-                tmpWorkspace = this.createGoWorkspace(projectDir, treesManager.logManager);
-                ScanUtils.executeCmd(GoUtils.GO_MOD_TIDY_CMD, tmpWorkspace);
+                tmpGoModPath = this.createGoWorkspace(projectDir, treesManager.logManager);
+                ScanUtils.executeCmd(GoUtils.GO_MOD_TIDY_CMD, path.dirname(tmpGoModPath));
             } catch (error) {
                 treesManager.logManager.logMessage('Failed creating go temporary workspace: ' + error, 'ERR');
                 treesManager.logManager.logMessageAndToastErr(
@@ -115,7 +115,7 @@ export class GoUtils {
                 );
             }
 
-            let root: GoTreeNode = new GoTreeNode(tmpWorkspace, treesManager, parent);
+            let root: GoTreeNode = new GoTreeNode(tmpGoModPath, treesManager, parent);
             root.refreshDependencies(goVersion);
             projectsToScan.push(root.projectDetails);
             // Set actual paths.
@@ -125,7 +125,7 @@ export class GoUtils {
             root.workspaceFolder = projectDir;
 
             try {
-                await ScanUtils.removeFolder(tmpWorkspace);
+                await ScanUtils.removeFolder(path.dirname(tmpGoModPath));
             } catch (error) {
                 treesManager.logManager.logMessage('Failed removing go temporary workspace directory: ' + error, 'ERR');
             }
@@ -164,7 +164,11 @@ export class GoUtils {
                 }
             }
         }
-        return targetDir;
+        const tmpGoModPath:string = path.join(targetDir,'go.mod')
+        if(!fs.existsSync(tmpGoModPath)){
+            throw new Error("fail to find temp go.mod while copy go.mod file to a temporary directory at "+ targetDir);
+        }
+        return  tmpGoModPath;
     }
 
     /**

--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -309,7 +309,7 @@ export class MavenUtils {
                     } else {
                         currNode = new PomTree(pomGav);
                     }
-                    currNode.pomPath = path.dirname(pom.fsPath);
+                    currNode.pomPath = pom.fsPath;
                     currNode.parentGav = parentGav;
                     MavenUtils.addPrototypeNode(prototypeTree, currNode);
                 }

--- a/src/main/utils/npmUtils.ts
+++ b/src/main/utils/npmUtils.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'child_process';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { NpmTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/npmTree';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
@@ -78,7 +77,7 @@ export class NpmUtils {
         treesManager.logManager.logMessage('package.json files to scan: [' + packageJsons.toString() + ']', 'DEBUG');
         for (let packageJson of packageJsons) {
             checkCanceled();
-            let root: NpmTreeNode = new NpmTreeNode(path.dirname(packageJson.fsPath), treesManager, parent);
+            let root: NpmTreeNode = new NpmTreeNode(packageJson.fsPath, treesManager, parent);
             root.refreshDependencies();
             projectsToScan.push(root.projectDetails);
         }

--- a/src/main/utils/nugetUtils.ts
+++ b/src/main/utils/nugetUtils.ts
@@ -9,7 +9,6 @@ import { Utils } from '../treeDataProviders/utils/utils';
 import { ProjectDetails } from '../types/projectDetails';
 
 export class NugetUtils {
-    
     public static readonly SOLUTION_SUFFIX: string = '.sln';
     public static readonly PROJECT_SUFFIX: string = '.csproj';
 
@@ -39,8 +38,8 @@ export class NugetUtils {
             if (!tree) {
                 continue;
             }
-            let projectsInSolutions: vscode.Uri[] | undefined = this.filterProjects(solutionsAndProjects,solution);
-            
+            let projectsInSolutions: vscode.Uri[] | undefined = this.filterProjects(solutionsAndProjects, solution);
+
             let root: NugetTreeNode = this.createSolutionNode(parent, solution, projectsInSolutions, tree, treesManager.logManager);
             for (let project of tree.projects) {
                 checkCanceled();
@@ -54,7 +53,13 @@ export class NugetUtils {
         }
     }
 
-    private static createSolutionNode(parent: DependenciesTreeNode, solution: vscode.Uri, projectsInSolutions: vscode.Uri[] | undefined, tree: any, logManager: LogManager): NugetTreeNode {
+    private static createSolutionNode(
+        parent: DependenciesTreeNode,
+        solution: vscode.Uri,
+        projectsInSolutions: vscode.Uri[] | undefined,
+        tree: any,
+        logManager: LogManager
+    ): NugetTreeNode {
         let solutionDir: string = path.dirname(solution.fsPath);
         let failed: boolean = false;
         if (projectsInSolutions && projectsInSolutions.length !== tree.projects.length) {
@@ -70,7 +75,7 @@ export class NugetUtils {
     }
 
     private static getProjectUri(projectName: string, solutionsAndProjects: vscode.Uri[] | undefined): vscode.Uri | undefined {
-        return solutionsAndProjects?.find(optional => optional.fsPath.includes(projectName))
+        return solutionsAndProjects?.find(optional => optional.fsPath.includes(projectName));
     }
 
     public static filterProjects(solutionsAndProjects: vscode.Uri[] | undefined, inSolution?: vscode.Uri): vscode.Uri[] | undefined {

--- a/src/main/utils/nugetUtils.ts
+++ b/src/main/utils/nugetUtils.ts
@@ -25,14 +25,13 @@ export class NugetUtils {
         treesManager: TreesManager,
         parent: DependenciesTreeNode,
         checkCanceled: () => void
-    ): Promise<vscode.Uri[]> {
+    ): Promise<void> {
         let solutions: vscode.Uri[] | undefined = this.filterSolutions(solutionsAndProjects);
         if (!solutions) {
             treesManager.logManager.logMessage('No *.sln files found in workspaces.', 'DEBUG');
-            return [];
+            return;
         }
         treesManager.logManager.logMessage('Solution files to scan: [' + solutions.toString() + ']', 'DEBUG');
-        let updatedDescriptorList: vscode.Uri[] = [];
         for (let solution of solutions) {
             checkCanceled();
             let projectsInSolutions: vscode.Uri[] | undefined = this.filterProjects(solutionsAndProjects, solution);
@@ -51,7 +50,6 @@ export class NugetUtils {
                 }
             }
         }
-        return updatedDescriptorList;
     }
 
     private static getPackagesConfigUri(projectUri: vscode.Uri): vscode.Uri | undefined {

--- a/src/main/utils/nugetUtils.ts
+++ b/src/main/utils/nugetUtils.ts
@@ -134,26 +134,6 @@ export class NugetUtils {
         return nugetList;
     }
 
-    // /**
-    //  * Get package.json file and return the position of 'dependencies' section.
-    //  * @param document - package.json file
-    //  */
-    // public static getDependenciesPos(document: vscode.TextDocument): vscode.Position[] {
-    //     let res: vscode.Position[] = [];
-    //     let packageJsonContent: string = document.getText();
-    //     let dependenciesMatch: RegExpMatchArray | null = packageJsonContent.match('"((devD)|(d))ependencies"s*:s*');
-    //     if (!dependenciesMatch) {
-    //         return res;
-    //     }
-    //     res.push(document.positionAt(<number>dependenciesMatch.index));
-    //     res.push(new vscode.Position(res[0].line, res[0].character + dependenciesMatch[0].length));
-    //     return res;
-    // }
-
-    // // public static getDependenciesPos(document: vscode.TextDocument): vscode.Position[] {
-
-    // // }
-
     public static getDependencyPosition(document: vscode.TextDocument, artifactId: string): vscode.Range[] {
         let res: vscode.Range[] = [];
         let projectContent: string = document.getText();

--- a/src/main/utils/nugetUtils.ts
+++ b/src/main/utils/nugetUtils.ts
@@ -5,28 +5,33 @@ import { LogManager } from '../log/logManager';
 import { NugetTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../treeDataProviders/treesManager';
+import { Utils } from '../treeDataProviders/utils/utils';
 import { ProjectDetails } from '../types/projectDetails';
 
 export class NugetUtils {
+    
+    public static readonly SOLUTION_SUFFIX: string = '.sln';
+    public static readonly PROJECT_SUFFIX: string = '.csproj';
+
     /**
-     * @param solutions        - Paths to *.sln files
+     * @param solutionsAndProjects        - Paths to *.sln files
      * @param componentsToScan - Set of nuget components to populate during the tree building. We'll use this set later on, while scanning the packages with Xray.
      * @param treesManager     - Scan trees manager
      * @param parent           - The base tree node
      * @param quickScan        - True to allow using the scan cache
      */
     public static async createDependenciesTrees(
-        solutions: vscode.Uri[] | undefined,
-        projectsToScan: ProjectDetails[],
+        solutionsAndProjects: vscode.Uri[] | undefined,
+        componentsToScan: ProjectDetails[],
         treesManager: TreesManager,
         parent: DependenciesTreeNode,
         checkCanceled: () => void
     ): Promise<void> {
+        let solutions: vscode.Uri[] | undefined = this.filterSolutions(solutionsAndProjects);
         if (!solutions) {
             treesManager.logManager.logMessage('No *.sln files found in workspaces.', 'DEBUG');
             return;
         }
-
         treesManager.logManager.logMessage('Solution files to scan: [' + solutions.toString() + ']', 'DEBUG');
         for (let solution of solutions) {
             checkCanceled();
@@ -34,14 +39,51 @@ export class NugetUtils {
             if (!tree) {
                 continue;
             }
-            let solutionDir: string = path.dirname(solution.fsPath);
+            let projectsInSolutions: vscode.Uri[] | undefined = this.filterProjects(solutionsAndProjects,solution);
+            
+            let root: NugetTreeNode = this.createSolutionNode(parent, solution, projectsInSolutions, tree, treesManager.logManager);
             for (let project of tree.projects) {
                 checkCanceled();
-                let root: NugetTreeNode = new NugetTreeNode(solutionDir, parent);
-                root.refreshDependencies(project);
-                projectsToScan.push(root.projectDetails);
+                let projectUri: vscode.Uri | undefined = this.getProjectUri(project.name, projectsInSolutions);
+                if (projectUri) {
+                    let projectDir: string = path.dirname(projectUri.fsPath);
+                    let projectNode: NugetTreeNode = new NugetTreeNode(projectDir, root);
+                    projectNode.refreshDependencies(project);
+                }
             }
         }
+    }
+
+    private static createSolutionNode(parent: DependenciesTreeNode, solution: vscode.Uri, projectsInSolutions: vscode.Uri[] | undefined, tree: any, logManager: LogManager): NugetTreeNode {
+        let solutionDir: string = path.dirname(solution.fsPath);
+        let failed: boolean = false;
+        if (projectsInSolutions && projectsInSolutions.length !== tree.projects.length) {
+            logManager.logMessageAndToastErr(
+                `Failed to scan nuget project. Hint: Please make sure the commands 'dotnet restore' or 'nuget restore' run successfully in '${solutionDir}'`,
+                'ERR'
+            );
+            failed = true;
+        }
+        let solutionNode: NugetTreeNode = new NugetTreeNode(solutionDir, parent);
+        solutionNode.setName(Utils.getLastSegment(solution.fsPath) + (failed ? ' [Not installed]' : ''));
+        return solutionNode;
+    }
+
+    private static getProjectUri(projectName: string, solutionsAndProjects: vscode.Uri[] | undefined): vscode.Uri | undefined {
+        return solutionsAndProjects?.find(optional => optional.fsPath.includes(projectName))
+    }
+
+    public static filterProjects(solutionsAndProjects: vscode.Uri[] | undefined, inSolution?: vscode.Uri): vscode.Uri[] | undefined {
+        let projects: vscode.Uri[] | undefined = solutionsAndProjects?.filter(optional => optional.fsPath.endsWith(NugetUtils.PROJECT_SUFFIX));
+        if (!inSolution || !projects) {
+            return projects;
+        }
+        let solutionDir: string = path.dirname(inSolution.fsPath);
+        return projects.filter(optional => optional.fsPath.includes(solutionDir));
+    }
+
+    public static filterSolutions(solutionsAndProjects: vscode.Uri[] | undefined): vscode.Uri[] | undefined {
+        return solutionsAndProjects?.filter(optional => optional.fsPath.endsWith(NugetUtils.SOLUTION_SUFFIX));
     }
 
     /**
@@ -74,4 +116,49 @@ export class NugetUtils {
         }
         return nugetList;
     }
+
+    // /**
+    //  * Get package.json file and return the position of 'dependencies' section.
+    //  * @param document - package.json file
+    //  */
+    // public static getDependenciesPos(document: vscode.TextDocument): vscode.Position[] {
+    //     let res: vscode.Position[] = [];
+    //     let packageJsonContent: string = document.getText();
+    //     let dependenciesMatch: RegExpMatchArray | null = packageJsonContent.match('"((devD)|(d))ependencies"s*:s*');
+    //     if (!dependenciesMatch) {
+    //         return res;
+    //     }
+    //     res.push(document.positionAt(<number>dependenciesMatch.index));
+    //     res.push(new vscode.Position(res[0].line, res[0].character + dependenciesMatch[0].length));
+    //     return res;
+    // }
+
+    // // public static getDependenciesPos(document: vscode.TextDocument): vscode.Position[] {
+
+    // // }
+
+    // /**
+    //  * Get package.json file and dependencies tree node. return the position of the dependency in the package.json file.
+    //  * @param document             - package.json file
+    //  * @param dependenciesTreeNode - dependencies tree node
+    //  */
+    // public static getDependencyPosition(document: vscode.TextDocument, artifactId: string, focusType: FocusType): vscode.Range[] {
+    //     let res: vscode.Range[] = [];
+    //     let packageJsonContent: string = document.getText();
+    //     let dependencyMatch: RegExpMatchArray | null = packageJsonContent.match('("' + artifactId + '"\\s*:\\s*).*"');
+    //     if (!dependencyMatch) {
+    //         return res;
+    //     }
+    //     let startPos: vscode.Position;
+    //     switch (focusType) {
+    //         case FocusType.Dependency:
+    //             startPos = document.positionAt(<number>dependencyMatch.index);
+    //             break;
+    //         case FocusType.DependencyVersion:
+    //             startPos = document.positionAt(<number>dependencyMatch.index + dependencyMatch[1].length);
+    //             break;
+    //     }
+    //     res.push(new vscode.Range(startPos, new vscode.Position(startPos.line, startPos.character + dependencyMatch[0].length)));
+    //     return res;
+    // }
 }

--- a/src/main/utils/nugetUtils.ts
+++ b/src/main/utils/nugetUtils.ts
@@ -159,9 +159,6 @@ export class NugetUtils {
     private static getCSProjFileRegex(artifactId: string): RegExp {
         let [artifactName, artifactVersion] = artifactId.split(':');
         artifactVersion = artifactVersion.replace(/\./g, '\\.');
-        // let referenceTag: string = `(<Reference\\s+Include=\\"` + artifactName + '\\"(\\s+Version=\\"' + artifactVersion + '\\")?.*>)';
-        // let packageReferenceTag: string = ;
-        // let hintPathTag: string = `((<HintPath>\\.\\.\\\\packages\\\\` + artifactName + '\\.' + artifactVersion + ').*>)';
         return new RegExp(`<PackageReference\\s+Include=\\"` + artifactName + '\\"(\\s+Version=\\"' + artifactVersion + '\\")?.*>', 'i');
     }
 }

--- a/src/main/utils/pomTree.ts
+++ b/src/main/utils/pomTree.ts
@@ -3,13 +3,16 @@ import { TreesManager } from '../treeDataProviders/treesManager';
 import { ScanUtils } from './scanUtils';
 
 export class PomTree {
+    private _pomLocation:string =''
     constructor(
         private _pomGav: string = '',
         private _pomPath: string = '',
         private _children: PomTree[] = [],
         private _parent?: PomTree,
         private _parentGav: string = ''
-    ) {}
+    ) {
+        this._pomLocation = path.dirname(_pomPath)
+    }
 
     public get pomGav(): string {
         return this._pomGav;
@@ -25,6 +28,11 @@ export class PomTree {
 
     public set pomPath(v: string) {
         this._pomPath = v;
+        this._pomLocation = path.dirname(v)
+    }
+
+    public get pomLocation(): string {
+        return this._pomLocation;
     }
 
     public get children(): PomTree[] {
@@ -65,11 +73,11 @@ export class PomTree {
         return;
     }
     public runMavenDependencyTree(): void {
-        ScanUtils.executeCmd(`mvn dependency:tree -DappendOutput=true -DoutputFile=.jfrog_vscode/maven`, this.pomPath);
+        ScanUtils.executeCmd(`mvn dependency:tree -DappendOutput=true -DoutputFile=.jfrog_vscode/maven`,  this.pomLocation);
     }
 
     public async getRawDependencies(treesManager: TreesManager): Promise<string[] | undefined> {
-        const dependencyTreeFile: string = path.join(this._pomPath, '.jfrog_vscode', 'maven');
+        const dependencyTreeFile: string = path.join(this.pomLocation, '.jfrog_vscode', 'maven');
         try {
             const pomContent: string | undefined = ScanUtils.readFileIfExists(dependencyTreeFile);
             if (!pomContent) {
@@ -80,7 +88,7 @@ export class PomTree {
         } catch (error) {
             treesManager.logManager.logMessage(
                 'Dependencies were not found at ' +
-                    path.join(this._pomPath, 'pom.xml') +
+                    path.join(this.pomLocation, 'pom.xml') +
                     '.\n' +
                     "Hint: For projects which include the 'org.apache.maven.plugins:maven-dependency-plugin' the scanning functionality is disabled",
                 'ERR'

--- a/src/main/utils/pypiUtils.ts
+++ b/src/main/utils/pypiUtils.ts
@@ -14,6 +14,7 @@ import { EnvironmentTreeNode } from '../treeDataProviders/issuesTree/descriptorT
 import { DependencyUtils } from '../treeDataProviders/utils/dependencyUtils';
 import { StepProgress } from '../treeDataProviders/utils/stepProgress';
 import { ScanResults, DependencyScanResults } from '../types/workspaceIssuesDetails';
+import { PackageType } from '../types/projectType';
 
 export class PypiUtils {
     public static readonly DOCUMENT_SELECTOR: vscode.DocumentSelector = { scheme: 'file', pattern: '**/*requirements*.txt' };
@@ -317,7 +318,11 @@ export class PypiUtils {
         if (!envIssues || !(envIssues instanceof VirtualEnvPypiTree)) {
             return [];
         }
-        let environmentGraph: RootNode | undefined = DependencyUtils.getDependencyGraph(workspaceDependenciesTree, scanResults.path);
+        let environmentGraph: RootNode | undefined = DependencyUtils.getDependencyGraph(
+            workspaceDependenciesTree,
+            scanResults.path,
+            PackageType.Python
+        );
         if (!environmentGraph) {
             progressManager.reportProgress(2 * progressManager.getStepIncValue);
             logManager.logMessage("Can't find virtual environment graph at " + envIssues.virtualEnvironmentPath, 'DEBUG');

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -12,6 +12,9 @@ import { Configuration } from './configuration';
 import { ContextKeys } from '../constants/contextKeys';
 import * as util from 'util';
 export class ScanUtils {
+    public static readonly DESCRIPTOR_SELECTOR_PATTERN: string =
+        '**/{go.mod,package.json,pom.xml,*requirements*.txt,yarn.lock,*.csproj,*.sln,packages.config}';
+
     public static readonly RESOURCES_DIR: string = ScanUtils.getResourcesDir();
     public static readonly SPAWN_PROCESS_BUFFER_SIZE: number = 104857600;
 
@@ -53,7 +56,7 @@ export class ScanUtils {
                 {
                     baseUri: workspace.uri,
                     base: workspace.uri.fsPath,
-                    pattern: '**/{go.mod,pom.xml,package.json,yarn.lock,*.sln,*.csproj,setup.py,requirements*.txt}'
+                    pattern: ScanUtils.DESCRIPTOR_SELECTOR_PATTERN
                 },
                 Configuration.getScanExcludePattern(workspace)
             );
@@ -163,10 +166,13 @@ export class ScanUtils {
             }
             return PackageType.Npm;
         }
-        if (fsPath.endsWith('.sln') || fsPath.endsWith('.csproj')) {
+        if (fsPath.endsWith('.sln') || fsPath.endsWith('.csproj') || fsPath.endsWith('packages.config')) {
             return PackageType.Nuget;
         }
-        return PackageType.Python;
+        if (fsPath.endsWith('.txt') || fsPath.endsWith('.py')) {
+            return PackageType.Python;
+        }
+        return;
     }
 
     static createTmpDir(): string {

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -53,7 +53,7 @@ export class ScanUtils {
                 {
                     baseUri: workspace.uri,
                     base: workspace.uri.fsPath,
-                    pattern: '**/{go.mod,pom.xml,package.json,yarn.lock,*.sln,setup.py,requirements*.txt}'
+                    pattern: '**/{go.mod,pom.xml,package.json,yarn.lock,*.sln,*.csproj,setup.py,requirements*.txt}'
                 },
                 Configuration.getScanExcludePattern(workspace)
             );
@@ -146,7 +146,7 @@ export class ScanUtils {
      * @param fsPath - path to package descriptor such as pom.xml, go.mod, etc.
      * @returns PackageType or undefined
      */
-    private static extractDescriptorTypeFromPath(fsPath: string): PackageType | undefined {
+    public static extractDescriptorTypeFromPath(fsPath: string): PackageType | undefined {
         if (fsPath.endsWith('go.mod')) {
             return PackageType.Go;
         }
@@ -163,7 +163,7 @@ export class ScanUtils {
             }
             return PackageType.Npm;
         }
-        if (fsPath.endsWith('.sln')) {
+        if (fsPath.endsWith('.sln') || fsPath.endsWith('.csproj')) {
             return PackageType.Nuget;
         }
         return PackageType.Python;

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -13,7 +13,7 @@ import { ContextKeys } from '../constants/contextKeys';
 import * as util from 'util';
 export class ScanUtils {
     public static readonly DESCRIPTOR_SELECTOR_PATTERN: string =
-        '**/{go.mod,package.json,pom.xml,*requirements*.txt,yarn.lock,*.csproj,*.sln,packages.config}';
+        '**/{go.mod,package.json,pom.xml,setup.py,*requirements*.txt,yarn.lock,*.csproj,*.sln,packages.config}';
 
     public static readonly RESOURCES_DIR: string = ScanUtils.getResourcesDir();
     public static readonly SPAWN_PROCESS_BUFFER_SIZE: number = 104857600;

--- a/src/main/utils/yarnUtils.ts
+++ b/src/main/utils/yarnUtils.ts
@@ -69,7 +69,7 @@ export class YarnUtils {
         for (let yarnLock of yarnLocks) {
             checkCanceled();
             // In yarn, the version may vary in different workspaces. Therefore we run 'yarn --version' for each workspace.
-            if (!YarnUtils.isVersionSupported(parent, treesManager.logManager, yarnLock.fsPath)) {
+            if (!YarnUtils.isVersionSupported(parent, treesManager.logManager, path.dirname(yarnLock.fsPath))) {
                 return;
             }
             checkCanceled();

--- a/src/main/utils/yarnUtils.ts
+++ b/src/main/utils/yarnUtils.ts
@@ -69,11 +69,11 @@ export class YarnUtils {
         for (let yarnLock of yarnLocks) {
             checkCanceled();
             // In yarn, the version may vary in different workspaces. Therefore we run 'yarn --version' for each workspace.
-            if (!YarnUtils.isVersionSupported(parent, treesManager.logManager, path.dirname(yarnLock.fsPath))) {
+            if (!YarnUtils.isVersionSupported(parent, treesManager.logManager, yarnLock.fsPath)) {
                 return;
             }
             checkCanceled();
-            let root: YarnTreeNode = new YarnTreeNode(path.dirname(yarnLock.fsPath), treesManager, parent);
+            let root: YarnTreeNode = new YarnTreeNode(yarnLock.fsPath, treesManager, parent);
             projectsToScan.push(root.projectDetails);
             root.refreshDependencies();
         }

--- a/src/test/tests/maven.test.ts
+++ b/src/test/tests/maven.test.ts
@@ -398,26 +398,26 @@ describe('Maven Tests', async () => {
 
     function expectedBuildPrototypePomTree(): PomTree[][] {
         return [
-            [new PomTree('org.jfrog.test:multi2:3.7-SNAPSHOT', path.join(__dirname, '..', 'resources', 'maven', 'dependency'))],
+            [new PomTree('org.jfrog.test:multi2:3.7-SNAPSHOT', path.join(__dirname, '..', 'resources', 'maven', 'dependency', 'pom.xml'))],
             [
-                new PomTree('org.jfrog.test:multi:3.7-SNAPSHOT', path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency'), [
+                new PomTree('org.jfrog.test:multi:3.7-SNAPSHOT', path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'pom.xml'), [
                     new PomTree(
                         'org.jfrog.test:multi1:3.7-SNAPSHOT',
-                        path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'multi1'),
+                        path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'multi1', 'pom.xml'),
                         [],
                         undefined,
                         'org.jfrog.test:multi:3.7-SNAPSHOT'
                     ),
                     new PomTree(
                         'org.jfrog.test:multi2:3.7-SNAPSHOT',
-                        path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'multi2'),
+                        path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'multi2', 'pom.xml'),
                         [],
                         undefined,
                         'org.jfrog.test:multi:3.7-SNAPSHOT'
                     ),
                     new PomTree(
                         'org.jfrog.test:multi3:3.7-SNAPSHOT',
-                        path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'multi3'),
+                        path.join(__dirname, '..', 'resources', 'maven', 'multiPomDependency', 'multi3', 'pom.xml'),
                         [],
                         undefined,
                         'org.jfrog.test:multi:3.7-SNAPSHOT'

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -71,22 +71,19 @@ describe('Nuget Utils Tests', async () => {
     it('Create NuGet Dependencies Trees', async () => {
         let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', PackageType.Unknown));
         let res: DependenciesTreeNode[] = await runCreateNugetDependenciesTrees(parent);
-        assert.equal(res.length, 2);
+        assert.equal(res.length, 3);
         // Assert dependency information
-        assert.deepEqual(res[0].label, 'assets.sln');
-        assert.deepEqual(res[0].parent, parent);
-        assert.lengthOf(res[0].children, 2);
-        assert.deepEqual(res[0].children[0].label, 'api');
-        assert.lengthOf(res[0].children[0].children, 1);
-        let child: DependenciesTreeNode = res[0].children[0].children[0];
-        assert.deepEqual(child.componentId, 'MyLogger:1.0.0');
-        assert.deepEqual(child.label, 'MyLogger');
-        assert.deepEqual(child.description, '1.0.0');
-        assert.deepEqual(child.parent, res[0].children[0]);
-        assert.deepEqual(res[0].children[1].label, 'core');
-        // Not installed
-        assert.deepEqual(res[1].label, 'empty.sln [Not installed]');
-        assert.lengthOf(res[1].children, 0);
+        let node: DependenciesTreeNode | undefined = res.find(child => child.label === 'api')
+        assert.isDefined(node)
+        assert.deepEqual(node?.children.length ?? 0, 1);
+        // Assert dependency information
+        node = res.find(child => child.label === 'core')
+        assert.isDefined(node)
+        assert.deepEqual(node?.children.length ?? 0, 1);
+        // Assert dependency information
+        node = res.find(child => child.label === 'empty.sln [Not installed]')
+        assert.isDefined(node)
+        assert.deepEqual(node?.children.length ?? 1, 0);
     });
 
     async function runCreateNugetDependenciesTrees(parent: DependenciesTreeNode): Promise<DependenciesTreeNode[]> {

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -93,7 +93,7 @@ describe('Nuget Utils Tests', async () => {
         let packageDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors(workspaceFolders, treesManager.logManager);
         let solutions: vscode.Uri[] | undefined = packageDescriptors.get(PackageType.Nuget);
         assert.isDefined(solutions);
-        await NugetUtils.createDependenciesTrees(solutions, [], treesManager, parent, () => {
+        await NugetUtils.createDependenciesTrees(solutions, treesManager, parent, () => {
             assert;
         });
         let res: DependenciesTreeNode[] = parent.children.sort((lhs, rhs) => (<string>lhs.label).localeCompare(<string>rhs.label));

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -6,7 +6,6 @@ import * as vscode from 'vscode';
 import { ConnectionManager } from '../../main/connect/connectionManager';
 import { LogManager } from '../../main/log/logManager';
 import { ScanCacheManager } from '../../main/cache/scanCacheManager';
-// import { ScanLogicManager } from '../../main/scanLogic/scanLogicManager';
 import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TreesManager } from '../../main/treeDataProviders/treesManager';
 import { GeneralInfo } from '../../main/types/generalInfo';
@@ -14,7 +13,6 @@ import { PackageType } from '../../main/types/projectType';
 import { NugetUtils } from '../../main/utils/nugetUtils';
 import { ScanUtils } from '../../main/utils/scanUtils';
 import { createScanCacheManager, isWindows } from './utils/utils.test';
-import { ProjectDetails } from '../../main/types/projectDetails';
 import { ScanManager } from '../../main/scanLogic/scanManager';
 import { CacheManager } from '../../main/cache/cacheManager';
 
@@ -32,9 +30,14 @@ describe('Nuget Utils Tests', async () => {
         {} as CacheManager,
         logManager
     );
-    let solutionsDirs: string[] = ['assets', 'empty'];
+
     let workspaceFolders: vscode.WorkspaceFolder[];
     let tmpDir: vscode.Uri = vscode.Uri.file(path.join(__dirname, '..', 'resources', 'nuget'));
+    let expectedDescriptors: string[] = [
+        path.join(tmpDir.fsPath, 'empty/empty-proj/empty-proj.csproj'),
+        path.join(tmpDir.fsPath, 'assets/api/api.csproj'),
+        path.join(tmpDir.fsPath, 'assets/core/core.csproj')
+    ];
 
     before(() => {
         workspaceFolders = [
@@ -48,20 +51,16 @@ describe('Nuget Utils Tests', async () => {
     });
 
     /**
-     * Test NugetUtils.locateSolutions.
+     * Test NugetUtils.
      */
-    it('Locate solutions', async () => {
+    it('Locate descriptors', async () => {
         let packageDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors(workspaceFolders, treesManager.logManager);
-        let solutions: vscode.Uri[] | undefined = packageDescriptors.get(PackageType.Nuget);
-        assert.isDefined(solutions);
-        assert.strictEqual(solutions?.length, solutionsDirs.length);
-
-        // Assert that results contains all solutions.
-        for (let expectedSolutionDir of solutionsDirs) {
-            let expectedSolution: string = path.join(tmpDir.fsPath, expectedSolutionDir, expectedSolutionDir + '.sln');
+        let descriptors: vscode.Uri[] | undefined = packageDescriptors.get(PackageType.Nuget);
+        assert.isDefined(descriptors);
+        for (let expectedDescriptor of expectedDescriptors) {
             assert.isDefined(
-                solutions?.find(solutions => solutions.fsPath === expectedSolution),
-                'Should contain ' + expectedSolution
+                descriptors?.find(descriptor => descriptor.fsPath === expectedDescriptor),
+                'Should contain ' + expectedDescriptor
             );
         }
     });
@@ -71,45 +70,37 @@ describe('Nuget Utils Tests', async () => {
      */
     it('Create NuGet Dependencies Trees', async () => {
         let parent: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo('parent', '1.0.0', [], '', PackageType.Unknown));
-        let projectDetails: ProjectDetails[] = [];
-        let res: DependenciesTreeNode[] = await runCreateNugetDependenciesTrees(projectDetails, parent);
-        projectDetails.sort((a, b) => a.name.localeCompare(b.name));
-
-        // Check that project details data.
-        assert.equal(projectDetails.length, 2);
-        assert.deepEqual(projectDetails[0].name, 'api');
-        assert.deepEqual(projectDetails[1].name, 'core');
-        assert.deepEqual(projectDetails[0].toArray()[0].component_id, 'nuget://MyLogger:1.0.0');
-        assert.deepEqual(projectDetails[1].toArray()[0].component_id, 'nuget://MyLogger:1.0.0');
-
-        // Check labels
-        assert.deepEqual(res[0].label, 'api');
-        assert.deepEqual(res[1].label, 'core');
-
-        // Check parents
+        let res: DependenciesTreeNode[] = await runCreateNugetDependenciesTrees(parent);
+        assert.equal(res.length, 2);
+        // Assert dependency information
+        assert.deepEqual(res[0].label, 'assets.sln');
         assert.deepEqual(res[0].parent, parent);
-        assert.deepEqual(res[1].parent, parent);
-
-        // Check children
-        assert.lengthOf(res[0].children, 1);
-        assert.lengthOf(res[1].children, 1);
-        assert.deepEqual(res[0].children[0].label, res[1].children[0].label);
-        let child: DependenciesTreeNode = res[0].children[0];
+        assert.lengthOf(res[0].children, 2);
+        assert.deepEqual(res[0].children[0].label, 'api');
+        assert.lengthOf(res[0].children[0].children, 1);
+        let child: DependenciesTreeNode = res[0].children[0].children[0];
         assert.deepEqual(child.componentId, 'MyLogger:1.0.0');
         assert.deepEqual(child.label, 'MyLogger');
         assert.deepEqual(child.description, '1.0.0');
-        assert.deepEqual(child.parent, res[0]);
+        assert.deepEqual(child.parent, res[0].children[0]);
+        assert.deepEqual(res[0].children[1].label, 'core');
+        // Not installed
+        assert.deepEqual(res[1].label, 'empty.sln [Not installed]');
+        assert.lengthOf(res[1].children, 0);
     });
 
-    async function runCreateNugetDependenciesTrees(componentsToScan: ProjectDetails[], parent: DependenciesTreeNode) {
+    async function runCreateNugetDependenciesTrees(parent: DependenciesTreeNode): Promise<DependenciesTreeNode[]> {
         let packageDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors(workspaceFolders, treesManager.logManager);
         let solutions: vscode.Uri[] | undefined = packageDescriptors.get(PackageType.Nuget);
         assert.isDefined(solutions);
-        await NugetUtils.createDependenciesTrees(solutions, componentsToScan, treesManager, parent, () => {
+        await NugetUtils.createDependenciesTrees(solutions, [], treesManager, parent, () => {
             assert;
         });
-        componentsToScan = componentsToScan.sort((l, r) => l.name.localeCompare(r.name));
-        return parent.children.sort((lhs, rhs) => (<string>lhs.label).localeCompare(<string>rhs.label));
+        let res: DependenciesTreeNode[] = parent.children.sort((lhs, rhs) => (<string>lhs.label).localeCompare(<string>rhs.label));
+        for (let child of res) {
+            child.children = child.children.sort((lhs, rhs) => (<string>lhs.label).localeCompare(<string>rhs.label));
+        }
+        return res;
     }
 
     function replacePackagesPathInAssets() {

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -90,9 +90,8 @@ describe('Nuget Utils Tests', async () => {
         let packageDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors(workspaceFolders, treesManager.logManager);
         let solutions: vscode.Uri[] | undefined = packageDescriptors.get(PackageType.Nuget);
         assert.isDefined(solutions);
-        await NugetUtils.createDependenciesTrees(solutions, treesManager, parent, () => {
-            assert;
-        });
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        await NugetUtils.createDependenciesTrees(solutions, treesManager, parent, () => {});
         let res: DependenciesTreeNode[] = parent.children.sort((lhs, rhs) => (<string>lhs.label).localeCompare(<string>rhs.label));
         for (let child of res) {
             child.children = child.children.sort((lhs, rhs) => (<string>lhs.label).localeCompare(<string>rhs.label));


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Improvements:
* Fix bug - tree only showed one descriptor type even if multiple types exists in the same directory
* Show .csproj / packages.config files instead of .sln files in tree
* Show hint if the number of parsed projects is different than the number of actual .csproj files
* Locate dependencies positions in descriptors to show diagnostics
* Update dependency version to fix issues