### PR TITLE
Add pass kind to applicable result

### DIFF
--- a/src/main/scanLogic/scanRunners/analyzerModels.ts
+++ b/src/main/scanLogic/scanRunners/analyzerModels.ts
@@ -3,6 +3,7 @@ export interface AnalyzerRequest {
 }
 
 type AnalyzerType = 'analyze-applicability' | 'analyze-codebase';
+type ResultKind = 'pass' | 'fail';
 
 export interface AnalyzeScanRequest {
     // What type of scan
@@ -36,6 +37,7 @@ export interface AnalyzerRule {
 
 export interface AnalyzeIssue {
     ruleId: string;
+    kind?: ResultKind;
     message: ResultContent;
     locations: AnalyzeLocation[];
     codeFlows?: CodeFlow[];

--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -107,7 +107,7 @@ export class ApplicabilityRunner extends BinaryRunner {
         }
         // Convert data to a response
         return {
-            scannedCve: Object.values(scanned),
+            scannedCve: Array.from(scanned),
             applicableCve: Object.fromEntries(applicable.entries())
         } as ApplicabilityScanResponse;
     }

--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -1,6 +1,6 @@
 import { LogManager } from '../../log/logManager';
 import { BinaryRunner } from './binaryRunner';
-import { AnalyzeIssue, AnalyzerScanRun, AnalyzeScanRequest, FileIssues } from './analyzerModels';
+import { AnalyzeIssue, AnalyzeLocation, AnalyzerScanRun, AnalyzeScanRequest, FileIssues } from './analyzerModels';
 import { ConnectionManager } from '../../connect/connectionManager';
 
 /**
@@ -90,14 +90,14 @@ export class ApplicabilityRunner extends BinaryRunner {
         let issues: AnalyzeIssue[] = run.results;
         if (issues) {
             // Generate applicable data for all the issues
-            issues.forEach(analyzeIssue => {
+            issues.forEach((analyzeIssue: AnalyzeIssue) => {
                 if ((!analyzeIssue.kind || analyzeIssue.kind === 'fail') && analyzeIssue.locations) {
                     let applicableDetails: CveApplicableDetails = this.getOrCreateApplicableDetails(
                         analyzeIssue,
                         applicable,
                         rulesFullDescription.get(analyzeIssue.ruleId)
                     );
-                    analyzeIssue.locations.forEach(location => {
+                    analyzeIssue.locations.forEach((location: AnalyzeLocation) => {
                         let fileIssues: FileIssues = this.getOrCreateFileIssues(applicableDetails, location.physicalLocation.artifactLocation.uri);
                         fileIssues.locations.push(location.physicalLocation.region);
                     });

--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -90,20 +90,22 @@ export class ApplicabilityRunner extends BinaryRunner {
         if (issues) {
             // Generate applicable data for all the issues
             issues.forEach(analyzeIssue => {
-                let applicableDetails: CveApplicableDetails = this.getOrCreateApplicableDetails(
-                    analyzeIssue,
-                    applicable,
-                    rulesFullDescription.get(analyzeIssue.ruleId)
-                );
-                analyzeIssue.locations.forEach(location => {
-                    let fileIssues: FileIssues = this.getOrCreateFileIssues(applicableDetails, location.physicalLocation.artifactLocation.uri);
-                    fileIssues.locations.push(location.physicalLocation.region);
-                });
+                if ((!analyzeIssue.kind || analyzeIssue.kind === 'fail') && analyzeIssue.locations) {
+                    let applicableDetails: CveApplicableDetails = this.getOrCreateApplicableDetails(
+                        analyzeIssue,
+                        applicable,
+                        rulesFullDescription.get(analyzeIssue.ruleId)
+                    );
+                    analyzeIssue.locations.forEach(location => {
+                        let fileIssues: FileIssues = this.getOrCreateFileIssues(applicableDetails, location.physicalLocation.artifactLocation.uri);
+                        fileIssues.locations.push(location.physicalLocation.region);
+                    });
+                }
             });
         }
         // Convert data to a response
         return {
-            scannedCve: run.tool.driver.rules.map(rule => this.getCveFromRuleId(rule.id)),
+            scannedCve: issues.map(issue => this.getCveFromRuleId(issue.ruleId)),
             applicableCve: Object.fromEntries(applicable.entries())
         } as ApplicabilityScanResponse;
     }

--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -82,6 +82,7 @@ export class ApplicabilityRunner extends BinaryRunner {
         }
         // Prepare
         let applicable: Map<string, CveApplicableDetails> = new Map<string, CveApplicableDetails>();
+        let scanned: Set<string> = new Set<string>();
         let rulesFullDescription: Map<string, string> = new Map<string, string>();
         for (const rule of run.tool.driver.rules) {
             rulesFullDescription.set(rule.id, rule.fullDescription.text);
@@ -101,11 +102,12 @@ export class ApplicabilityRunner extends BinaryRunner {
                         fileIssues.locations.push(location.physicalLocation.region);
                     });
                 }
+                scanned.add(this.getCveFromRuleId(analyzeIssue.ruleId));
             });
         }
         // Convert data to a response
         return {
-            scannedCve: issues.map(issue => this.getCveFromRuleId(issue.ruleId)),
+            scannedCve: Object.values(scanned),
             applicableCve: Object.fromEntries(applicable.entries())
         } as ApplicabilityScanResponse;
     }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/virtualEnvPypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/virtualEnvPypiTree.ts
@@ -29,7 +29,7 @@ export class VirtualEnvPypiTree extends PypiTreeNode {
     public toEnvironmentTreeNode() {
         return new EnvironmentTreeNode(this.virtualEnvironmentPath, this.generalInfo.pkgType);
     }
-    
+
     public toDependencyScanResults() {
         return {
             type: this.generalInfo.pkgType,

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -553,19 +553,13 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
         descriptorNode: DescriptorTreeNode,
         abortController: AbortController
     ): Promise<void> {
-        let cveToScan: string[] = [];
+        let cvesToScan: string[] = [];
         descriptorNode.issues.forEach(issue => {
-            if (
-                issue instanceof CveTreeNode &&
-                !issue.parent.indirect &&
-                issue.cve &&
-                issue.cve.cve &&
-                !cveToScan.find(i => issue.cve && i == issue.cve.cve)
-            ) {
-                cveToScan.push(issue.cve.cve);
+            if (issue instanceof CveTreeNode && !issue.parent.indirect && issue.cve?.cve && !cvesToScan.includes(issue.cve?.cve)) {
+                cvesToScan.push(issue.cve.cve);
             }
         });
-        if (cveToScan.length == 0) {
+        if (cvesToScan.length == 0) {
             return;
         }
         this._logManager.logMessage('Scanning descriptor ' + descriptorIssues.fullPath + ' for cve applicability issues', 'INFO');
@@ -574,7 +568,7 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
         descriptorIssues.applicableIssues = await this._scanManager.scanApplicability(
             path.dirname(descriptorIssues.fullPath),
             abortController,
-            cveToScan
+            cvesToScan
         );
 
         if (descriptorIssues.applicableIssues && descriptorIssues.applicableIssues.applicableCve) {

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -555,7 +555,13 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
     ): Promise<void> {
         let cveToScan: string[] = [];
         descriptorNode.issues.forEach(issue => {
-            if (issue instanceof CveTreeNode && issue.cve && issue.cve.cve && !cveToScan.find(i => issue.cve && i == issue.cve.cve)) {
+            if (
+                issue instanceof CveTreeNode &&
+                !issue.parent.indirect &&
+                issue.cve &&
+                issue.cve.cve &&
+                !cveToScan.find(i => issue.cve && i == issue.cve.cve)
+            ) {
                 cveToScan.push(issue.cve.cve);
             }
         });

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -137,7 +137,7 @@ export class AnalyzerUtils {
                             searchTarget: details.fullDescription,
                             evidence: evidences
                         } as IApplicableDetails;
-                    } else if (!node.parent.indirect) {
+                    } else {
                         // Not applicable
                         node.severity = SeverityUtils.notApplicable(node.severity);
                         node.applicableDetails = { isApplicable: false } as IApplicableDetails;


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fix parsing the applicable scan result.
We also get now the pass result (i.e the not applicable CVE) we don't need to infer those our self.
pass result does not contain location