### PR TITLE
Promote jfrog-client-js to version to 2.6.2, fix impact root name and test for mac

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
             - name: Install
               run: npm i
               # Make sure no new dependencies were installed after running 'npm i'
-            - name: Setup Maven v3.8.7 for Windows
+            - name: Setup Maven v3.8.7 for Windows and MAC
               uses: stCarolas/setup-maven@v4.5
               with:
                 maven-version: 3.8.7
-                if: runner.os == 'Windows'
+                if: runner.os == 'Windows' || runner.os == 'macOS'
             - name: Make sure branch is clean
               run: git diff --exit-code
             - name: Lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "adm-zip": "~0.5.9",
                 "fs-extra": "~10.1.0",
-                "jfrog-client-js": "github:jfrog/jfrog-client-js#master",
+                "jfrog-client-js": "^2.6.2",
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.1.20.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
@@ -3626,9 +3626,9 @@
             }
         },
         "node_modules/jfrog-client-js": {
-            "version": "2.6.1",
-            "resolved": "git+ssh://git@github.com/jfrog/jfrog-client-js.git#7d9962d2aa312de78413b9f4fd263d53c8882814",
-            "license": "Apache-2.0",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.6.2.tgz",
+            "integrity": "sha512-3jQKpjiklv2RlA+g8jUiOoz0SH2/W1v8qTw0M7R4MSyLHkm4kOr67/gN22dz7Qa06Dd3iBRmlBpjFMiQC2796A==",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5"

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "dependencies": {
         "adm-zip": "~0.5.9",
         "fs-extra": "~10.1.0",
-        "jfrog-client-js": "github:jfrog/jfrog-client-js#master",
+        "jfrog-client-js": "^2.6.2",
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.1.20.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -35,12 +35,18 @@ export class DependencyUtils {
             let issue: IVulnerability = issues[i];
             for (let [componentId, component] of Object.entries(issue.components)) {
                 paths.set(issue.issue_id + componentId, {
-                    name: descriptorGraph.componentId,
+                    name: this.getGraphName(descriptorGraph),
                     children: this.getChildrenImpact(descriptorGraph, component)
                 } as IImpactGraph);
             }
         }
         return paths;
+    }
+
+    private static getGraphName(descriptorGraph: RootNode): string {
+        return descriptorGraph.componentId.endsWith(':')
+            ? descriptorGraph.componentId.slice(0, descriptorGraph.componentId.length - 1)
+            : descriptorGraph.componentId;
     }
 
     /**


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
