### PR TITLE
Fix resource download temp path for windows

### DIFF
--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -38,7 +38,7 @@ export class Resource {
      * @returns the full path of the file that was downloaded successfully, undefined otherwise
      */
     private async download(downloadToFolder: string = this._targetDir): Promise<string> {
-        let resourcePath: string = path.join(downloadToFolder, Utils.getLastSegment(this.sourceUrl));
+        let resourcePath: string = path.join(downloadToFolder, this.sourceUrl.substring(this.sourceUrl.lastIndexOf('/') + 1));
         await this._connectionManager
             .artifactory()
             .download()
@@ -99,7 +99,7 @@ export class Resource {
         if (this._targetPath.endsWith('.zip')) {
             return this._targetPath;
         }
-        let extensionIdx: number = this.name.indexOf('.');
+        let extensionIdx: number = this.name.lastIndexOf('.');
         let cleanName: string = extensionIdx > 0 ? this.name.substring(0, extensionIdx) : this.name;
         return Utils.addZipSuffix(path.join(this._targetDir, cleanName));
     }

--- a/src/test/tests/resource.test.ts
+++ b/src/test/tests/resource.test.ts
@@ -100,7 +100,7 @@ describe('Resource Tests', () => {
 
     function createTestResource(testCase: any, testDir: string): Resource {
         return new Resource(
-            testCase.target,
+            'baseURL/' + testCase.target,
             path.join(testDir, testCase.target),
             logManager,
             ConnectionUtils.createJfrogClient(SERVER_URL, SERVER_URL + '/artifactory', '', '', '', '')


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Parsing Url as path failed at windows.