### PR TITLE
Fix relative path display for file in windows

### DIFF
--- a/src/main/treeDataProviders/issuesTree/fileTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/fileTreeNode.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ContextKeys } from '../../constants/contextKeys';
 
 import { Severity, SeverityUtils } from '../../types/severity';
@@ -46,7 +47,7 @@ export abstract class FileTreeNode extends vscode.TreeItem {
         if (this._parent && this._fullPath.startsWith(this._parent.workSpace.uri.fsPath)) {
             let localPath: string = this._fullPath.substring(this._parent.workSpace.uri.fsPath.length + 1);
             if (localPath !== this.name) {
-                description = './' + localPath;
+                description = '.' + path.sep + localPath;
             } else {
                 description = undefined;
             }

--- a/src/test/tests/fileTreeNode.test.ts
+++ b/src/test/tests/fileTreeNode.test.ts
@@ -87,7 +87,7 @@ describe('File Node Tests', () => {
             // Parent in path and parent is not root
             testNode.parent = new IssuesRootTreeNode({ uri: { fsPath: path.join('root') } as vscode.Uri } as vscode.WorkspaceFolder);
             testNode.apply();
-            assert.equal(testNode.description, './' + path.join('folder', 'path'));
+            assert.equal(testNode.description, '.' + path.sep + path.join('folder', 'path'));
         });
     });
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

`./ec2\main.tf` --> `.\ec2\main.tf`

![image](https://user-images.githubusercontent.com/49212512/221406843-153ff715-4004-4815-ad24-757595c8a317.png)
