### PR TITLE
Add warnning log if checksum header not exists

### DIFF
--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -44,7 +44,11 @@ export class Resource {
             .download()
             .downloadArtifactToFile(this.sourceUrl, resourcePath);
         if (!(await this.isLocalAndRemoteChecksumMatch(resourcePath))) {
-            throw Error('Local checksum is not match to the remote');
+            if (this._cacheRemoteSha256) {
+                throw Error('Local checksum is not match to the remote');
+            } else {
+                this._logManager.logMessage("Can't get remote checksum header for resource " + this.name, 'WARN');
+            }
         }
         return resourcePath;
     }

--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -47,7 +47,7 @@ export class Resource {
             if (this._cacheRemoteSha256) {
                 throw Error('Local checksum is not match to the remote');
             } else {
-                this._logManager.logMessage("Can't get remote checksum header for resource " + this.name, 'WARN');
+                this._logManager.logMessage("Can't get 'x-checksum-sha256' header from " + this.sourceUrl, 'WARN');
             }
         }
         return resourcePath;


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

If the remote checksum could not be fetched or not exists in the header:
1. Add warning log to inform the user
2. Continue update without comparing and replace old files even if they are the same