### PR TITLE
Add tests to translators for webview and analyzer

### DIFF
--- a/src/test/tests/translators.test.ts
+++ b/src/test/tests/translators.test.ts
@@ -11,17 +11,16 @@ import { Translators } from '../../main/utils/translators';
 describe('Translators Tests', () => {
     it('toAnalyzerLogLevel', async () => {
         [
-            { extLevel: 'DEBUG', analyzerLevel: 'debug' },
-            { extLevel: 'INFO', analyzerLevel: 'info' },
-            { extLevel: 'WARN', analyzerLevel: 'error' },
-            { extLevel: 'ERR', analyzerLevel: 'error' }
+            { inputLevel: 'DEBUG', expectedLevel: 'debug' },
+            { inputLevel: 'INFO', expectedLevel: 'info' },
+            { inputLevel: 'WARN', expectedLevel: 'error' },
+            { inputLevel: 'ERR', expectedLevel: 'error' }
         ].forEach(test => {
-            assert.equal(test.analyzerLevel, Translators.toAnalyzerLogLevel(<LogLevel>test.extLevel));
+            assert.equal(test.expectedLevel, Translators.toAnalyzerLogLevel(<LogLevel>test.inputLevel));
         });
     });
 
     it('toWebViewICve', async () => {
-        //
         let cve: IGraphCve = {
             cve: 'cve',
             cvss_v2_score: 'score v2',


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
