### PR TITLE
Only add protocol prefix if proxy is from config

### DIFF
--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -141,15 +141,15 @@ export abstract class BinaryRunner {
             if (optional) {
                 let proxyConfig: IProxyConfig = <IProxyConfig>optional;
                 let proxyUrl: string = proxyConfig.host + (proxyConfig.port !== 0 ? ':' + proxyConfig.port : '');
-                proxyHttpUrl = proxyUrl;
-                proxyHttpsUrl = proxyUrl;
+                proxyHttpUrl = 'http://' + proxyUrl;
+                proxyHttpsUrl = 'https://' + proxyUrl;
             }
             // Proxy url
             if (proxyHttpUrl) {
-                binaryVars.HTTP_PROXY = 'http://' + this.addOptionalProxyAuthInformation(proxyHttpUrl);
+                binaryVars.HTTP_PROXY = this.addOptionalProxyAuthInformation(proxyHttpUrl);
             }
             if (proxyHttpsUrl) {
-                binaryVars.HTTPS_PROXY = 'https://' + this.addOptionalProxyAuthInformation(proxyHttpsUrl);
+                binaryVars.HTTPS_PROXY = this.addOptionalProxyAuthInformation(proxyHttpsUrl);
             }
 
             return {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
We only need to add the protocol prefix if we are getting the proxy URL from the VS-code config and not from the Environment variables