### PR TITLE
Add timeout to analyzer scans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "typescript": "^4.7.2",
                 "vsce": "^2.9.0",
                 "vscode-test": "^1.6.1",
-                "webpack": "^5.72.1",
+                "webpack": "^5.76.0",
                 "webpack-cli": "^4.9.2"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
         "typescript": "^4.7.2",
         "vsce": "^2.9.0",
         "vscode-test": "^1.6.1",
-        "webpack": "^5.72.1",
+        "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2"
     },
     "keywords": [

--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -186,7 +186,10 @@ export class ScanManager implements ExtensionComponent {
             return {} as ApplicabilityScanResponse;
         }
         let skipFiles: string[] = AnalyzerUtils.getApplicableExcludePattern(Configuration.getScanExcludePattern());
-        this._logManager.logMessage('Scanning directory ' + directory + ', for CVE issues: ' + cveToRun + ', skipping files: ' + skipFiles, 'DEBUG');
+        this._logManager.logMessage(
+            'Scanning directory ' + directory + ', for CVE issues: ' + Array.from(cveToRun.values()) + ', skipping files: ' + skipFiles,
+            'DEBUG'
+        );
         return applicableRunner.scan(directory, checkCancel, cveToRun, skipFiles);
     }
 

--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -167,7 +167,7 @@ export class ScanManager implements ExtensionComponent {
     /**
      * Scan CVE in files for applicability issues.
      * @param directory - the directory that will be scan
-     * @param checkCancel - check if cancel
+     * @param checkCancel - check if should cancel
      * @param cveToRun - the CVE list we want to run applicability scan on
      * @returns the applicability scan response
      */

--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -23,8 +23,6 @@ import { Utils } from '../utils/utils';
  * Manage all the Xray scans
  */
 export class ScanManager implements ExtensionComponent {
-    // every 1 sec
-    private static readonly BINARY_ABORT_CHECK_INTERVAL_MILLISECS: number = 1000;
     // every day
     private static readonly RESOURCE_CHECK_UPDATE_INTERVAL_MILLISECS: number = 1000 * 60 * 60 * 24;
 
@@ -142,18 +140,14 @@ export class ScanManager implements ExtensionComponent {
      * Validate if the applicable-scan is supported
      */
     public isApplicableSupported(): boolean {
-        return new ApplicabilityRunner(
-            this._connectionManager,
-            ScanManager.BINARY_ABORT_CHECK_INTERVAL_MILLISECS,
-            this._logManager
-        ).validateSupported();
+        return new ApplicabilityRunner(this._connectionManager, ScanUtils.ANALYZER_TIMEOUT_MILLISECS, this._logManager).validateSupported();
     }
 
     /**
      * Validate if the eos-scan is supported
      */
     public isEosSupported(): boolean {
-        return new EosRunner(this._connectionManager, ScanManager.BINARY_ABORT_CHECK_INTERVAL_MILLISECS, this._logManager).validateSupported();
+        return new EosRunner(this._connectionManager, ScanUtils.ANALYZER_TIMEOUT_MILLISECS, this._logManager).validateSupported();
     }
 
     /**
@@ -173,18 +167,18 @@ export class ScanManager implements ExtensionComponent {
     /**
      * Scan CVE in files for applicability issues.
      * @param directory - the directory that will be scan
-     * @param abortController - the abort controller for cancel request
+     * @param checkCancel - check if cancel
      * @param cveToRun - the CVE list we want to run applicability scan on
      * @returns the applicability scan response
      */
     public async scanApplicability(
         directory: string,
-        abortController: AbortController,
+        checkCancel: () => void,
         cveToRun: Set<string> = new Set<string>()
     ): Promise<ApplicabilityScanResponse> {
         let applicableRunner: ApplicabilityRunner = new ApplicabilityRunner(
             this._connectionManager,
-            ScanManager.BINARY_ABORT_CHECK_INTERVAL_MILLISECS,
+            ScanUtils.ANALYZER_TIMEOUT_MILLISECS,
             this._logManager
         );
         if (!applicableRunner.validateSupported()) {
@@ -193,11 +187,11 @@ export class ScanManager implements ExtensionComponent {
         }
         let skipFiles: string[] = AnalyzerUtils.getApplicableExcludePattern(Configuration.getScanExcludePattern());
         this._logManager.logMessage('Scanning directory ' + directory + ', for CVE issues: ' + cveToRun + ', skipping files: ' + skipFiles, 'DEBUG');
-        return applicableRunner.scan(directory, abortController, cveToRun, skipFiles);
+        return applicableRunner.scan(directory, checkCancel, cveToRun, skipFiles);
     }
 
-    public async scanEos(abortController: AbortController, ...requests: EosScanRequest[]): Promise<EosScanResponse> {
-        let eosRunner: EosRunner = new EosRunner(this._connectionManager, ScanManager.BINARY_ABORT_CHECK_INTERVAL_MILLISECS, this._logManager);
+    public async scanEos(checkCancel: () => void, ...requests: EosScanRequest[]): Promise<EosScanResponse> {
+        let eosRunner: EosRunner = new EosRunner(this._connectionManager, ScanUtils.ANALYZER_TIMEOUT_MILLISECS, this._logManager);
         if (!eosRunner.validateSupported()) {
             this._logManager.logMessage('Eos scan is not supported', 'DEBUG');
             return {} as EosScanResponse;
@@ -212,6 +206,6 @@ export class ScanManager implements ExtensionComponent {
             }
         }
         this._logManager.logMessage('Scanning for Eos issues, roots: ' + eosRequests.map(request => request.roots.join()).join(), 'DEBUG');
-        return eosRunner.scan(abortController, ...eosRequests);
+        return eosRunner.scan(checkCancel, ...eosRequests);
     }
 }

--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -38,8 +38,8 @@ export class ApplicabilityRunner extends BinaryRunner {
     }
 
     /** @override */
-    public async runBinary(abortSignal: AbortSignal, yamlConfigPath: string, executionLogDirectory: string): Promise<void> {
-        await this.executeBinary(abortSignal, ['ca', yamlConfigPath], executionLogDirectory);
+    public async runBinary(checkCancel: () => void, yamlConfigPath: string, executionLogDirectory: string): Promise<void> {
+        await this.executeBinary(checkCancel, ['ca', yamlConfigPath], executionLogDirectory);
     }
 
     /** @override */
@@ -51,14 +51,14 @@ export class ApplicabilityRunner extends BinaryRunner {
     /**
      * Scan for applicability issues
      * @param directory - the directory the scan will perform on its files
-     * @param abortController - the controller that signals abort for the operation
+     * @param checkCancel - check if cancel
      * @param cvesToRun - the CVEs to run the scan on
      * @param skipFolders - the subfolders inside the directory to exclude from the scan
      * @returns the response generated from the scan
      */
     public async scan(
         directory: string,
-        abortController: AbortController,
+        checkCancel: () => void,
         cveToRun: Set<string> = new Set<string>(),
         skipFolders: string[] = []
     ): Promise<ApplicabilityScanResponse> {
@@ -68,7 +68,7 @@ export class ApplicabilityRunner extends BinaryRunner {
             cve_whitelist: Array.from(cveToRun),
             skipped_folders: skipFolders
         } as ApplicabilityScanRequest;
-        return this.run(abortController, false, request).then(response => this.generateResponse(response?.runs[0]));
+        return this.run(checkCancel, false, request).then(response => this.generateResponse(response?.runs[0]));
     }
 
     /**

--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -91,10 +91,9 @@ export abstract class BinaryRunner {
      * @param executionLogDirectory - the directory to save the execution log in
      */
     protected async executeBinary(checkCancel: () => void, args: string[], executionLogDirectory: string): Promise<void> {
-        await RunUtils.runWithTimeout(
-            this._abortCheckInterval,
-            checkCancel,
-            ScanUtils.executeCmdAsync(
+        await RunUtils.runWithTimeout(this._abortCheckInterval, checkCancel, {
+            title: this._binary.name,
+            task: ScanUtils.executeCmdAsync(
                 '"' + this._binary.fullPath + '" ' + args.join(' '),
                 this._runDirectory,
                 this.createEnvForRun(executionLogDirectory)
@@ -106,7 +105,7 @@ export abstract class BinaryRunner {
                     this._logManager.logMessage("Done executing '" + this._binary.name + "' with error, error log:\n" + std.stderr, 'ERR');
                 }
             })
-        );
+        });
     }
 
     /**

--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -25,8 +25,6 @@ interface RunArgs {
     directory: string;
     // The requests for the run
     requests: RunRequest[];
-    // The signal to abort the operation
-    signal: AbortSignal;
 }
 
 interface RunRequest {
@@ -72,11 +70,11 @@ export abstract class BinaryRunner {
 
     /**
      * Run the executeBinary method with the provided request path
-     * @param abortSignal - signal to abort the operation
+     * @param checkCancel - check if cancel
      * @param yamlConfigPath - the path to the request
      * @param executionLogDirectory - og file will be written to the dir
      */
-    public abstract runBinary(abortSignal: AbortSignal, yamlConfigPath: string, executionLogDirectory: string): Promise<void>;
+    public abstract runBinary(checkCancel: () => void, yamlConfigPath: string, executionLogDirectory: string): Promise<void>;
 
     /**
      * Validates that the binary exists and can run
@@ -88,14 +86,14 @@ export abstract class BinaryRunner {
 
     /**
      * Execute the cmd command to run the binary with given arguments and an option to abort the operation.
-     * Checks every this._abortCheckInterval to see if the abort signal was given
-     * @param abortSignal - the signal to abort the operation
-     * @param args - the arguments for the command
+     * @param checkCancel - check if cancel
+     * @param args  - the arguments for the command
+     * @param executionLogDirectory - the directory to save the execution log in
      */
-    protected async executeBinary(abortSignal: AbortSignal, args: string[], executionLogDirectory: string): Promise<void> {
-        await RunUtils.withAbortSignal(
-            abortSignal,
+    protected async executeBinary(checkCancel: () => void, args: string[], executionLogDirectory: string): Promise<void> {
+        await RunUtils.runWithTimeout(
             this._abortCheckInterval,
+            checkCancel,
             ScanUtils.executeCmdAsync(
                 '"' + this._binary.fullPath + '" ' + args.join(' '),
                 this._runDirectory,
@@ -231,12 +229,12 @@ export abstract class BinaryRunner {
 
     /**
      * Run the runner async, and perform the given run requests using this binary.
-     * @param abortController - the abort controller that signals on a cancel/abort request
+     * @param checkCancel - check if cancel
      * @param split - if true the runner will be run separately for all the requests otherwise all the requests will be performed together
      * @param requests - the request to perform using this binary
      * @returns - the binary analyzer scan response after running for all the request
      */
-    public async run(abortController: AbortController, split: boolean, ...requests: AnalyzeScanRequest[]): Promise<AnalyzerScanResponse | undefined> {
+    public async run(checkCancel: () => void, split: boolean, ...requests: AnalyzeScanRequest[]): Promise<AnalyzerScanResponse | undefined> {
         // Prepare and validate
         if (!this.validateSupported()) {
             return undefined;
@@ -245,8 +243,7 @@ export abstract class BinaryRunner {
             directory: ScanUtils.createTmpDir(),
             split: split,
             activeTasks: 0,
-            requests: [],
-            signal: abortController.signal
+            requests: []
         } as RunArgs;
         let validRequest: AnalyzeScanRequest | undefined = this.prepareRequests(args, ...requests);
         if (args.requests.length == 0 || !validRequest) {
@@ -255,7 +252,7 @@ export abstract class BinaryRunner {
         }
         // Run
         let runs: Promise<any>[] = [];
-        let aggResponse: AnalyzerScanResponse = this.populateRunTasks(args, runs);
+        let aggResponse: AnalyzerScanResponse = this.populateRunTasks(checkCancel, args, runs);
         let hadError: boolean = false;
         await Promise.all(runs)
             .catch(err => {
@@ -275,11 +272,11 @@ export abstract class BinaryRunner {
         return aggResponse;
     }
 
-    private populateRunTasks(args: RunArgs, runs: Promise<any>[]): AnalyzerScanResponse {
+    private populateRunTasks(checkCancel: () => void, args: RunArgs, runs: Promise<any>[]): AnalyzerScanResponse {
         let aggResponse: AnalyzerScanResponse = { runs: [] } as AnalyzerScanResponse;
         for (let i: number = 0; i < args.requests.length; i++) {
             runs.push(
-                this.runRequest(args.signal, args.requests[i].request, args.requests[i].requestPath, ...args.requests[i].responsePaths)
+                this.runRequest(checkCancel, args.requests[i].request, args.requests[i].requestPath, ...args.requests[i].responsePaths)
                     .then(response => {
                         if (response && response.runs) {
                             aggResponse.runs.push(...response.runs);
@@ -329,14 +326,14 @@ export abstract class BinaryRunner {
      * 1. Save the request in a given path
      * 2. Run the binary
      * 3. Collect the responses for each run in the request
-     * @param abortSignal - signal to abort the operation
+     * @param checkCancel - check if cancel
      * @param request - the request to perform in YAML format
      * @param requestPath - the path that the request will be
      * @param responsePaths - the path of the response for each request in the run
      * @returns the response from all the binary runs
      */
     private async runRequest(
-        abortSignal: AbortSignal,
+        checkCancel: () => void,
         request: string,
         requestPath: string,
         ...responsePaths: string[]
@@ -344,7 +341,7 @@ export abstract class BinaryRunner {
         // 1. Save requests as yaml file in folder
         fs.writeFileSync(requestPath, request);
         // 2. Run the binary
-        await this.runBinary(abortSignal, requestPath, path.dirname(requestPath)).catch(error => {
+        await this.runBinary(checkCancel, requestPath, path.dirname(requestPath)).catch(error => {
             if (error.code) {
                 // Not entitled to run binary
                 if (error.code === BinaryRunner.NOT_ENTITLED) {

--- a/src/main/scanLogic/scanRunners/eosScan.ts
+++ b/src/main/scanLogic/scanRunners/eosScan.ts
@@ -72,21 +72,21 @@ export class EosRunner extends BinaryRunner {
     }
 
     /** @override */
-    public async runBinary(abortSignal: AbortSignal, yamlConfigPath: string, executionLogDirectory: string): Promise<void> {
-        await this.executeBinary(abortSignal, ['analyze', 'config', yamlConfigPath], executionLogDirectory);
+    public async runBinary(checkCancel: () => void, yamlConfigPath: string, executionLogDirectory: string): Promise<void> {
+        await this.executeBinary(checkCancel, ['analyze', 'config', yamlConfigPath], executionLogDirectory);
     }
 
     /**
      * Scan for EOS issues
-     * @param abortController - the controller that signals abort for the operation
+     * @param checkCancel - check if cancel
      * @param requests - requests to run
      * @returns the response generated from the scan
      */
-    public async scan(abortController: AbortController, ...requests: EosScanRequest[]): Promise<EosScanResponse> {
+    public async scan(checkCancel: () => void, ...requests: EosScanRequest[]): Promise<EosScanResponse> {
         for (const request of requests) {
             request.type = 'analyze-codebase';
         }
-        return await this.run(abortController, true, ...requests).then(runResult => this.generateScanResponse(runResult));
+        return await this.run(checkCancel, true, ...requests).then(runResult => this.generateScanResponse(runResult));
     }
 
     /**

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -174,8 +174,10 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
         let progressManager: StepProgress = new StepProgress(
             progress,
             () => {
-                this.onChangeFire();
                 checkCanceled();
+            },
+            () => {
+                this.onChangeFire();
             },
             this._logManager
         );

--- a/src/main/treeDataProviders/utils/stepProgress.ts
+++ b/src/main/treeDataProviders/utils/stepProgress.ts
@@ -1,8 +1,6 @@
 import { XrayScanProgress } from 'jfrog-client-js';
 import * as vscode from 'vscode';
 import { LogManager } from '../../log/logManager';
-import { ScanCancellationError } from '../../utils/scanUtils';
-
 /**
  * Manage the vscode.Progress with steps and substeps if needed
  */
@@ -12,22 +10,26 @@ export class StepProgress {
     private currentStepMsg?: string;
     private currentStepsDone: number = 0;
     private currentSubstepsCount?: number;
-    public abortController: AbortController;
 
     constructor(
         private _progress: vscode.Progress<{ message?: string; increment?: number }>,
-        public onProgress: () => void = () => {
-            //
-        },
+        public checkCancel: () => void = () => undefined,
+        private activateOnProgress?: () => void,
         private _log?: LogManager,
         totalSteps?: number
     ) {
         this._totalSteps = totalSteps ?? 1;
-        this.abortController = new AbortController();
     }
 
     public get totalSteps(): number | undefined {
         return this._totalSteps;
+    }
+
+    public onProgress() {
+        this.checkCancel();
+        if (this.activateOnProgress) {
+            this.activateOnProgress();
+        }
     }
 
     /**
@@ -41,19 +43,7 @@ export class StepProgress {
         this.currentStepsDone++;
         this.currentStepMsg = msg + (this._totalSteps > 1 ? ' (' + this.currentStepsDone + '/' + this._totalSteps + ')' : '');
         this.currentSubstepsCount = subSteps && subSteps > 0 ? subSteps : undefined;
-        this._progress.report({ message: this.currentStepMsg });
-        this.activateOnProgress();
-    }
-
-    public activateOnProgress() {
-        try {
-            this.onProgress();
-        } catch (error) {
-            if (error instanceof ScanCancellationError) {
-                this.abortController.abort();
-                throw error;
-            }
-        }
+        this.reportProgress(0);
     }
 
     /**
@@ -71,8 +61,8 @@ export class StepProgress {
     public reportProgress(inc: number = this.getStepIncValue) {
         if (this.currentStepMsg) {
             this._progress.report({ message: this.currentStepMsg, increment: inc });
-            this.activateOnProgress();
         }
+        this.onProgress();
     }
 
     /**
@@ -87,17 +77,15 @@ export class StepProgress {
 
 export class GraphScanProgress implements XrayScanProgress {
     private lastPercentage: number = 0;
-    public readonly abortController: AbortController;
     public readonly onProgress: () => void;
 
     constructor(private _scanName: string, private _manager: StepProgress, private _totalProgress: number, private _log?: LogManager) {
-        this.abortController = this._manager.abortController;
-        this.onProgress = this._manager.activateOnProgress;
+        this.onProgress = this._manager.checkCancel;
     }
 
     /** @override */
     public setPercentage(percentage: number): void {
-        if (percentage != this.lastPercentage && !this.abortController.signal.aborted) {
+        if (percentage != this.lastPercentage) {
             let inc: number = this._totalProgress * ((percentage - this.lastPercentage) / 100);
             this._log?.logMessage(
                 '[' + this._scanName + '] reported change in progress ' + this.lastPercentage + '% -> ' + percentage + '%',

--- a/src/main/treeDataProviders/utils/stepProgress.ts
+++ b/src/main/treeDataProviders/utils/stepProgress.ts
@@ -85,7 +85,7 @@ export class GraphScanProgress implements XrayScanProgress {
 
     /** @override */
     public setPercentage(percentage: number): void {
-        if (percentage != this.lastPercentage) {
+        if (percentage != this.lastPercentage && percentage < 100) {
             let inc: number = this._totalProgress * ((percentage - this.lastPercentage) / 100);
             this._log?.logMessage(
                 '[' + this._scanName + '] reported change in progress ' + this.lastPercentage + '% -> ' + percentage + '%',

--- a/src/main/utils/runUtils.ts
+++ b/src/main/utils/runUtils.ts
@@ -1,34 +1,37 @@
-import { ScanCancellationError } from './scanUtils';
+import { ScanTimeoutError } from './scanUtils';
 
-interface TasksBundle {
-    activeTasks: number;
-    tasks: Promise<any>[];
-    signal: AbortSignal;
-    checkInterval: number;
+export interface Task<T> {
+    title: string;
+    task: Promise<T>;
 }
 
 export class RunUtils {
+    // every 0.1 sec
+    private static readonly CHECK_INTERVAL_MILLISECS: number = 100;
+
     /**
-     * Creates a Promise that is resolved with an array of results when all of the provided Promises resolve, or rejected when any Promise is rejected or if a given abort signal was given.
-     * @param abortSignal - the signal that can abort and reject all the given promises
-     * @param abortCheckInterval - the interval in milliseconds to check if an abort signal was fired
-     * @param promises - the promises that the new promise will wrap
+     * Creates a Promise that is resolved with an array of results when all of the provided Promises resolve, or rejected when:
+     * 1. Any Promise is rejected.
+     * 2. Cancel was requested.
+     * 3. Timeout reached.
+     * @param timeout - time in millisecs until execution timeout
+     * @param checkCancel - check if cancel was requested
+     * @param tasks - the promises that the new promise will wrap
      * @returns Promise that wrap the given promises
      */
-    public static async withAbortSignal(abortSignal: AbortSignal, abortCheckInterval: number, ...promises: Promise<any>[]): Promise<any[]> {
-        let bundle: TasksBundle = {
-            activeTasks: promises.length,
-            tasks: [],
-            signal: abortSignal,
-            checkInterval: abortCheckInterval
-        };
-        // Add async tasks to execute
-        for (let task of promises) {
-            bundle.tasks.push(task.finally(() => bundle.activeTasks--));
-        }
-        // Add abort task to execute and stop the other tasks if abort signal was given
-        bundle.tasks.push(this.checkIfAbortedTask(bundle));
-        return (await Promise.all(bundle.tasks)).slice(0, promises.length);
+    static async runWithTimeout<T>(timeout: number, checkCancel: () => void, ...tasks: (Promise<T> | Task<T>)[]): Promise<T[]> {
+        let results: T[] = [];
+        const wrappedTasks: Promise<T>[] = <Promise<T>[]>tasks.map(async (task, index) => {
+            let result: T = <T>await Promise.race([
+                // Add task from argument
+                !(task instanceof Promise) && task.task ? task.task : task,
+                // Add task to check if cancel was requested from the user or reached timeout
+                this.checkCancelAndTimeoutTask(!(task instanceof Promise) && task.title ? task.title : '' + index + 1, timeout, checkCancel)
+            ]);
+            results.push(result);
+        });
+        await Promise.all(wrappedTasks);
+        return results;
     }
 
     /**
@@ -36,20 +39,19 @@ export class RunUtils {
      * If the active task is <= 0 the task is completed
      * @param tasksBundle - an object that holds the information about the active async tasks count and the abort signal for them
      */
-    private static async checkIfAbortedTask(tasksBundle: TasksBundle): Promise<void> {
-        while (tasksBundle.activeTasks > 0) {
-            if (tasksBundle.signal.aborted) {
-                throw new ScanCancellationError();
-            }
-            await this.delay(tasksBundle.checkInterval);
+    private static async checkCancelAndTimeoutTask(title: string, timeout: number, checkCancel: () => void): Promise<void> {
+        for (let elapsed: number = 0; elapsed < timeout; elapsed += RunUtils.CHECK_INTERVAL_MILLISECS) {
+            checkCancel();
+            await this.delay(RunUtils.CHECK_INTERVAL_MILLISECS);
         }
+        throw new ScanTimeoutError(title, timeout);
     }
 
     /**
      * Sleep and delay task for sleepIntervalMilliseconds
      * @param sleepIntervalMilliseconds - the amount of time in milliseconds to wait
      */
-    private static async delay(sleepIntervalMilliseconds: number): Promise<void> {
+    public static async delay(sleepIntervalMilliseconds: number): Promise<void> {
         return new Promise(resolve => setTimeout(resolve, sleepIntervalMilliseconds));
     }
 }

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -21,6 +21,8 @@ export class ScanUtils {
 
     public static readonly RESOURCES_DIR: string = ScanUtils.getResourcesDir();
     public static readonly SPAWN_PROCESS_BUFFER_SIZE: number = 104857600;
+    // 5 min
+    public static readonly ANALYZER_TIMEOUT_MILLISECS: number = 1000 * 60 * 5;
 
     public static async scanWithProgress(
         scanCbk: (progress: vscode.Progress<{ message?: string; increment?: number }>, checkCanceled: () => void) => Promise<void>,
@@ -245,7 +247,7 @@ export class ScanUtils {
             logger.logMessage(error.message, 'INFO');
             return undefined;
         }
-        if (handle) {
+        if (handle || error instanceof ScanTimeoutError) {
             logger.logError(error, true);
             return undefined;
         }
@@ -280,4 +282,10 @@ export class FileScanError extends Error {
 
 export class ScanCancellationError extends Error {
     message: string = 'Scan was cancelled';
+}
+
+export class ScanTimeoutError extends Error {
+    constructor(scan: string, public time_millisecs: number) {
+        super(`Task ${scan} timed out after ${time_millisecs}ms`);
+    }
 }

--- a/src/test/tests/runUtils.test.ts
+++ b/src/test/tests/runUtils.test.ts
@@ -1,0 +1,89 @@
+import { assert } from 'chai';
+import { RunUtils, Task } from '../../main/utils/runUtils';
+import { ScanCancellationError, ScanTimeoutError } from '../../main/utils/scanUtils';
+
+describe('Run Utils tests', async () => {
+    [
+        {
+            name: 'Task ended',
+            timeout: false,
+            shouldAbort: false,
+            addTitle: undefined,
+            expectedErr: undefined
+        },
+        {
+            name: 'Task aborted',
+            timeout: false,
+            shouldAbort: true,
+            addTitle: undefined,
+            expectedErr: new ScanCancellationError()
+        },
+        {
+            name: 'Task timeout with title',
+            timeout: true,
+            shouldAbort: false,
+            addTitle: "'TitledTask'",
+            expectedErr: new ScanTimeoutError("'TitledTask'", 100)
+        },
+        {
+            name: 'Task timeout no title',
+            timeout: true,
+            shouldAbort: false,
+            addTitle: undefined,
+            expectedErr: new Error()
+        },
+        {
+            name: 'Task throws error',
+            timeout: false,
+            shouldAbort: false,
+            addTitle: undefined,
+            expectedErr: new Error('general error')
+        }
+    ].forEach(async test => {
+        it('Run with abort controller - ' + test.name, async () => {
+            let tasks: (Promise<number> | Task<number>)[] = [];
+            let expectedResults: number[] = [0, 1, 2, 3];
+
+            for (let i: number = 0; i < expectedResults.length; i++) {
+                let task: Promise<number> | Task<number> =
+                    test.name.includes('Task throws error') && i == expectedResults.length - 1
+                        ? RunUtils.delay(200).then(() => {
+                              throw new Error('general error');
+                          })
+                        : RunUtils.delay((expectedResults.length - i) * 200).then(() => {
+                              return i;
+                          });
+                tasks.push(test.addTitle ? ({ title: test.addTitle, task: task } as Task<number>) : task);
+            }
+
+            try {
+                let activeTasks: Promise<any[]> = RunUtils.runWithTimeout(
+                    test.timeout ? 100 : 1000,
+                    () => {
+                        if (test.shouldAbort) {
+                            throw new ScanCancellationError();
+                        }
+                    },
+                    ...tasks
+                );
+                let actualResults: number[] = await activeTasks;
+                if (test.expectedErr) {
+                    assert.fail('Expected run to throw error');
+                }
+                // Make sure all tasks ended
+                assert.sameMembers(actualResults, expectedResults);
+            } catch (err) {
+                if (!test.expectedErr) {
+                    assert.fail('Expected run not to throw error but got ' + err);
+                }
+                if (err instanceof Error) {
+                    if (test.timeout && !test.addTitle) {
+                        assert.include(err.message, 'timed out after');
+                    } else {
+                        assert.equal(err.message, test.expectedErr.message);
+                    }
+                }
+            }
+        });
+    });
+});


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
* Adding timeout after 5min to each run of analyzer manager binary
* Fix cancel request to apply request for all scans and operations
* Add tests to running tasks with timeout and checking cancel