### PR TITLE
Remove constant maven version for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,6 @@ jobs:
             - name: Install
               run: npm i
               # Make sure no new dependencies were installed after running 'npm i'
-            - name: Setup Maven v3.8.7
-              uses: stCarolas/setup-maven@v4.5
-              with:
-                maven-version: 3.8.7
             - name: Make sure branch is clean
               run: git diff --exit-code
             - name: Lint
@@ -43,6 +39,6 @@ jobs:
               run: npm t
               if: runner.os != 'Linux'
             - name: Tests on Linux
-              # Run tests with Virtual framebuffer to allow running VS-Code without a display
+              # Run tests with Virtual frame buffer to allow running VS-Code without a display
               run: xvfb-run npm t
               if: runner.os == 'Linux'


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
In maven 3.9.0 a bug in apache was included that failed our tests. 
![image](https://user-images.githubusercontent.com/49212512/227867477-1d5c82d7-3cc4-4e03-ac15-d228229d257f.png)

we made sure to run on constant version 3.8.7: https://github.com/jfrog/jfrog-vscode-extension/commit/59723efb1b70d3bd1203cd83de1903ec32619496, https://github.com/jfrog/jfrog-vscode-extension/commit/860c1d2f42653749bf78f0d81dc18933d743c4bc

In version 3.9.1 this bug was fixed and the tests are successful now, we should remove this to use the latest
![image](https://user-images.githubusercontent.com/49212512/227866098-d55220ae-220d-4824-96fb-85d7ba20281d.png)
