### PR TITLE
Promote jfrog-client-js to version to 2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "adm-zip": "~0.5.9",
                 "fs-extra": "~10.1.0",
-                "jfrog-client-js": "^2.6.3",
+                "jfrog-client-js": "^2.6.4",
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.1.21.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
@@ -902,7 +902,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -3205,7 +3204,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -3633,12 +3631,13 @@
             }
         },
         "node_modules/jfrog-client-js": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.6.3.tgz",
-            "integrity": "sha512-TyEHKwh/PdkAnzPj7FtJcFSq6FkJW+8jq2vyoSxwn/wlEjTjmOiYen6qEnJCRsgkkmeYgpOX4I58GGS+e40pHQ==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.6.4.tgz",
+            "integrity": "sha512-YwsShtUfXFsUj/+A+D9+Mg3MN2n3RIVDxfAzkfa0lQfdlIhF2sJsRbdHxVtTH+vG1FoeqGrDmeENjnABLVOlvA==",
             "dependencies": {
                 "axios": "~0.27.2",
-                "axios-retry": "~3.2.5"
+                "axios-retry": "~3.2.5",
+                "https-proxy-agent": "^5.0.1"
             }
         },
         "node_modules/jfrog-ide-webview": {

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "dependencies": {
         "adm-zip": "~0.5.9",
         "fs-extra": "~10.1.0",
-        "jfrog-client-js": "^2.6.3",
+        "jfrog-client-js": "^2.6.4",
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.1.21.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
