### PR TITLE
Add option to set timeout in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,12 @@
                     "default": 3,
                     "scope": "application",
                     "markdownDescription": "Maximum connection retry attempts"
+                },
+                "jfrog.connectionTimeout": {
+                    "type": "number",
+                    "default": 10000,
+                    "scope": "application",
+                    "markdownDescription": "Time in milliseconds before a request times out"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
                     "type": "number",
                     "default": 60,
                     "scope": "application",
-                    "markdownDescription": "Time in seconds before a request times out"
+                    "markdownDescription": "Timeout period before the connection is terminated in seconds"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -123,9 +123,9 @@
                 },
                 "jfrog.connectionTimeout": {
                     "type": "number",
-                    "default": 10000,
+                    "default": 60,
                     "scope": "application",
-                    "markdownDescription": "Time in milliseconds before a request times out"
+                    "markdownDescription": "Time in seconds before a request times out"
                 }
             }
         },

--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -260,7 +260,9 @@ export class ConnectionUtils {
         xrayUrl: string,
         username: string,
         password: string,
-        accessToken: string
+        accessToken: string,
+        retries?: number,
+        timeout?: number
     ): JfrogClient {
         let clientConfig: IJfrogClientConfig = {
             platformUrl: platformUrl,
@@ -271,8 +273,8 @@ export class ConnectionUtils {
             accessToken: accessToken,
             headers: {},
             proxy: ConnectionUtils.getProxyConfig(),
-            retries: Configuration.getConnectionRetries(),
-            timeout: Configuration.getConnectionTimeout()
+            retries: retries ?? Configuration.getConnectionRetries(),
+            timeout: timeout ?? Configuration.getConnectionTimeout()
         } as IJfrogClientConfig;
         ConnectionUtils.addUserAgentHeader(clientConfig);
         ConnectionUtils.addProxyAuthHeader(clientConfig);

--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -271,7 +271,8 @@ export class ConnectionUtils {
             accessToken: accessToken,
             headers: {},
             proxy: ConnectionUtils.getProxyConfig(),
-            retries: Configuration.getConnectionRetries()
+            retries: Configuration.getConnectionRetries(),
+            timeout: Configuration.getConnectionTimeout()
         } as IJfrogClientConfig;
         ConnectionUtils.addUserAgentHeader(clientConfig);
         ConnectionUtils.addProxyAuthHeader(clientConfig);

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -66,10 +66,10 @@ export class Configuration {
     }
 
     /**
-     * @returns the number of connection retries
+     * @returns the time in milliseconds before a request times out
      */
     public static getConnectionTimeout(): number {
-        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('connectionTimeout', 10000);
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('connectionTimeout', 60) * 1000;
     }
 
     /**

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -66,7 +66,7 @@ export class Configuration {
     }
 
     /**
-     * @returns the time in milliseconds before a request times out
+     * @returns timeout in milliseconds
      */
     public static getConnectionTimeout(): number {
         return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('connectionTimeout', 60) * 1000;

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -66,6 +66,13 @@ export class Configuration {
     }
 
     /**
+     * @returns the number of connection retries
+     */
+    public static getConnectionTimeout(): number {
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('connectionTimeout', 10000);
+    }
+
+    /**
      * @returns the encoded proxy authorization if exists
      */
     public static getProxyAuth(): string | undefined {

--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -6,9 +6,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ConnectionManager } from '../../main/connect/connectionManager';
 import { ConnectionUtils } from '../../main/connect/connectionUtils';
-import { ContextKeys, SessionStatus } from '../../main/constants/contextKeys';
 import { LogManager } from '../../main/log/logManager';
-import { getCliHomeDir, setCliHomeDir } from './utils/utils.test';
+import { createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
 
 describe('Connection Manager Tests', () => {
     let connectionManager: ConnectionManager;
@@ -16,21 +15,7 @@ describe('Connection Manager Tests', () => {
         // Don't override existing connection details
         process.env[ConnectionManager.STORE_CONNECTION_ENV] = 'FALSE';
 
-        connectionManager = await new ConnectionManager(new LogManager().activate()).activate({
-            globalState: {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                get(key: string) {
-                    if (key == ContextKeys.SESSION_STATUS) {
-                        return SessionStatus.SignedOut;
-                    }
-                    return;
-                },
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                update(key: string, value: any) {
-                    return;
-                }
-            } as vscode.Memento
-        } as vscode.ExtensionContext);
+        connectionManager = await createTestConnectionManager(new LogManager().activate(), 60, 60000);
     });
 
     it('User agent header', () => {

--- a/src/test/tests/utils/utils.test.ts
+++ b/src/test/tests/utils/utils.test.ts
@@ -5,6 +5,10 @@ import { ConnectionManager } from '../../../main/connect/connectionManager';
 import { ScanCacheManager } from '../../../main/cache/scanCacheManager';
 import { DependenciesTreeNode } from '../../../main/treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { TestMemento } from './testMemento.test';
+import { LogManager } from '../../../main/log/logManager';
+import { ContextKeys, SessionStatus } from '../../../main/constants/contextKeys';
+import { ConnectionUtils } from '../../../main/connect/connectionUtils';
+import { JfrogClient } from 'jfrog-client-js';
 
 export function isWindows(): boolean {
     return os.platform() === 'win32';
@@ -33,8 +37,42 @@ export function createScanCacheManager(): ScanCacheManager {
     } as vscode.ExtensionContext);
 }
 
-export function createConnectionManager(): ConnectionManager {
-    return {} as ConnectionManager;
+export async function createTestConnectionManager(logManager: LogManager, timeout?: number, retry?: number): Promise<ConnectionManager> {
+    return await new ConnectionManagerWrapper(logManager, timeout, retry).activate({
+        globalState: {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get(key: string) {
+                if (key == ContextKeys.SESSION_STATUS) {
+                    return SessionStatus.SignedOut;
+                }
+                return;
+            },
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            update(key: string, value: any) {
+                return;
+            }
+        } as vscode.Memento
+    } as vscode.ExtensionContext);
+}
+
+export class ConnectionManagerWrapper extends ConnectionManager {
+    constructor(logManager: LogManager, private _timeout?: number, private _retry?: number) {
+        super(logManager);
+    }
+
+    /** @override */
+    public createJfrogClient(): JfrogClient {
+        return ConnectionUtils.createJfrogClient(
+            this.url,
+            this.rtUrl,
+            this.xrayUrl,
+            this.username,
+            this.password,
+            this.accessToken,
+            this._retry,
+            this._timeout
+        );
+    }
 }
 
 export function getCliHomeDir(): string {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Also fixes the tests that httpbin always falls, we try 60 time until it passes only for those tests

depend on https://github.com/jfrog/jfrog-vscode-extension/pull/332
that includes https://github.com/jfrog/jfrog-client-js/pull/81
