### PR TITLE
Promote jfrog-client-js to version to 2.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "adm-zip": "~0.5.9",
                 "fs-extra": "~10.1.0",
-                "jfrog-client-js": "^2.6.4",
+                "jfrog-client-js": "^2.6.5",
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.1.21.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
@@ -80,9 +80,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
-            "integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
             "dev": true,
             "dependencies": {
                 "eslint-visitor-keys": "^3.3.0"
@@ -95,23 +95,23 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
-            "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+            "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.0",
+                "espree": "^9.5.1",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -127,9 +127,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+            "version": "8.38.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
+            "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -179,9 +179,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -208,9 +208,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -222,9 +222,9 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -342,9 +342,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.21.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
-            "integrity": "sha512-EMpxUyystd3uZVByZap1DACsMXvb82ypQnGn89e1Y0a+LYu3JJscUd/gqhRsVFDkaD2MIiWo0MT8EfXr3DGRKw==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
+            "integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -360,9 +360,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "0.0.51",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
         },
         "node_modules/@types/fs-extra": {
             "version": "9.0.13",
@@ -412,9 +412,9 @@
             }
         },
         "node_modules/@types/mdast": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-            "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+            "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -437,9 +437,9 @@
             "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "node_modules/@types/node": {
-            "version": "18.15.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
+            "version": "18.15.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.5",
@@ -447,9 +447,9 @@
             "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "node_modules/@types/react": {
-            "version": "18.0.28",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-            "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+            "version": "18.0.37",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.37.tgz",
+            "integrity": "sha512-4yaZZtkRN3ZIQD3KSEwkfcik8s0SWV+82dlJot1AbGYHCzJkWP3ENBY6wYeDRmKZ6HkrgoGAmR2HqdwYGp6OEw==",
             "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
@@ -458,9 +458,9 @@
             }
         },
         "node_modules/@types/scheduler": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+            "version": "0.16.3",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+            "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
             "peer": true
         },
         "node_modules/@types/semver": {
@@ -487,15 +487,15 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.55.0.tgz",
-            "integrity": "sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz",
+            "integrity": "sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
-                "@typescript-eslint/scope-manager": "5.55.0",
-                "@typescript-eslint/type-utils": "5.55.0",
-                "@typescript-eslint/utils": "5.55.0",
+                "@typescript-eslint/scope-manager": "5.59.0",
+                "@typescript-eslint/type-utils": "5.59.0",
+                "@typescript-eslint/utils": "5.59.0",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
@@ -521,14 +521,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.55.0.tgz",
-            "integrity": "sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+            "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.55.0",
-                "@typescript-eslint/types": "5.55.0",
-                "@typescript-eslint/typescript-estree": "5.55.0",
+                "@typescript-eslint/scope-manager": "5.59.0",
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/typescript-estree": "5.59.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -548,13 +548,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
-            "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+            "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.55.0",
-                "@typescript-eslint/visitor-keys": "5.55.0"
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/visitor-keys": "5.59.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -565,13 +565,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.55.0.tgz",
-            "integrity": "sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz",
+            "integrity": "sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.55.0",
-                "@typescript-eslint/utils": "5.55.0",
+                "@typescript-eslint/typescript-estree": "5.59.0",
+                "@typescript-eslint/utils": "5.59.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -592,9 +592,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
-            "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+            "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -605,13 +605,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
-            "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+            "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.55.0",
-                "@typescript-eslint/visitor-keys": "5.55.0",
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/visitor-keys": "5.59.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -632,17 +632,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.55.0.tgz",
-            "integrity": "sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+            "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.55.0",
-                "@typescript-eslint/types": "5.55.0",
-                "@typescript-eslint/typescript-estree": "5.55.0",
+                "@typescript-eslint/scope-manager": "5.59.0",
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/typescript-estree": "5.59.0",
                 "eslint-scope": "^5.1.1",
                 "semver": "^7.3.7"
             },
@@ -658,12 +658,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.55.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
-            "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+            "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.55.0",
+                "@typescript-eslint/types": "5.59.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -1447,9 +1447,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001468",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001468.tgz",
-            "integrity": "sha512-zgAo8D5kbOyUcRAgSmgyuvBkjrGk5CGYG5TYgFdpQv+ywcyEpo1LOWoG8YmoflGnh+V+UsNuKYedsoYs0hzV5A==",
+            "version": "1.0.30001480",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
+            "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1458,6 +1458,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ]
         },
@@ -1700,9 +1704,9 @@
             "dev": true
         },
         "node_modules/colorette": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
         "node_modules/combined-stream": {
@@ -1858,9 +1862,9 @@
             }
         },
         "node_modules/csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
             "peer": true
         },
         "node_modules/d3-ease": {
@@ -2163,9 +2167,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.333",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.333.tgz",
-            "integrity": "sha512-YyE8+GKyGtPEP1/kpvqsdhD6rA/TP1DUFDN4uiU/YI52NzDxmwHkEb3qjId8hLBa5siJvG0sfC3O66501jMruQ=="
+            "version": "1.4.368",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.368.tgz",
+            "integrity": "sha512-e2aeCAixCj9M7nJxdB/wDjO6mbYX+lJJxSJCXDzlr5YPGYVofuJwGN9nKg2o6wWInjX6XmxRinn3AeJMK81ltw=="
         },
         "node_modules/elliptic": {
             "version": "6.5.4",
@@ -2213,9 +2217,9 @@
             }
         },
         "node_modules/entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
             "engines": {
                 "node": ">=0.12"
@@ -2237,9 +2241,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
+            "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
         },
         "node_modules/es6-object-assign": {
             "version": "1.1.0",
@@ -2267,15 +2271,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+            "version": "8.38.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
+            "integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.0.1",
-                "@eslint/js": "8.36.0",
+                "@eslint/eslintrc": "^2.0.2",
+                "@eslint/js": "8.38.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -2286,8 +2290,8 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.5.0",
+                "eslint-visitor-keys": "^3.4.0",
+                "espree": "^9.5.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2324,9 +2328,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-            "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -2348,18 +2352,21 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+            "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -2367,6 +2374,9 @@
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/estraverse": {
@@ -2379,14 +2389,14 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+            "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3163,9 +3173,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -3176,9 +3186,9 @@
             ],
             "dependencies": {
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
+                "domhandler": "^5.0.3",
                 "domutils": "^3.0.1",
-                "entities": "^4.3.0"
+                "entities": "^4.4.0"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -3413,9 +3423,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -3631,9 +3641,9 @@
             }
         },
         "node_modules/jfrog-client-js": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.6.4.tgz",
-            "integrity": "sha512-YwsShtUfXFsUj/+A+D9+Mg3MN2n3RIVDxfAzkfa0lQfdlIhF2sJsRbdHxVtTH+vG1FoeqGrDmeENjnABLVOlvA==",
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.6.5.tgz",
+            "integrity": "sha512-r4Ej7RWOTVqMy7HWyge8gksBgSwLBoX4qFNmriKbh4lHZuHjIGf4WJN5DxOMZvjA/li2JU/ALsbXIexl3lhd/g==",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5",
@@ -3655,9 +3665,9 @@
             }
         },
         "node_modules/js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -4006,9 +4016,9 @@
             }
         },
         "node_modules/mdast-util-to-string": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
-            "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+            "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
             "dependencies": {
                 "@types/mdast": "^3.0.0"
             },
@@ -4761,9 +4771,9 @@
             }
         },
         "node_modules/node-abi": {
-            "version": "3.33.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
-            "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
+            "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -5552,9 +5562,9 @@
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/react-markdown": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.5.tgz",
-            "integrity": "sha512-jGJolWWmOWAvzf+xMdB9zwStViODyyFQhNB/bwCerbBKmrTmgmA599CGiOlP58OId1IMoIRsA8UdI1Lod4zb5A==",
+            "version": "8.0.7",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+            "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
             "dependencies": {
                 "@types/hast": "^2.0.0",
                 "@types/prop-types": "^15.0.0",
@@ -5726,12 +5736,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.9.0",
+                "is-core-module": "^2.11.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -5904,9 +5914,9 @@
             }
         },
         "node_modules/schema-utils": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+            "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -6267,9 +6277,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.16.6",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
-            "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
+            "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
@@ -6683,9 +6693,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-            "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6694,6 +6704,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
@@ -6701,7 +6715,7 @@
                 "picocolors": "^1.0.0"
             },
             "bin": {
-                "browserslist-lint": "cli.js"
+                "update-browserslist-db": "cli.js"
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
@@ -6974,12 +6988,12 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.76.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
-            "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
+            "version": "5.79.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.79.0.tgz",
+            "integrity": "sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
-                "@types/estree": "^0.0.51",
+                "@types/estree": "^1.0.0",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
@@ -6988,7 +7002,7 @@
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^5.10.0",
-                "es-module-lexer": "^0.9.0",
+                "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
@@ -6999,7 +7013,7 @@
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.1.3",
+                "terser-webpack-plugin": "^5.3.7",
                 "watchpack": "^2.4.0",
                 "webpack-sources": "^3.2.3"
             },

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "dependencies": {
         "adm-zip": "~0.5.9",
         "fs-extra": "~10.1.0",
-        "jfrog-client-js": "^2.6.4",
+        "jfrog-client-js": "^2.6.5",
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.1.21.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

add ability to set the timeout for requests
