### PR TITLE
Fix Windows tests for parsing path

### DIFF
--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -113,9 +113,10 @@ export class AnalyzerUtils {
         let isWindows: boolean = os.platform() === 'win32';
         if (isWindows) {
             filePath = filePath.includes('file:///') ? filePath.substring('file:///'.length) : filePath;
+        }
+        filePath = filePath.includes('file://') ? filePath.substring('file://'.length) : filePath;
+        if (isWindows) {
             filePath = filePath.replace(/['/']/g, '\\');
-        } else {
-            filePath = filePath.includes('file://') ? filePath.substring('file://'.length) : filePath;
         }
         return decodeURI(filePath);
     }

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -104,9 +104,9 @@ export class AnalyzerUtils {
     /**
      * The paths that returns from the analyzerManager follows the SARIF format and are encoded, with prefix and fixed (not os depended).
      * This method will parse a given path and will fix it to match the actual path expected by the vscode
-     * * Remove the prefix 'file:///' for windows or 'file://' if exists
-     * * replaces '/' with '\\' for windows
-     * * decode the encoded path
+     * * Remove the prefix 'file:///' for windows or 'file://' if exists.
+     * * replaces '/' with '\\' for windows.
+     * * decode the encoded path.
      * @param filePath - path to remove prefix and decode
      */
     public static parseLocationFilePath(filePath: string): string {

--- a/src/test/tests/analyzerUtils.test.ts
+++ b/src/test/tests/analyzerUtils.test.ts
@@ -34,9 +34,10 @@ describe('Analyzer Utils Tests', async () => {
         });
     });
 
-    [path.join('somewhere', 'file'), path.join('somewhere', 'folder', 'file')].forEach(testCase => {
+    [path.join('somewhere', 'file'), path.join('somewhere', 'folder', 'file'), path.join(__dirname,'file')].forEach(testCase => {
         it('Parse location file path test - ' + testCase, () => {
-            let result: string = AnalyzerUtils.parseLocationFilePath(`file://${testCase.replace(/['\\']/g, '/')}`);
+            let input: string = testCase.replace(/['\\']/g, '/');
+            let result: string = AnalyzerUtils.parseLocationFilePath(`file://${input}`);
             assert.deepEqual(result, testCase);
         });
     });

--- a/src/test/tests/analyzerUtils.test.ts
+++ b/src/test/tests/analyzerUtils.test.ts
@@ -34,7 +34,7 @@ describe('Analyzer Utils Tests', async () => {
         });
     });
 
-    [path.join('somewhere', 'file'), path.join('somewhere', 'folder', 'file'), path.join(__dirname,'file')].forEach(testCase => {
+    [path.join('somewhere', 'file'), path.join('somewhere', 'folder', 'file'), path.join(__dirname, 'file')].forEach(testCase => {
         it('Parse location file path test - ' + testCase, () => {
             let input: string = testCase.replace(/['\\']/g, '/');
             let result: string = AnalyzerUtils.parseLocationFilePath(`file://${input}`);


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
