### PR TITLE
Remove info log when scan not supported

### DIFF
--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -243,7 +243,7 @@ export class ScanUtils {
         if (error instanceof ScanCancellationError) {
             throw error;
         }
-        if (error instanceof NotEntitledError || error instanceof NotSupportedError) {
+        if (error instanceof NotEntitledError) {
             logger.logMessage(error.message, 'INFO');
             return undefined;
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
left over that logs info if scan not supported instead of debug and prevent to log in debug
![image](https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/9bf2afbe-2c46-47a8-a267-91911a439119)
