### PR TITLE
Fix run for whitespace in path of MavenReader

### DIFF
--- a/src/main/utils/mavenUtils.ts
+++ b/src/main/utils/mavenUtils.ts
@@ -404,7 +404,7 @@ export class MavenUtils {
      * Install Maven GAV Reader to maven local repository.
      */
     public static installMavenGavReader() {
-        ScanUtils.executeCmd('mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file -Dfile=' + MavenUtils.MAVEN_GAV_READER);
+        ScanUtils.executeCmd(`mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file -Dfile="${MavenUtils.MAVEN_GAV_READER}"`);
         MavenUtils.mavenGavReaderInstalled = true;
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fixing issue when the user is using a directory with whitespace in it. causes an error when running a maven command that expect a path as an argument causing the parsing of the command to fail.
adding " to wrap the path text to appear as a single argument for all cases