### PR TITLE
Fix connect icon path in resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
             {
                 "command": "jfrog.xray.connect",
                 "title": "Connect",
-                "icon": "resources/readme/connect.png",
+                "icon": "resources/connect.png",
                 "category": "JFrog",
                 "enablement": "!jfrog.scanInProgress"
             },


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
issue:
![image](https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/a5095cdb-5cc8-49f4-9ee9-db8d2e41d84c)
fix:
![image](https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/0983a9a0-b60a-474a-977f-b2008d9ec7a2)
