### PR TITLE
Remove err log if not supported scan

### DIFF
--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -276,7 +276,7 @@ export abstract class BinaryRunner {
                     })
             );
         }
-        let exeErr: Error | undefined = undefined;
+        let exeErr: Error | undefined;
         await Promise.all(runs)
             .catch(err => {
                 exeErr = err;
@@ -288,9 +288,9 @@ export abstract class BinaryRunner {
     }
 
     private handleExecutionLog(args: RunArgs, exeErr: Error | undefined) {
-        let logPath: string | undefined = this.copyRunLogToFolder(args, exeErr !== undefined);
+        let hadError: boolean = exeErr !== undefined;
+        let logPath: string | undefined = this.copyRunLogToFolder(args, hadError);
         if (logPath && !(exeErr instanceof NotSupportedError)) {
-            let hadError: boolean = exeErr !== undefined;
             this._logManager.logMessage(
                 'AnalyzerManager run ' +
                     this._type +


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Removed msg that error log was generated if the error is of type NotSupported

Old:
```
[DEBUG - 12:33:01 PM] iac-scan-modules is not supported in the current Analyzer Manager version
[ERR - 12:33:01 PM] AnalyzerManager run iac-scan-modules on c:\Git\dlp-repo\dlp-cloud ended with error, scan log was generated at C:\Users\pv732260\.jfrog-vscode-extension\issues\logs\dlp-cloud-iac-scan-modules-1687158181150.log
```
New:
```
[DEBUG - 12:33:01 PM] iac-scan-modules is not supported in the current Analyzer Manager version
```
