### PR TITLE
Ignore stderr when invoking npm (#191)

### DIFF
--- a/src/main/utils/cmds/npm.ts
+++ b/src/main/utils/cmds/npm.ts
@@ -12,6 +12,7 @@ export enum Flag {
     Version = ' --version',
     Json = ' --json',
     All = ' --all',
+    Silent = ' --silent',
     PackageLockOnly = ' --package-lock-only',
     // Legacy for npm version 6
     LegacySkipDevDependencies = ' --prod',
@@ -46,7 +47,7 @@ export class NpmCmd {
     }
 
     protected static getNpmLsArgs(projectRoot: string): string {
-        let args: string = `${Flag.Json} ${Flag.All}`;
+        let args: string = `${Flag.Json} ${Flag.All} ${Flag.Silent}`;
         args += this.getSkipDevDependenciesFlag();
         return args + this.getPackageLockOnlyFlag(projectRoot);
     }


### PR DESCRIPTION
- Invoke npm with --silent option to ignore stderr

- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
