### PR TITLE
Fix - Download AnalyzerManager async issue

### DIFF
--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -237,7 +237,7 @@ export class ScanManager implements ExtensionComponent {
     ): Promise<ApplicabilityScanResponse> {
         let applicableRunner: ApplicabilityRunner = new ApplicabilityRunner(this._connectionManager, this._logManager);
         if (!applicableRunner.validateSupported()) {
-            this._logManager.logMessage('Applicability runner could not find binary to run', 'DEBUG');
+            this._logManager.logMessage('Applicability runner could not find binary to run', 'WARN');
             return {} as ApplicabilityScanResponse;
         }
         let skipFiles: string[] = AnalyzerUtils.getAnalyzerManagerExcludePattern(Configuration.getScanExcludePattern());
@@ -257,7 +257,7 @@ export class ScanManager implements ExtensionComponent {
     public async scanIac(directory: string, checkCancel: () => void): Promise<IacScanResponse> {
         let iacRunner: IacRunner = new IacRunner(this._connectionManager, this.logManager);
         if (!iacRunner.validateSupported()) {
-            this._logManager.logMessage('Iac runner could not find binary to run', 'DEBUG');
+            this._logManager.logMessage('Iac runner could not find binary to run', 'WARN');
             return {} as IacScanResponse;
         }
         let skipFiles: string[] = AnalyzerUtils.getAnalyzerManagerExcludePattern(Configuration.getScanExcludePattern());
@@ -273,7 +273,7 @@ export class ScanManager implements ExtensionComponent {
     public async scanSecrets(directory: string, checkCancel: () => void): Promise<SecretsScanResponse> {
         let secretsRunner: SecretsRunner = new SecretsRunner(this._connectionManager, this.logManager);
         if (!secretsRunner.validateSupported()) {
-            this._logManager.logMessage('Secrets runner could not find binary to run', 'DEBUG');
+            this._logManager.logMessage('Secrets runner could not find binary to run', 'WARN');
             return {} as SecretsScanResponse;
         }
         let skipFiles: string[] = AnalyzerUtils.getAnalyzerManagerExcludePattern(Configuration.getScanExcludePattern());
@@ -290,7 +290,7 @@ export class ScanManager implements ExtensionComponent {
     public async scanEos(checkCancel: () => void, ...requests: EosScanRequest[]): Promise<EosScanResponse> {
         let eosRunner: EosRunner = new EosRunner(this._connectionManager, this._logManager);
         if (!eosRunner.validateSupported()) {
-            this._logManager.logMessage('Eos runner could not find binary to run', 'DEBUG');
+            this._logManager.logMessage('Eos runner could not find binary to run', 'WARN');
             return {} as EosScanResponse;
         }
         if (requests.length === 0) {

--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -62,7 +62,7 @@ export class Resource {
      */
     public async copyToTarget(tempPath: string) {
         if (tempPath.endsWith('.zip')) {
-            await Utils.removeDirIfExists(this._targetDir);
+            await ScanUtils.removeFolder(this._targetDir);
             Utils.extractZip(tempPath, this._targetDir);
             // Copy zip file to folder to calculate checksum
             fs.copyFileSync(tempPath, this.getTargetPathAsZip());

--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -60,9 +60,9 @@ export class Resource {
      * if the given file is a binary, replace and copy it to the target path
      * @param tempPath - the file to copy into target
      */
-    public copyToTarget(tempPath: string) {
+    public async copyToTarget(tempPath: string) {
         if (tempPath.endsWith('.zip')) {
-            Utils.removeDirIfExists(this._targetDir);
+            await Utils.removeDirIfExists(this._targetDir);
             Utils.extractZip(tempPath, this._targetDir);
             // Copy zip file to folder to calculate checksum
             fs.copyFileSync(tempPath, this.getTargetPathAsZip());
@@ -82,7 +82,7 @@ export class Resource {
         let tmpFolder: string = ScanUtils.createTmpDir();
         try {
             this._logManager.logMessage('Starting to update resource ' + this._name + ' from ' + this._artifactoryUrl + this.sourceUrl, 'DEBUG');
-            this.copyToTarget(await this.download(tmpFolder));
+            await this.copyToTarget(await this.download(tmpFolder));
             this._logManager.logMessage('Resource ' + this._name + ' was update successfully.', 'DEBUG');
             return true;
         } catch (error) {

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as fs from 'fs';
 import AdmZip, { IZipEntry } from 'adm-zip';
-import { ScanUtils } from './scanUtils';
 
 export class Utils {
     private static readonly MAX_FILES_EXTRACTED_ZIP: number = 1000;

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -151,12 +151,6 @@ export class Utils {
         }
     }
 
-    public static async removeDirIfExists(dirPath: string) {
-        if (fs.existsSync(dirPath)) {
-            await ScanUtils.removeFolder(dirPath);
-        }
-    }
-
     public static removeFileIfExists(filePath: string) {
         if (fs.existsSync(filePath)) {
             fs.rmSync(filePath);

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -151,9 +151,9 @@ export class Utils {
         }
     }
 
-    public static removeDirIfExists(dirPath: string) {
+    public static async removeDirIfExists(dirPath: string) {
         if (fs.existsSync(dirPath)) {
-            ScanUtils.removeFolder(dirPath);
+            await ScanUtils.removeFolder(dirPath);
         }
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

When downloading AnalyzerManager, removing old version didn't wait, allowing the extract method to finish before deleting the old content resulting in removing the new analyzer manager as well.

This was the root caused of the following log that was shown:
```[DEBUG - 3:35:21 PM] Applicability runner could not find binary to run```