### PR TITLE
Scan Applicable issues per workspace and not per descriptor

### DIFF
--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -318,17 +318,19 @@ export class AnalyzerUtils {
                     codeEvidence: location.snippet.text
                 } as IEvidence);
                 // Populate nodes
-                fileNode.issues.push(
-                    new ApplicableTreeNode(
-                        issueNode,
-                        fileNode,
-                        new vscode.Range(
-                            new vscode.Position(location.startLine, location.startColumn),
-                            new vscode.Position(location.endLine, location.endColumn)
-                        ),
-                        issueNode.severity
-                    )
-                );
+                if (fileNode.issues.find(issue => issue.issueId == issueNode.labelId) == undefined) {
+                    fileNode.issues.push(
+                        new ApplicableTreeNode(
+                            issueNode,
+                            fileNode,
+                            new vscode.Range(
+                                new vscode.Position(location.startLine, location.startColumn),
+                                new vscode.Position(location.endLine, location.endColumn)
+                            ),
+                            issueNode.severity
+                        )
+                    );
+                }
                 issuesCount++;
             }
         });

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { IApplicableDetails, IEvidence } from 'jfrog-ide-webview';
-import { CveApplicableDetails } from '../../scanLogic/scanRunners/applicabilityScan';
+import { ApplicabilityScanResponse, CveApplicableDetails } from '../../scanLogic/scanRunners/applicabilityScan';
 import { Severity, SeverityUtils } from '../../types/severity';
 import { ApplicableTreeNode } from '../issuesTree/codeFileTree/applicableTreeNode';
 import { CodeFileTreeNode } from '../issuesTree/codeFileTree/codeFileTreeNode';
@@ -11,7 +11,7 @@ import { FileTreeNode } from '../issuesTree/fileTreeNode';
 import { IssuesRootTreeNode } from '../issuesTree/issuesRootTreeNode';
 import { IssueTreeNode } from '../issuesTree/issueTreeNode';
 import { PackageType } from '../../types/projectType';
-import { GraphScanProgress, StepProgress } from './stepProgress';
+import { StepProgress } from './stepProgress';
 import { EosIssue, EosIssueLocation, EosRunner, EosScanRequest, LanguageType } from '../../scanLogic/scanRunners/eosScan';
 import { ScanManager } from '../../scanLogic/scanManager';
 import { AnalyzeIssue, FileIssues, FileRegion } from '../../scanLogic/scanRunners/analyzerModels';
@@ -22,6 +22,8 @@ import { IacTreeNode } from '../issuesTree/codeFileTree/iacTreeNode';
 import { SecretTreeNode } from '../issuesTree/codeFileTree/secretsTreeNode';
 import { Translators } from '../../utils/translators';
 import { ProjectDependencyTreeNode } from '../issuesTree/descriptorTree/projectDependencyTreeNode';
+import { LogManager } from '../../log/logManager';
+import { Utils } from '../../utils/utils';
 
 export interface FileWithSecurityIssues {
     full_path: string;
@@ -186,55 +188,148 @@ export class AnalyzerUtils {
     /**
      * Run CVE applicable scan async task and populate the given bundle with the results.
      * @param scanManager - the ScanManager that preforms the actual scans
-     * @param fileScanBundle - the file bundle that contains all the information on scan results
+     * @param fileScanBundles - the file bundles that contains all the information on scan results
      * @param scanProgress - the progress for the given scan
      */
     public static async cveApplicableScanning(
         scanManager: ScanManager,
-        fileScanBundle: FileScanBundle,
-        scanProgress: GraphScanProgress
+        fileScanBundles: FileScanBundle[],
+        progressManager: StepProgress
     ): Promise<void> {
-        let cvesToScan: Set<string> = new Set<string>();
-        if (!(fileScanBundle.dataNode instanceof ProjectDependencyTreeNode)) {
-            return;
-        }
-        let descriptorIssues: DependencyScanResults = <DependencyScanResults>fileScanBundle.data;
-        fileScanBundle.dataNode.issues.forEach((issue: IssueTreeNode) => {
-            if (issue instanceof CveTreeNode && !issue.parent.indirect && issue.cve?.cve) {
-                cvesToScan.add(issue.cve.cve);
-            }
-        });
-        if (cvesToScan.size == 0) {
-            return;
-        }
-        scanManager.logManager.logMessage('Scanning descriptor ' + descriptorIssues.fullPath + ' for cve applicability issues', 'INFO');
-
-        let startApplicableTime: number = Date.now();
-        descriptorIssues.applicableIssues = await scanManager.scanApplicability(
-            path.dirname(descriptorIssues.fullPath),
-            scanProgress.onProgress,
-            cvesToScan
+        let spaceToBundles: Map<string, Map<FileScanBundle, Set<string>>> = this.mapBundlesForApplicableScanning(
+            scanManager.logManager,
+            fileScanBundles
         );
+        if (spaceToBundles.size == 0) {
+            return;
+        }
+        for (let [spacePath, bundles] of spaceToBundles) {
+            let cveToScan: Set<string> = Utils.combineSets(Array.from(bundles.values()));
+            // Scan workspace for all cve in relevant bundles
+            let startApplicableTime: number = Date.now();
+            let applicableIssues: ApplicabilityScanResponse = await scanManager.scanApplicability(spacePath, progressManager.checkCancel, cveToScan);
+            if (applicableIssues && applicableIssues.applicableCve) {
+                let applicableScanTimestamp: number = Date.now();
+                AnalyzerUtils.transferApplicableResponseToBundles(
+                    applicableIssues,
+                    bundles,
+                    scanManager.logManager,
+                    applicableScanTimestamp,
+                    applicableScanTimestamp - startApplicableTime
+                );
+            }
+        }
+    }
 
-        if (descriptorIssues.applicableIssues && descriptorIssues.applicableIssues.applicableCve) {
-            descriptorIssues.applicableScanTimestamp = Date.now();
+    /**
+     * Create a mapping between a workspace and all the given bundles that relevant to it.
+     * In addition, filter not relevant bundles.
+     * @param logManager - logger to log added map
+     * @param fileScanBundles - bundles to map
+     * @returns mapped bundles to similar workspace
+     */
+    private static mapBundlesForApplicableScanning(
+        logManager: LogManager,
+        fileScanBundles: FileScanBundle[]
+    ): Map<string, Map<FileScanBundle, Set<string>>> {
+        let bundleMap: Map<string, Map<FileScanBundle, Set<string>>> = new Map<string, Map<FileScanBundle, Set<string>>>();
+
+        for (let fileScanBundle of fileScanBundles) {
+            if (!(fileScanBundle.dataNode instanceof ProjectDependencyTreeNode)) {
+                // Filter non dependencies projects
+                continue;
+            }
+            let descriptorIssues: DependencyScanResults = <DependencyScanResults>fileScanBundle.data;
+            // Map information
+            let cvesToScan: Set<string> = new Set<string>();
+            fileScanBundle.dataNode.issues.forEach((issue: IssueTreeNode) => {
+                if (issue instanceof CveTreeNode && !issue.parent.indirect && issue.cve?.cve) {
+                    // Only direct cve issues
+                    cvesToScan.add(issue.cve.cve);
+                }
+            });
+            if (cvesToScan.size == 0) {
+                // Nothing to do in bundle
+                continue;
+            }
+            let spacePath: string = path.dirname(descriptorIssues.fullPath);
+            if (!bundleMap.has(spacePath)) {
+                bundleMap.set(spacePath, new Map<FileScanBundle, Set<string>>());
+            }
+            bundleMap.get(spacePath)?.set(fileScanBundle, cvesToScan);
+            logManager.logMessage('Adding data from descriptor ' + descriptorIssues.fullPath + ' for cve applicability scan', 'INFO');
+        }
+
+        return bundleMap;
+    }
+
+    /**
+     * Transfer and populate information from a given applicable scan to each bundle
+     * @param applicableIssues - full scan response with information relevant to all the bundles
+     * @param bundles - the bundles that will be populated only with their relevant information
+     * @param logManager - logger to log information to the user
+     * @param applicableTimeStamp - ended time stamp for the applicable scan
+     * @param elapsedTimeInMillsSec - elapsed time that took the scan to run
+     */
+    private static transferApplicableResponseToBundles(
+        applicableIssues: ApplicabilityScanResponse,
+        bundles: Map<FileScanBundle, Set<string>>,
+        logManager: LogManager,
+        applicableTimeStamp: number,
+        elapsedTimeInMillsSec: number
+    ) {
+        for (let [bundle, relevantCve] of bundles) {
+            let descriptorIssues: DependencyScanResults = <DependencyScanResults>bundle.data;
+            // Filter only relevant information
+            descriptorIssues.applicableScanTimestamp = applicableTimeStamp;
+            descriptorIssues.applicableIssues = AnalyzerUtils.filterOnlyRelevantApplicableData(applicableIssues, relevantCve);
+            // Populate it in bundle
             let applicableIssuesCount: number = AnalyzerUtils.populateApplicableIssues(
-                fileScanBundle.root,
-                fileScanBundle.dataNode,
+                bundle.root,
+                <ProjectDependencyTreeNode>bundle.dataNode,
                 descriptorIssues
             );
-            scanManager.logManager.logMessage(
+            logManager.logMessage(
                 'Found ' +
                     applicableIssuesCount +
                     " applicable CVE issues in descriptor = '" +
                     descriptorIssues.fullPath +
                     "' (elapsed " +
-                    (Date.now() - startApplicableTime) / 1000 +
+                    elapsedTimeInMillsSec / 1000 +
                     ' seconds)',
                 'INFO'
             );
-            fileScanBundle.root.apply();
+            bundle.root.apply();
         }
+    }
+
+    /**
+     * Filter a given full applicable data to only relevant information base on a given cve list
+     * @param applicableIssues - all the applicable information
+     * @param relevantCve - cve list to filter information only for them
+     * @returns applicableIssues with information relevant only for the given relevantCve
+     */
+    private static filterOnlyRelevantApplicableData(
+        applicableIssues: ApplicabilityScanResponse,
+        relevantCve: Set<string>
+    ): ApplicabilityScanResponse {
+        let scanned: string[] = [];
+        let allApplicable: Map<string, CveApplicableDetails> = new Map<string, CveApplicableDetails>(Object.entries(applicableIssues.applicableCve));
+        let applicable: Map<string, CveApplicableDetails> = new Map<string, CveApplicableDetails>();
+
+        for (let scannedCve of applicableIssues.scannedCve) {
+            if (relevantCve.has(scannedCve)) {
+                scanned.push(scannedCve);
+                let potential: CveApplicableDetails | undefined = allApplicable.get(scannedCve);
+                if (potential) {
+                    applicable.set(scannedCve, potential);
+                }
+            }
+        }
+        return {
+            scannedCve: Array.from(scanned),
+            applicableCve: Object.fromEntries(applicable.entries())
+        } as ApplicabilityScanResponse;
     }
 
     /**

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -139,6 +139,16 @@ export class AnalyzerUtils {
     }
 
     /**
+     * Check if two ranges are equals
+     * @param region - first range
+     * @param other - second range
+     * @returns true if the ranges match false otherwise
+     */
+    public static isSameRange(range: vscode.Range, other: vscode.Range): boolean {
+        return range.start.isEqual(other.start) && range.end.isEqual(other.end);
+    }
+
+    /**
      * Get or create CodeFileNode object if not exists in root and update its severity if provided
      * @param root - the root to search the node inside
      * @param filePath - the file path to search
@@ -413,18 +423,12 @@ export class AnalyzerUtils {
                     codeEvidence: location.snippet.text
                 } as IEvidence);
                 // Populate nodes
-                if (fileNode.issues.find(issue => issue.issueId == issueNode.labelId) == undefined) {
-                    fileNode.issues.push(
-                        new ApplicableTreeNode(
-                            issueNode,
-                            fileNode,
-                            new vscode.Range(
-                                new vscode.Position(location.startLine, location.startColumn),
-                                new vscode.Position(location.endLine, location.endColumn)
-                            ),
-                            issueNode.severity
-                        )
-                    );
+                let range: vscode.Range = new vscode.Range(
+                    new vscode.Position(location.startLine, location.startColumn),
+                    new vscode.Position(location.endLine, location.endColumn)
+                );
+                if (fileNode.issues.find(issue => this.isSameRange(range, issue.regionWithIssue)) == undefined) {
+                    fileNode.issues.push(new ApplicableTreeNode(issueNode, fileNode, range, issueNode.severity));
                 }
                 issuesCount++;
             }

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -66,6 +66,7 @@ export class DependencyUtils {
         progressManager.reportProgress();
         // Adjust progress value with 2 substeps and the new number of discovered project dependency tree items.
         let progressIncValue: number = (descriptorsPaths.length / packageDependenciesTree.children.length) * progressManager.getStepIncValue;
+        let bundlesWithIssues: FileScanBundle[] = [];
         for (let child of packageDependenciesTree.children) {
             if (child instanceof RootNode) {
                 // Create bundle for the scan
@@ -87,9 +88,14 @@ export class DependencyUtils {
                             scanManager,
                             scanBundle,
                             child,
-                            progressManager.createScanProgress(child.fullPath, progressIncValue / 2),
-                            contextualScan
-                        ).finally(() => progressManager.reportProgress(progressIncValue / 2))
+                            progressManager.createScanProgress(child.fullPath, progressIncValue / 2)
+                        )
+                            .then(issueCount => {
+                                if (issueCount > 0) {
+                                    bundlesWithIssues.push(scanBundle);
+                                }
+                            })
+                            .finally(() => progressManager.reportProgress(progressIncValue / 2))
                     );
                     continue;
                 }
@@ -100,7 +106,15 @@ export class DependencyUtils {
             descriptorsParsed.add(child.generalInfo.path);
         }
         this.reportNotFoundDescriptors(descriptorsPaths, descriptorsParsed, scanManager.logManager);
-        await Promise.all(scansPromises);
+        await Promise.all(scansPromises).then(async () => {
+            // Applicable scan task for the current type
+            if (!contextualScan || !ApplicabilityRunner.supportedPackageTypes().includes(type) || bundlesWithIssues.length == 0) {
+                return;
+            }
+            await AnalyzerUtils.cveApplicableScanning(scanManager, bundlesWithIssues, progressManager).catch(err =>
+                ScanUtils.onScanError(err, scanManager.logManager, true)
+            );
+        });
     }
 
     private static isGraphHasBuildError(child: RootNode, scanBundle: FileScanBundle, logManager: LogManager) {
@@ -179,19 +193,17 @@ export class DependencyUtils {
      * @param fileScanBundle - the bundle for the scan that contains dataNode as ProjectDependencyTreeNode instance
      * @param rootGraph - the descriptor dependencies graph
      * @param scanProgress - the progress manager for the scan
-     * @param contextualScan - if true (default), will apply contextual analysis scan if a CVE was detected
      */
     private static async createDependencyScanTask(
         scanManager: ScanManager,
         fileScanBundle: FileScanBundle,
         rootGraph: RootNode,
-        scanProgress: GraphScanProgress,
-        contextualScan: boolean = true
-    ): Promise<void> {
+        scanProgress: GraphScanProgress
+    ): Promise<number> {
         if (!(fileScanBundle.dataNode instanceof ProjectDependencyTreeNode)) {
-            return;
+            return 0;
         }
-        let foundIssues: boolean = false;
+        let issuesCount: number = 0;
         let dependencyScanResult: DependencyScanResults = <DependencyScanResults>fileScanBundle.data;
         // Dependency graph scan task
         await DependencyUtils.scanProjectDependencyGraph(
@@ -203,8 +215,8 @@ export class DependencyUtils {
             scanProgress.onProgress
         )
             .then((issuesFound: number) => {
-                foundIssues = issuesFound > 0;
-                if (foundIssues) {
+                issuesCount = issuesFound;
+                if (issuesCount > 0) {
                     // populate data and view
                     fileScanBundle.workspaceResults.descriptorsIssues.push(dependencyScanResult);
                     fileScanBundle.root.addChildAndApply(fileScanBundle.dataNode);
@@ -212,16 +224,7 @@ export class DependencyUtils {
             })
             .catch(error => DependencyUtils.onFileScanError(error, scanManager.logManager, fileScanBundle))
             .finally(() => scanProgress.onProgress());
-
-        // Applicable scan task
-        if (!contextualScan || !foundIssues || !ApplicabilityRunner.supportedPackageTypes().includes(dependencyScanResult.type)) {
-            return;
-        }
-        if (fileScanBundle.dataNode instanceof ProjectDependencyTreeNode) {
-            await AnalyzerUtils.cveApplicableScanning(scanManager, fileScanBundle, scanProgress).catch(err =>
-                ScanUtils.onScanError(err, scanManager.logManager, true)
-            );
-        }
+        return issuesCount;
     }
 
     /**

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -262,10 +262,10 @@ export class ScanUtils {
 export interface FileScanBundle {
     // The results data of all the scans in the workspace
     workspaceResults: ScanResults;
-    // The root view node of the workspace
-    root: IssuesRootTreeNode;
-    // The results if exists if the scan
+    // The issues, if exists, found as a result of specific scan
     data: EntryIssuesData;
+    // The root view node of the workspace
+    rootNode: IssuesRootTreeNode;
     // The view node of the file if exists issues in data
     dataNode?: FileTreeNode;
 }

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -22,13 +22,7 @@ export class Utils {
     }
 
     public static combineSets(sets: Set<string>[]): Set<string> {
-        const combinedSet: Set<string> = new Set();
-        for (const set of sets) {
-            for (const value of set) {
-                combinedSet.add(value);
-            }
-        }
-        return combinedSet;
+        return new Set<string>(...sets);
     }
 
     /**

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -21,6 +21,16 @@ export class Utils {
         await vscode.commands.executeCommand('workbench.action.openSettings', `@ext:${Utils.getExtensionId()}` + (id ? ` ${id}` : ''));
     }
 
+    public static combineSets(sets: Set<string>[]): Set<string> {
+        const combinedSet: Set<string> = new Set();
+        for (const set of sets) {
+            for (const value of set) {
+                combinedSet.add(value);
+            }
+        }
+        return combinedSet;
+    }
+
     /**
      *  @returns the last segment of a path.
      */

--- a/src/test/tests/applicabilityScan.test.ts
+++ b/src/test/tests/applicabilityScan.test.ts
@@ -102,7 +102,7 @@ describe('Applicability Scan Tests', () => {
             // Create dummy bundle for tests
             let scanBundle: FileScanBundle = {
                 workspaceResults: {} as ScanResults,
-                root: testRoot,
+                rootNode: testRoot,
                 data: { fullPath: 'some-path', applicableScanTimestamp: 1 } as DependencyScanResults,
                 dataNode: testDescriptor
             } as FileScanBundle;

--- a/src/test/tests/applicabilityScan.test.ts
+++ b/src/test/tests/applicabilityScan.test.ts
@@ -27,7 +27,7 @@ import { CodeIssueTreeNode } from '../../main/treeDataProviders/issuesTree/codeF
 import { ApplicableTreeNode } from '../../main/treeDataProviders/issuesTree/codeFileTree/applicableTreeNode';
 import { getAnalyzerScanResponse, removeWindowsWhiteSpace } from './utils/utils.test';
 import { ScanManager } from '../../main/scanLogic/scanManager';
-import { GraphScanProgress } from '../../main/treeDataProviders/utils/stepProgress';
+import { StepProgress } from '../../main/treeDataProviders/utils/stepProgress';
 import { ProjectDependencyTreeNode } from '../../main/treeDataProviders/issuesTree/descriptorTree/projectDependencyTreeNode';
 import { EnvironmentTreeNode } from '../../main/treeDataProviders/issuesTree/descriptorTree/environmentTreeNode';
 
@@ -107,7 +107,7 @@ describe('Applicability Scan Tests', () => {
                 dataNode: testDescriptor
             } as FileScanBundle;
             // Run scan
-            await AnalyzerUtils.cveApplicableScanning(scanManager, scanBundle, {} as GraphScanProgress);
+            await AnalyzerUtils.cveApplicableScanning(scanManager, [scanBundle], {} as StepProgress);
         });
 
         it('Check Virtual Environment is scanned', () => {

--- a/src/test/tests/dependencyUtils.test.ts
+++ b/src/test/tests/dependencyUtils.test.ts
@@ -204,7 +204,7 @@ describe('Dependency Utils Tests', () => {
         it('On file scan error - ' + test.name, () => {
             let bundle: FileScanBundle = {
                 workspaceResults: new ScanResults('workspace'),
-                root: createRootTestNode('nowhere'),
+                rootNode: createRootTestNode('nowhere'),
                 data: root.createEmptyScanResultsObject()
             } as FileScanBundle;
             if (test.expectedThrow || !test.withBundle) {
@@ -215,7 +215,7 @@ describe('Dependency Utils Tests', () => {
                     assert.isDefined(errorNode);
                     assert.include(errorNode?.name, test.expectedNodeName);
                     // make sure information is populated
-                    assert.lengthOf(bundle.root.children, 1);
+                    assert.lengthOf(bundle.rootNode.children, 1);
                     assert.lengthOf(bundle.workspaceResults.failedFiles, 1);
                     assert.include(bundle.workspaceResults.failedFiles[0].name, test.expectedNodeName);
                 } else {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Scan Contextual Analysis (Applicability Scan) per workspace and type and not for each descriptor. (Saves time and duplicate scans)
* in addition fix an issue where multiple descriptors can add ApplicableTreeNode for the same CVE applicable location