### PR TITLE
Close old web view page on refresh

### DIFF
--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -165,7 +165,7 @@ export class CommandManager implements ExtensionComponent {
      * @param scan - True to scan the workspace, false will load from cache
      */
     private async doRefresh(scan: boolean = true) {
-        this.doCloseCurrentDetailsPage();
+        this.doCloseDetailsPage();
         this._diagnosticManager.clearDiagnostics();
         await this._treesManager.refresh(scan);
         this._diagnosticManager.updateDiagnostics();
@@ -176,13 +176,13 @@ export class CommandManager implements ExtensionComponent {
      * @param page - data to show in webpage
      */
     public doShowDetailsPage(page: WebviewPage) {
-        vscode.commands.executeCommand('jfrog.view.details.page', page);
+        vscode.commands.executeCommand('jfrog.view.details.page.open', page);
     }
 
     /**
      * Close current webpage if one is open
      */
-    public doCloseCurrentDetailsPage() {
+    public doCloseDetailsPage() {
         vscode.commands.executeCommand('jfrog.view.details.page.close');
     }
 

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -165,6 +165,7 @@ export class CommandManager implements ExtensionComponent {
      * @param scan - True to scan the workspace, false will load from cache
      */
     private async doRefresh(scan: boolean = true) {
+        this.doCloseCurrentDetailsPage();
         this._diagnosticManager.clearDiagnostics();
         await this._treesManager.refresh(scan);
         this._diagnosticManager.updateDiagnostics();
@@ -176,6 +177,13 @@ export class CommandManager implements ExtensionComponent {
      */
     public doShowDetailsPage(page: WebviewPage) {
         vscode.commands.executeCommand('jfrog.view.details.page', page);
+    }
+
+    /**
+     * Close current webpage if one is open
+     */
+    public doCloseCurrentDetailsPage() {
+        vscode.commands.executeCommand('jfrog.view.details.page.close');
     }
 
     /**

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -414,7 +414,7 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
             }
             // Descriptor issues nodes
             if (element instanceof CveTreeNode || element instanceof LicenseIssueTreeNode) {
-                element.command = Utils.createNodeCommand('jfrog.view.details.page', 'Show details', [element.getDetailsPage()]);
+                element.command = Utils.createNodeCommand('jfrog.view.details.page.open', 'Show details', [element.getDetailsPage()]);
             }
             // Source code issues nodes
             if (

--- a/src/main/webview/webview.ts
+++ b/src/main/webview/webview.ts
@@ -17,8 +17,19 @@ export class WebView {
 
     public async activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('jfrog.view.details.page', (page: WebviewPage) => this.updateWebview(page, context))
+            vscode.commands.registerCommand('jfrog.view.details.page', (page: WebviewPage) => this.updateWebview(page, context)),
+            vscode.commands.registerCommand('jfrog.view.details.page.close', () => this.closeWebview())
         );
+    }
+
+    /**
+     * Close, if exists, an open webview page
+     */
+    public closeWebview() {
+        if (this._webview) {
+            this._currentPage = undefined;
+            this._webview?.dispose();
+        }
     }
 
     /**

--- a/src/main/webview/webview.ts
+++ b/src/main/webview/webview.ts
@@ -17,7 +17,7 @@ export class WebView {
 
     public async activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('jfrog.view.details.page', (page: WebviewPage) => this.updateWebview(page, context)),
+            vscode.commands.registerCommand('jfrog.view.details.page.open', (page: WebviewPage) => this.updateWebview(page, context)),
             vscode.commands.registerCommand('jfrog.view.details.page.close', () => this.closeWebview())
         );
     }
@@ -26,10 +26,8 @@ export class WebView {
      * Close, if exists, an open webview page
      */
     public closeWebview() {
-        if (this._webview) {
-            this._currentPage = undefined;
-            this._webview?.dispose();
-        }
+        this._currentPage = undefined;
+        this._webview?.dispose();
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Closes an open webview page on a refresh scan