### PR TITLE
Apply uppercase log level in AnalyzerManager

### DIFF
--- a/src/main/utils/translators.ts
+++ b/src/main/utils/translators.ts
@@ -26,7 +26,7 @@ import { LanguageType } from '../scanLogic/scanRunners/eosScan';
 export class Translators {
     public static toAnalyzerLogLevel(logLevel: LogLevel): string {
         if (logLevel === 'WARN' || logLevel === 'ERR') {
-            return 'error';
+            return 'ERROR';
         }
         return logLevel.toUpperCase();
     }

--- a/src/main/utils/translators.ts
+++ b/src/main/utils/translators.ts
@@ -28,7 +28,7 @@ export class Translators {
         if (logLevel === 'WARN' || logLevel === 'ERR') {
             return 'error';
         }
-        return logLevel.toLowerCase();
+        return logLevel.toUpperCase();
     }
 
     public static toLanguageType(type: PackageType): LanguageType | undefined {

--- a/src/test/tests/translators.test.ts
+++ b/src/test/tests/translators.test.ts
@@ -10,7 +10,7 @@ import { AnalyzerManagerSeverityLevel } from '../../main/scanLogic/scanRunners/a
 /**
  * Test functionality of @class Translators.
  */
-describe.only('Translators Tests', () => {
+describe('Translators Tests', () => {
     it('toAnalyzerLogLevel', async () => {
         [
             { inputLevel: 'DEBUG', expectedLevel: 'DEBUG' },

--- a/src/test/tests/translators.test.ts
+++ b/src/test/tests/translators.test.ts
@@ -10,13 +10,13 @@ import { AnalyzerManagerSeverityLevel } from '../../main/scanLogic/scanRunners/a
 /**
  * Test functionality of @class Translators.
  */
-describe('Translators Tests', () => {
+describe.only('Translators Tests', () => {
     it('toAnalyzerLogLevel', async () => {
         [
-            { inputLevel: 'DEBUG', expectedLevel: 'debug' },
-            { inputLevel: 'INFO', expectedLevel: 'info' },
-            { inputLevel: 'WARN', expectedLevel: 'error' },
-            { inputLevel: 'ERR', expectedLevel: 'error' }
+            { inputLevel: 'DEBUG', expectedLevel: 'DEBUG' },
+            { inputLevel: 'INFO', expectedLevel: 'INFO' },
+            { inputLevel: 'WARN', expectedLevel: 'ERROR' },
+            { inputLevel: 'ERR', expectedLevel: 'ERROR' }
         ].forEach(test => {
             assert.equal(test.expectedLevel, Translators.toAnalyzerLogLevel(<LogLevel>test.inputLevel));
         });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

AnalyzerManager didn't apply the log level passed to it.
Fix - AnalyzerManager expect log level to be passed with Upper case.