### PR TITLE
Block exclusion pattern empty after comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
                     "type": "string",
                     "default": "**/*{test,venv,node_modules,target}*",
                     "scope": "resource",
-                    "pattern": "^\\*\\*/\\*\\{([^{},]+(?:,[^{},]+)*)(?!,)\\}\\*$",
+                    "pattern": "^\\*\\*/\\*\\{([^{},]+(,[^{},]+)*)\\}\\*$",
                     "markdownDescription": "A [glob pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern) used to exclude specific paths from being scanned by JFrog Xray. For example, go.mod files under directories named testdata will not be scanned."
                 },
                 "jfrog.xray.ciIntegration.buildNamePattern": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
                     "type": "string",
                     "default": "**/*{test,venv,node_modules,target}*",
                     "scope": "resource",
-                    "pattern": "^\\*\\*/\\*\\{([^{},]+,?)+\\}\\*$",
+                    "pattern": "^\\*\\*/\\*\\{([^{},]+(?:,[^{},]+)*)(?!,)\\}\\*$",
                     "markdownDescription": "A [glob pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern) used to exclude specific paths from being scanned by JFrog Xray. For example, go.mod files under directories named testdata will not be scanned."
                 },
                 "jfrog.xray.ciIntegration.buildNamePattern": {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Don't allow exclusion pattern without content after a comma like the following:
`**/*{test,}*`
`**/*{test,venv,node_modules,target,}*`

will end up with pattern: `**/**/**` for scanners, skipping all files
