### PR TITLE
Add warning in case os not supported the scanners

### DIFF
--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -46,7 +46,7 @@ export abstract class BinaryRunner {
     protected _runDirectory: string;
 
     private static readonly RUNNER_NAME: string = 'analyzerManager';
-    private static readonly RUNNER_VERSION: string = '1.2.3.1851039';
+    private static readonly RUNNER_VERSION: string = '1.2.4.1858388';
     private static readonly DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1/';
 
     public static readonly NOT_ENTITLED: number = 31;

--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { LogManager } from '../../log/logManager';
 import { Utils } from '../../utils/utils';
-import { NotEntitledError, NotSupportedError, ScanCancellationError, ScanUtils } from '../../utils/scanUtils';
+import { NotEntitledError, NotSupportedError, OsNotSupportedError, ScanCancellationError, ScanUtils } from '../../utils/scanUtils';
 import { AnalyzerRequest, AnalyzerScanResponse, ScanType, AnalyzeScanRequest } from './analyzerModels';
 import { ConnectionManager } from '../../connect/connectionManager';
 import { ConnectionUtils } from '../../connect/connectionUtils';
@@ -51,6 +51,7 @@ export abstract class BinaryRunner {
 
     public static readonly NOT_ENTITLED: number = 31;
     public static readonly NOT_SUPPORTED: number = 13;
+    public static readonly OS_NOT_SUPPORTED: number = 55;
 
     public static readonly ENV_PLATFORM_URL: string = 'JF_PLATFORM_URL';
     public static readonly ENV_TOKEN: string = 'JF_TOKEN';
@@ -361,6 +362,9 @@ export abstract class BinaryRunner {
                 }
                 if (error.code === BinaryRunner.NOT_SUPPORTED) {
                     throw new NotSupportedError(this._type);
+                }
+                if (error.code === BinaryRunner.OS_NOT_SUPPORTED) {
+                    throw new OsNotSupportedError(this._type);
                 }
                 this._logManager.logMessage("Binary '" + this._type + "' task ended with status code: " + error.code, 'ERR');
             }

--- a/src/main/scanLogic/scanRunners/binaryRunner.ts
+++ b/src/main/scanLogic/scanRunners/binaryRunner.ts
@@ -123,10 +123,16 @@ export abstract class BinaryRunner {
                 this.createEnvForRun(executionLogDirectory)
             ).then(std => {
                 if (std.stdout && std.stdout.length > 0) {
-                    this._logManager.logMessage("Done executing '" + this._type + "' with log, log:\n" + std.stdout, 'DEBUG');
+                    this._logManager.logMessage(
+                        "Done executing '" + Translators.toAnalyzerTypeString(this._type) + "' with log, log:\n" + std.stdout,
+                        'DEBUG'
+                    );
                 }
                 if (std.stderr && std.stderr.length > 0) {
-                    this._logManager.logMessage("Done executing '" + this._type + "' with error, error log:\n" + std.stderr, 'ERR');
+                    this._logManager.logMessage(
+                        "Done executing '" + Translators.toAnalyzerTypeString(this._type) + "' with error, error log:\n" + std.stderr,
+                        'ERR'
+                    );
                 }
             })
         });
@@ -298,7 +304,7 @@ export abstract class BinaryRunner {
         if (logPath && !(exeErr instanceof NotSupportedError)) {
             this._logManager.logMessage(
                 'AnalyzerManager run ' +
-                    this._type +
+                    Translators.toAnalyzerTypeString(this._type) +
                     ' on ' +
                     args.getRoots() +
                     ' ended ' +
@@ -325,7 +331,11 @@ export abstract class BinaryRunner {
         let roots: string[] = args.getRoots();
         let logFinalPath: string = path.join(
             copyToDirectory,
-            LogUtils.getLogFileName(roots.map(root => Utils.getLastSegment(root)).join('_'), this._type, '' + Date.now())
+            LogUtils.getLogFileName(
+                roots.map(root => Utils.getLastSegment(root)).join('_'),
+                Translators.toAnalyzerTypeString(this._type),
+                '' + Date.now()
+            )
         );
 
         fs.copyFileSync(path.join(args.directory, logFile), logFinalPath);
@@ -361,12 +371,15 @@ export abstract class BinaryRunner {
                     throw new NotEntitledError();
                 }
                 if (error.code === BinaryRunner.NOT_SUPPORTED) {
-                    throw new NotSupportedError(this._type);
+                    throw new NotSupportedError(Translators.toAnalyzerTypeString(this._type));
                 }
                 if (error.code === BinaryRunner.OS_NOT_SUPPORTED) {
-                    throw new OsNotSupportedError(this._type);
+                    throw new OsNotSupportedError(Translators.toAnalyzerTypeString(this._type));
                 }
-                this._logManager.logMessage("Binary '" + this._type + "' task ended with status code: " + error.code, 'ERR');
+                this._logManager.logMessage(
+                    "Binary '" + Translators.toAnalyzerTypeString(this._type) + "' task ended with status code: " + error.code,
+                    'ERR'
+                );
             }
             throw error;
         });
@@ -374,7 +387,9 @@ export abstract class BinaryRunner {
         let analyzerScanResponse: AnalyzerScanResponse = { runs: [] } as AnalyzerScanResponse;
         for (const responsePath of responsePaths) {
             if (!fs.existsSync(responsePath)) {
-                throw new Error("Running '" + this._type + "' binary didn't produce response.\nRequest: " + request);
+                throw new Error(
+                    "Running '" + Translators.toAnalyzerTypeString(this._type) + "' binary didn't produce response.\nRequest: " + request
+                );
             }
             // Load result and parse as response
             let result: AnalyzerScanResponse = JSON.parse(fs.readFileSync(responsePath, 'utf8').toString());

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -247,6 +247,10 @@ export class ScanUtils {
             logger.logMessage(error.message, 'INFO');
             return undefined;
         }
+        if (error instanceof OsNotSupportedError) {
+            logger.logMessage(error.message, 'WARN');
+            return undefined;
+        }
         if (error instanceof NotSupportedError) {
             logger.logMessage(error.message, 'DEBUG');
             return undefined;
@@ -277,6 +281,12 @@ export class NotEntitledError extends Error {
 export class NotSupportedError extends Error {
     constructor(typeNotSupported: string) {
         super(typeNotSupported + ' is not supported in the current Analyzer Manager version');
+    }
+}
+
+export class OsNotSupportedError extends Error {
+    constructor(typeNotSupported: string) {
+        super(typeNotSupported + ' is not supported in your operating system');
     }
 }
 

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -286,7 +286,7 @@ export class NotSupportedError extends Error {
 
 export class OsNotSupportedError extends Error {
     constructor(typeNotSupported: string) {
-        super(typeNotSupported + ' is not supported in your operating system');
+        super(typeNotSupported + ' is not supported for this operating system');
     }
 }
 

--- a/src/main/utils/translators.ts
+++ b/src/main/utils/translators.ts
@@ -17,13 +17,26 @@ import { GeneralInfo } from '../types/generalInfo';
 import { IIssueCacheObject } from '../types/issueCacheObject';
 import { ILicenseCacheObject } from '../types/licenseCacheObject';
 import { Severity } from '../types/severity';
-import { FileLocation, AnalyzerManagerSeverityLevel } from '../scanLogic/scanRunners/analyzerModels';
+import { FileLocation, AnalyzerManagerSeverityLevel, ScanType } from '../scanLogic/scanRunners/analyzerModels';
 import { PackageType, toPackageType } from '../types/projectType';
 import { Utils } from './utils';
 import { LogLevel } from '../log/logManager';
 import { LanguageType } from '../scanLogic/scanRunners/eosScan';
 
 export class Translators {
+    public static toAnalyzerTypeString(type: ScanType): string {
+        switch (type) {
+            case ScanType.ContextualAnalysis:
+                return 'contextual-analysis';
+            case ScanType.Iac:
+                return 'iac-scan';
+            case ScanType.Secrets:
+                return 'secrets-detection';
+            default:
+                return type;
+        }
+    }
+
     public static toAnalyzerLogLevel(logLevel: LogLevel): string {
         if (logLevel === 'WARN' || logLevel === 'ERR') {
             return 'ERROR';

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -9,6 +9,7 @@ import { AnalyzerScanResponse, ScanType, AnalyzeScanRequest } from '../../main/s
 import { BinaryRunner } from '../../main/scanLogic/scanRunners/binaryRunner';
 import { NotEntitledError, ScanCancellationError, ScanTimeoutError, ScanUtils } from '../../main/utils/scanUtils';
 import { RunUtils } from '../../main/utils/runUtils';
+import { Translators } from '../../main/utils/translators';
 
 // binary runner
 describe('Analyzer BinaryRunner tests', async () => {
@@ -198,7 +199,9 @@ describe('Analyzer BinaryRunner tests', async () => {
             timeout: ScanUtils.ANALYZER_TIMEOUT_MILLISECS,
             createDummyResponse: false,
             shouldAbort: false,
-            expectedErr: new Error("Running '" + dummyName + "' binary didn't produce response.\nRequest: request data")
+            expectedErr: new Error(
+                "Running '" + Translators.toAnalyzerTypeString(dummyName) + "' binary didn't produce response.\nRequest: request data"
+            )
         }
     ].forEach(async test => {
         it('Run request - ' + test.name, async () => {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

AnalyzerManager version `1.2.4.1858388` added error 55 (not supported by OS)