### PR TITLE
Restrict the usage of SVG-formatted badges to only GitHub Actions badge

### DIFF
--- a/.github/workflows/detect-svg-in-readme.yml
+++ b/.github/workflows/detect-svg-in-readme.yml
@@ -1,10 +1,10 @@
-name: Detect SVG in readme
+name: Readme
 
 on: [pull_request, push]
 
 jobs:
-  detect_badge:
-    runs-on: ubuntu-latest
+  detect_svg:
+    runs-on: macOS-latest
 
     steps:
     - name: Checkout code
@@ -12,9 +12,17 @@ jobs:
 
     - name: Detect SVG in readme
       run: |
-        if grep -E "\([^)]+\.svg\)" README.md; then
+        # Run grep command to match URLs containing .svg in the readme.md
+        svgs=$(grep -oE '\([^)]+\.svg\)' README.md)
+
+        # Define a whitelist of .svg
+        Whitelist="(https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml/badge.svg)"
+
+        # Check for any SVG images that are not included in the Whitelist.
+        if [[ ! -z $(echo "$svgs" | grep -vE "$Whitelist") ]]
+        then
           echo "Error: SVGs are restricted in README.md."
-          echo "Please usg PNG or remove the following badge pattern from the README.md file:"
-          grep -oE "\([^)]+\.svg\)" README.md
+          echo "Please use PNG instead, or remove the following line(s) from the README.md file:"
+          echo $(echo "$svgs" | grep -vE "$Whitelist")
           exit 1
         fi

--- a/.github/workflows/detect-svg-in-readme.yml
+++ b/.github/workflows/detect-svg-in-readme.yml
@@ -16,13 +16,13 @@ jobs:
         svgs=$(grep -oE '\([^)]+\.svg\)' README.md)
 
         # Define a whitelist of .svg
-        Whitelist="(https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml/badge.svg)"
+        whitelist="(https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml/badge.svg)"
 
-        # Check for any SVG images that are not included in the Whitelist.
-        if [[ ! -z $(echo "$svgs" | grep -vE "$Whitelist") ]]
+        # Check for any SVG images that are not included in the whitelist.
+        if [[ ! -z $(echo "$svgs" | grep -vE "$whitelist") ]]
         then
           echo "Error: SVGs are restricted in README.md."
           echo "Please use PNG instead, or remove the following line(s) from the README.md file:"
-          echo $(echo "$svgs" | grep -vE "$Whitelist")
+          echo $(echo "$svgs" | grep -vE "$whitelist")
           exit 1
         fi

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  [![Visual Studio Code Version](https://img.shields.io/visual-studio-marketplace/v/JFrog.jfrog-vscode-extension?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=JFrog.jfrog-vscode-extension)
 
 [![Visual Studio Marketplace](https://img.shields.io/badge/Visual%20Studio%20Code-Marketplace-blue.png)](https://marketplace.visualstudio.com/items?itemName=JFrog.jfrog-vscode-extension)  [![Open VSX Registry](https://img.shields.io/badge/Open%20VSX%20Registry-Marketplace-blue.png)](https://open-vsx.org/extension/JFrog/jfrog-vscode-extension)
-[![Scanned by Frogbot](https://raw.github.com/jfrog/frogbot/master/images/frogbot-badge.png)](https://github.com/jfrog/frogbot#readme) [![Test](https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml/badge.png)](https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml?branch=master)
+[![Scanned by Frogbot](https://raw.github.com/jfrog/frogbot/master/images/frogbot-badge.png)](https://github.com/jfrog/frogbot#readme) [![Test](https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml/badge.svg)](https://github.com/jfrog/jfrog-vscode-extension/actions/workflows/test.yml?branch=master)
 
 </div>
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Due to the limitation of GitHub Actions badges being available exclusively in SVG format, we permit only the usage of GitHub Actions badges to be in the format of SVG.