### PR TITLE
Contextual Analysis - Scan all CVEs for Python projects

### DIFF
--- a/src/main/cache/cacheManager.ts
+++ b/src/main/cache/cacheManager.ts
@@ -51,7 +51,7 @@ export class CacheManager {
             return;
         }
         const record: CacheRecord = CacheRecord.fromJson(rawJson);
-        if (!record.isNotExpired()) {
+        if (record.isExpired()) {
             vscode.window.showInformationMessage('JFrog: Scan results have expired.', ...['Rescan']).then(answer => {
                 if (answer === 'Rescan') {
                     vscode.commands.executeCommand('jfrog.scan.refresh');

--- a/src/main/cache/cacheManager.ts
+++ b/src/main/cache/cacheManager.ts
@@ -47,10 +47,10 @@ export class CacheManager {
     }
 
     private toScanResult(rawJson: string | undefined): ScanResults | undefined {
-        const record: CacheRecord = CacheRecord.fromJson(rawJson);
-        if (record.isEmpty()) {
-            return
+        if (!rawJson) {
+            return;
         }
+        const record: CacheRecord = CacheRecord.fromJson(rawJson);
         if (!record.isNotExpired()) {
             vscode.window.showInformationMessage('JFrog: Scan results have expired.', ...['Rescan']).then(answer => {
                 if (answer === 'Rescan') {

--- a/src/main/cache/cacheManager.ts
+++ b/src/main/cache/cacheManager.ts
@@ -48,7 +48,10 @@ export class CacheManager {
 
     private toScanResult(rawJson: string | undefined): ScanResults | undefined {
         const record: CacheRecord = CacheRecord.fromJson(rawJson);
-        if (!record.isValid()) {
+        if (record.isEmpty()) {
+            return
+        }
+        if (!record.isNotExpired()) {
             vscode.window.showInformationMessage('JFrog: Scan results have expired.', ...['Rescan']).then(answer => {
                 if (answer === 'Rescan') {
                     vscode.commands.executeCommand('jfrog.scan.refresh');

--- a/src/main/cache/cacheRecord.ts
+++ b/src/main/cache/cacheRecord.ts
@@ -33,10 +33,6 @@ export class CacheRecord {
         return this.isWithinMaxAge() && this.hasCurrentVersion();
     }
 
-    public isEmpty(): boolean {
-        return this._data === undefined;
-    }
-
     private isWithinMaxAge(): boolean {
         return this._timestamp !== undefined && Date.now() - this._timestamp <= CacheRecord.MAX_CACHE_AGE_MILLISECS;
     }

--- a/src/main/cache/cacheRecord.ts
+++ b/src/main/cache/cacheRecord.ts
@@ -29,15 +29,15 @@ export class CacheRecord {
         return this._data;
     }
 
-    public isValid(): boolean {
-        return this.hasValidData() && this.isNotExpired() && this.hasCurrentVersion();
+    public isNotExpired(): boolean {
+        return this.isWithinMaxAge() && this.hasCurrentVersion();
     }
 
-    private hasValidData(): boolean {
-        return this._data !== undefined;
+    public isEmpty(): boolean {
+        return this._data === undefined;
     }
 
-    private isNotExpired(): boolean {
+    private isWithinMaxAge(): boolean {
         return this._timestamp !== undefined && Date.now() - this._timestamp <= CacheRecord.MAX_CACHE_AGE_MILLISECS;
     }
 

--- a/src/main/cache/cacheRecord.ts
+++ b/src/main/cache/cacheRecord.ts
@@ -29,15 +29,15 @@ export class CacheRecord {
         return this._data;
     }
 
-    public isNotExpired(): boolean {
-        return this.isWithinMaxAge() && this.hasCurrentVersion();
+    public isExpired(): boolean {
+        return this.passedMaxAge() || this.hasOldCacheVersion();
     }
 
-    private isWithinMaxAge(): boolean {
-        return this._timestamp !== undefined && Date.now() - this._timestamp <= CacheRecord.MAX_CACHE_AGE_MILLISECS;
+    private passedMaxAge(): boolean {
+        return this._timestamp === undefined || Date.now() - this._timestamp > CacheRecord.MAX_CACHE_AGE_MILLISECS;
     }
 
-    private hasCurrentVersion(): boolean {
-        return this._version !== undefined && this._version === CacheRecord.CURRENT_CACHE_VERSION;
+    private hasOldCacheVersion(): boolean {
+        return this._version === undefined || this._version !== CacheRecord.CURRENT_CACHE_VERSION;
     }
 }

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { IApplicableDetails, IEvidence } from 'jfrog-ide-webview';
-import { ApplicabilityScanResponse, CveApplicableDetails } from '../../scanLogic/scanRunners/applicabilityScan';
+import { ApplicabilityRunner, ApplicabilityScanResponse, CveApplicableDetails } from '../../scanLogic/scanRunners/applicabilityScan';
 import { Severity, SeverityUtils } from '../../types/severity';
 import { ApplicableTreeNode } from '../issuesTree/codeFileTree/applicableTreeNode';
 import { CodeFileTreeNode } from '../issuesTree/codeFileTree/codeFileTreeNode';
@@ -204,9 +204,13 @@ export class AnalyzerUtils {
     public static async cveApplicableScanning(
         scanManager: ScanManager,
         fileScanBundles: FileScanBundle[],
-        progressManager: StepProgress
+        progressManager: StepProgress,
+        type: PackageType
     ): Promise<void> {
-        let filteredBundles: Map<FileScanBundle, Set<string>> = this.filterBundlesWithoutIssuesToScan(fileScanBundles);
+        if (!ApplicabilityRunner.supportedPackageTypes().includes(type)) {
+            return;
+        }
+        let filteredBundles: Map<FileScanBundle, Set<string>> = this.filterBundlesWithoutIssuesToScan(fileScanBundles, type);
         let spaceToBundles: Map<string, Map<FileScanBundle, Set<string>>> = this.mapBundlesForApplicableScanning(
             scanManager.logManager,
             filteredBundles
@@ -237,7 +241,7 @@ export class AnalyzerUtils {
      * @param fileScanBundles - bundles to process and filter if needed
      * @returns Map of bundles to their set of direct cves issues, with at least one for each bundle
      */
-    private static filterBundlesWithoutIssuesToScan(fileScanBundles: FileScanBundle[]): Map<FileScanBundle, Set<string>> {
+    private static filterBundlesWithoutIssuesToScan(fileScanBundles: FileScanBundle[], type: PackageType): Map<FileScanBundle, Set<string>> {
         let filtered: Map<FileScanBundle, Set<string>> = new Map<FileScanBundle, Set<string>>();
 
         for (let fileScanBundle of fileScanBundles) {
@@ -247,8 +251,12 @@ export class AnalyzerUtils {
             }
             let cvesToScan: Set<string> = new Set<string>();
             fileScanBundle.dataNode.issues.forEach((issue: IssueTreeNode) => {
-                if (issue instanceof CveTreeNode && !issue.parent.indirect && issue.cve?.cve) {
-                    // Only direct cve issues
+                if (!(issue instanceof CveTreeNode) || !issue.cve?.cve) {
+                    return;
+                }
+                // For Python projects, all CVEs should be included.
+                // Other project types should include only CVEs on direct dependencies.
+                if (type === PackageType.Python || !issue.parent.indirect) {
                     cvesToScan.add(issue.cve.cve);
                 }
             });

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -254,7 +254,7 @@ export class AnalyzerUtils {
                 if (!(issue instanceof CveTreeNode) || !issue.cve?.cve) {
                     return;
                 }
-                // For Python projects, all CVEs should be included.
+                // For Python projects, all CVEs should be included because in some cases it is impossible to determine whether a dependency is direct.
                 // Other project types should include only CVEs on direct dependencies.
                 if (type === PackageType.Python || !issue.parent.indirect) {
                     cvesToScan.add(issue.cve.cve);

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -106,10 +106,11 @@ export class DependencyUtils {
             descriptorsParsed.add(child.generalInfo.path);
         }
         this.reportNotFoundDescriptors(descriptorsPaths, descriptorsParsed, scanManager.logManager);
-        if (!contextualScan || bundlesWithIssues.length == 0) {
-            return;
-        }
+
         await Promise.all(scansPromises).then(async () => {
+            if (!contextualScan || bundlesWithIssues.length == 0) {
+                return;
+            }
             await AnalyzerUtils.cveApplicableScanning(scanManager, bundlesWithIssues, progressManager, type).catch(err =>
                 ScanUtils.onScanError(err, scanManager.logManager, true)
             );

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -29,7 +29,6 @@ import { FileScanBundle, FileScanError, ScanUtils } from '../../utils/scanUtils'
 import { LogManager } from '../../log/logManager';
 import { GeneralInfo } from '../../types/generalInfo';
 import { FileTreeNode } from '../issuesTree/fileTreeNode';
-import { ApplicabilityRunner } from '../../scanLogic/scanRunners/applicabilityScan';
 
 export class DependencyUtils {
     public static readonly FAIL_TO_SCAN: string = '[Fail to scan]';
@@ -107,12 +106,11 @@ export class DependencyUtils {
             descriptorsParsed.add(child.generalInfo.path);
         }
         this.reportNotFoundDescriptors(descriptorsPaths, descriptorsParsed, scanManager.logManager);
+        if (!contextualScan || bundlesWithIssues.length == 0) {
+            return;
+        }
         await Promise.all(scansPromises).then(async () => {
-            // Applicable scan task for the current type
-            if (!contextualScan || !ApplicabilityRunner.supportedPackageTypes().includes(type) || bundlesWithIssues.length == 0) {
-                return;
-            }
-            await AnalyzerUtils.cveApplicableScanning(scanManager, bundlesWithIssues, progressManager).catch(err =>
+            await AnalyzerUtils.cveApplicableScanning(scanManager, bundlesWithIssues, progressManager, type).catch(err =>
                 ScanUtils.onScanError(err, scanManager.logManager, true)
             );
         });

--- a/src/main/types/workspaceIssuesDetails.ts
+++ b/src/main/types/workspaceIssuesDetails.ts
@@ -23,6 +23,9 @@ export class ScanResults {
     constructor(private _path: string) {}
 
     public static fromJson(jsonScanResults: any) {
+        if (!jsonScanResults) {
+            return;
+        }
         const workspaceIssuesDetails: ScanResults = new ScanResults(jsonScanResults._path);
         if (jsonScanResults._descriptorsIssues) {
             workspaceIssuesDetails.descriptorsIssues.push(...jsonScanResults._descriptorsIssues);


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Due to the [limitations](https://github.com/tox-dev/pipdeptree/issues/277#issuecomment-1671932271) of pipdeptree, direct dependencies may not always be captured in Python projects if they are also present as indirect dependencies. This could lead to the possibility of missing certain CVEs during the Contextual Analysis scan. To prevent this, we make sure to send all CVEs to the Contextual Analysis.