### PR TITLE
Bump semver from 7.5.2 to 7.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "original-fs": "~1.1.0",
                 "p-queue": "~6.6.2",
                 "retries": "~1.0.0",
-                "semver": "^7.5.2",
+                "semver": "^7.5.4",
                 "typescript-collections": "~1.3.3",
                 "walkdir": "~0.4.1",
                 "xmlbuilder2": "~3.0.2"
@@ -6035,9 +6035,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
         "original-fs": "~1.1.0",
         "p-queue": "~6.6.2",
         "retries": "~1.0.0",
-        "semver": "^7.5.2",
+        "semver": "^7.5.4",
         "typescript-collections": "~1.3.3",
         "walkdir": "~0.4.1",
         "xmlbuilder2": "~3.0.2"


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
