### PR TITLE
Fix scanning wrong directory in CA for venv

### DIFF
--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -24,6 +24,7 @@ import { Translators } from '../../utils/translators';
 import { ProjectDependencyTreeNode } from '../issuesTree/descriptorTree/projectDependencyTreeNode';
 import { LogManager } from '../../log/logManager';
 import { Utils } from '../../utils/utils';
+import { EnvironmentTreeNode } from '../issuesTree/descriptorTree/environmentTreeNode';
 
 export interface FileWithSecurityIssues {
     full_path: string;
@@ -287,6 +288,9 @@ export class AnalyzerUtils {
             let descriptorIssues: DependencyScanResults = <DependencyScanResults>fileScanBundle.data;
             // Map information to similar directory space
             let spacePath: string = path.dirname(descriptorIssues.fullPath);
+            if (fileScanBundle instanceof EnvironmentTreeNode) {
+                spacePath = descriptorIssues.fullPath;
+            }
             if (!workspaceToScanBundles.has(spacePath)) {
                 workspaceToScanBundles.set(spacePath, new Map<FileScanBundle, Set<string>>());
             }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fix - treating the virtual environment the same as the descriptor taking the dir of there full path for scanning CA.
