### PR TITLE
Wait before loading a page at the first time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
+      
+      - name: Rebuild native modules
+        run: npm rebuild
 
       - name: Tests on macOS, Windows
         env:

--- a/src/main/webview/webviewManager.ts
+++ b/src/main/webview/webviewManager.ts
@@ -25,8 +25,8 @@ export class WebviewManager implements ExtensionComponent {
         this.webviewSidebar.loadPage(await this.createLoginPage());
     }
 
-    public loadWebviewTab(page: WebviewPage) {
-        this.webviewTab.resolveWebviewView();
+    public async loadWebviewTab(page: WebviewPage) {
+        await this.webviewTab.resolveWebviewView();
         this.webviewTab.loadPage(page);
     }
 

--- a/src/main/webview/webviewTab.ts
+++ b/src/main/webview/webviewTab.ts
@@ -4,11 +4,13 @@ import { LogManager } from '../log/logManager';
 import { EventManager } from './event/eventManager';
 import { WebView } from './webview';
 import { ConnectionManager } from '../connect/connectionManager';
+import { RunUtils } from '../utils/runUtils';
 
 /**
  * Show a webview panel with details about objects in the project
  */
 export class WebviewTab extends WebView {
+    private static readonly WEBVIEW_DELAY_MILLISECS: number = 2000;
     private panel: vscode.WebviewPanel | undefined;
 
     constructor(logManager: LogManager, private connectionManager: ConnectionManager, private context: vscode.ExtensionContext) {
@@ -20,10 +22,14 @@ export class WebviewTab extends WebView {
      * @param data - the data of the page to be update and show in the webpage
      * @param context - context of the extension
      */
-    public resolveWebviewView() {
+    public async resolveWebviewView() {
         if (!this.panel) {
             this.panel = this.createWebview();
             this.eventManager = this.createEventManager(this.panel);
+            // Workaround: Delay the initial page load to ensure proper message delivery in the Webview.
+            // This is necessary because in the Webview, messages are only delivered when the webview is alive.
+            // This workaround applies specifically to VS-Code remote development environments.
+            await RunUtils.delay(WebviewTab.WEBVIEW_DELAY_MILLISECS);
         } else {
             this.panel.reveal();
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Workaround for VS-Code remote development environments -
Delay the initial page load to ensure proper message delivery in the Webview.
This is necessary because in the Webview, messages are only delivered when the Webview is alive.
