### PR TITLE
Add a new command for deleting caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
                 "enablement": "viewItem =~ /jfrog.item.copy.to.clipboard/"
             },
             {
+                "command": "jfrog.issues.cache.delete",
+                "title": "Delete cache",
+                "category": "JFrog"
+            },
+            {
                 "command": "jfrog.xray.builds",
                 "title": "Select build to display",
                 "icon": {

--- a/src/main/cache/cacheManager.ts
+++ b/src/main/cache/cacheManager.ts
@@ -28,6 +28,14 @@ export class CacheManager {
     }
 
     /**
+     * Delete a workspace issues data from the cache
+     * @param workspace - the workspace to clear cache
+     */
+    public delete(workspace: vscode.WorkspaceFolder) {
+        return this._cache.update(this.toCacheKey(workspace), undefined);
+    }
+
+    /**
      * Get the unique key for this workspace
      * @param workspace - the workspace we want to get it's id
      * @returns - the unique key for this workspace

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -48,6 +48,7 @@ export class CommandManager implements ExtensionComponent {
         // Local state
         this.registerCommand(context, 'jfrog.issues.open.ignore', issue => vscode.env.openExternal(vscode.Uri.parse(issue.ignoreUrl)));
         this.registerCommand(context, 'jfrog.issues.file.open', file => ScanUtils.openFile(file));
+        this.registerCommand(context, 'jfrog.issues.cache.delete', () => this.deleteCache());
         this.registerCommand(context, 'jfrog.issues.file.open.location', (file, fileRegion) => ScanUtils.openFile(file, fileRegion));
         this.registerCommand(context, 'jfrog.issues.select.node', item => this._treesManager.selectItemOnIssuesTree(item));
         this.registerCommand(context, 'jfrog.issues.select.updateDependency', (dependency: DependencyIssuesTreeNode, version: string) =>
@@ -173,9 +174,19 @@ export class CommandManager implements ExtensionComponent {
      * @param scan - True to scan the workspace, false will load from cache
      */
     private async doRefresh(scan: boolean = true) {
+        this.clearView()
+        await this._treesManager.refresh(scan);
+    }
+
+    private async deleteCache() {
+        ScanUtils.setFirstScanForWorkspace(true);
+        this.clearView()
+        this._treesManager.deleteCache();
+    }
+
+    private clearView() {
         this.doCloseDetailsPage();
         this._diagnosticManager.clearDiagnostics();
-        await this._treesManager.refresh(scan);
         this._diagnosticManager.updateDiagnostics();
     }
 

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -174,13 +174,13 @@ export class CommandManager implements ExtensionComponent {
      * @param scan - True to scan the workspace, false will load from cache
      */
     private async doRefresh(scan: boolean = true) {
-        this.clearView()
+        this.clearView();
         await this._treesManager.refresh(scan);
     }
 
     private async deleteCache() {
         ScanUtils.setFirstScanForWorkspace(true);
-        this.clearView()
+        this.clearView();
         this._treesManager.deleteCache();
     }
 

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -106,6 +106,9 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
     public clearTree() {
         this._workspaceToRoot = new Map<vscode.WorkspaceFolder, IssuesRootTreeNode>();
         this.onChangeFire();
+        for (const workspace of this._workspaceFolders) {
+            this._cacheManager.delete(workspace);
+        }
     }
 
     /**

--- a/src/main/treeDataProviders/treesManager.ts
+++ b/src/main/treeDataProviders/treesManager.ts
@@ -79,6 +79,10 @@ export class TreesManager implements ExtensionComponent {
         }
     }
 
+    public deleteCache() {
+        this.issuesTreeDataProvider.clearTree()
+    }
+
     /**
      * Shows a specific node in the source code tree after clicking on the bulb icon in the source code.
      * @param sourceCodeCveTreeNode

--- a/src/main/treeDataProviders/treesManager.ts
+++ b/src/main/treeDataProviders/treesManager.ts
@@ -80,7 +80,7 @@ export class TreesManager implements ExtensionComponent {
     }
 
     public deleteCache() {
-        this.issuesTreeDataProvider.clearTree()
+        this.issuesTreeDataProvider.clearTree();
     }
 
     /**


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
This pull request introduces a new command to the JFrog extension, allowing users to delete the cache of the currently opened workspace associated with the extension.