### PR TITLE
Yarn - Fix incorrect package type

### DIFF
--- a/src/main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ILicense } from 'jfrog-ide-webview';
-import { PackageType, toPackageType } from '../../../types/projectType';
+import { PackageType } from '../../../types/projectType';
 import { Severity, SeverityUtils } from '../../../types/severity';
 import { IComponent } from 'jfrog-client-js';
 import { CveTreeNode } from './cveTreeNode';
@@ -24,7 +24,7 @@ export class DependencyIssuesTreeNode extends vscode.TreeItem {
 
         this._name = component.package_name;
         this._version = component.package_version;
-        this._type = toPackageType(component.package_type);
+        this._type = _parent.type
         this.description = this._version + (_indirect ? ' (indirect)' : '');
         this.contextValue += ContextKeys.COPY_TO_CLIPBOARD_ENABLED;
     }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
This pull request fixes the issue where yarn dependencies were receiving an incorrect 'npm' type, resulting in no diagnostics or autofix. The underlying problem stems from the fact that Xray's response for yarn vulnerable dependencies was type as 'npm,' and this was applied to each vulnerable yarn dependency.

To address this, the vulnerable package type is now extended from the root project identified by the extension.