### PR TITLE
Yarn - Fix incorrect impact graph

### DIFF
--- a/src/main/scanLogic/scanGraphLogic.ts
+++ b/src/main/scanLogic/scanGraphLogic.ts
@@ -23,7 +23,7 @@ export class GraphScanLogic {
      */
     public async scan(graphRoot: RootNode, progress: XrayScanProgress, checkCanceled: () => void): Promise<IGraphResponse> {
         let graphRequest: IGraphRequestModel = {
-            component_id: graphRoot.generalInfo.artifactId ?? graphRoot.dependencyId,
+            component_id: graphRoot.generalInfo.artifactId ?? graphRoot.xrayId,
             nodes: this.getFlattenRequestModelNodes(graphRoot, new Set<string>())
         } as IGraphRequestModel;
         if (!graphRequest.nodes || graphRequest.nodes.length === 0) {
@@ -48,10 +48,10 @@ export class GraphScanLogic {
     public getFlattenRequestModelNodes(dependency: DependenciesTreeNode, components: Set<string>): IGraphRequestModel[] | undefined {
         let nodes: IGraphRequestModel[] = [];
         for (let child of dependency.children) {
-            if (child.dependencyId && !components.has(child.dependencyId)) {
-                components.add(child.dependencyId);
+            if (child.xrayId && !components.has(child.xrayId)) {
+                components.add(child.xrayId);
                 nodes.push({
-                    component_id: child.dependencyId
+                    component_id: child.xrayId
                 } as IGraphRequestModel);
             }
             let childNodes: IGraphRequestModel[] | undefined = this.getFlattenRequestModelNodes(child, components);

--- a/src/main/scanLogic/scanGraphLogic.ts
+++ b/src/main/scanLogic/scanGraphLogic.ts
@@ -23,7 +23,7 @@ export class GraphScanLogic {
      */
     public async scan(graphRoot: RootNode, progress: XrayScanProgress, checkCanceled: () => void): Promise<IGraphResponse> {
         let graphRequest: IGraphRequestModel = {
-            component_id: graphRoot.generalInfo.artifactId ?? graphRoot.xrayId,
+            component_id: graphRoot.generalInfo.artifactId ?? graphRoot.xrayDependencyId,
             nodes: this.getFlattenRequestModelNodes(graphRoot, new Set<string>())
         } as IGraphRequestModel;
         if (!graphRequest.nodes || graphRequest.nodes.length === 0) {
@@ -48,10 +48,10 @@ export class GraphScanLogic {
     public getFlattenRequestModelNodes(dependency: DependenciesTreeNode, components: Set<string>): IGraphRequestModel[] | undefined {
         let nodes: IGraphRequestModel[] = [];
         for (let child of dependency.children) {
-            if (child.xrayId && !components.has(child.xrayId)) {
-                components.add(child.xrayId);
+            if (child.xrayDependencyId && !components.has(child.xrayDependencyId)) {
+                components.add(child.xrayDependencyId);
                 nodes.push({
-                    component_id: child.xrayId
+                    component_id: child.xrayDependencyId
                 } as IGraphRequestModel);
             }
             let childNodes: IGraphRequestModel[] | undefined = this.getFlattenRequestModelNodes(child, components);

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
@@ -153,7 +153,7 @@ export class GoTreeNode extends RootNode {
 
     private addComponentToScan(dependenciesTreeNode: DependenciesTreeNode) {
         let componentId: string = dependenciesTreeNode.generalInfo.artifactId + ':' + dependenciesTreeNode.generalInfo.version;
-        dependenciesTreeNode.xrayId = GoTreeNode.COMPONENT_PREFIX + componentId;
+        dependenciesTreeNode.xrayDependencyId = GoTreeNode.COMPONENT_PREFIX + componentId;
     }
 
     private getNameVersionTuple(value: string): string[] {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/goTree.ts
@@ -153,8 +153,7 @@ export class GoTreeNode extends RootNode {
 
     private addComponentToScan(dependenciesTreeNode: DependenciesTreeNode) {
         let componentId: string = dependenciesTreeNode.generalInfo.artifactId + ':' + dependenciesTreeNode.generalInfo.version;
-        this.projectDetails.addDependency(GoTreeNode.COMPONENT_PREFIX + componentId);
-        dependenciesTreeNode.dependencyId = GoTreeNode.COMPONENT_PREFIX + componentId;
+        dependenciesTreeNode.xrayId = GoTreeNode.COMPONENT_PREFIX + componentId;
     }
 
     private getNameVersionTuple(value: string): string[] {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
@@ -66,9 +66,8 @@ export class MavenTreeNode extends RootNode {
             let child: DependenciesTreeNode = new DependenciesTreeNode(gavGeneralInfo, treeCollapsibleState, parent);
             child.label = group + ':' + name;
             let componentId: string = gavGeneralInfo.getComponentId();
-            this.projectDetails.addDependency(MavenTreeNode.COMPONENT_PREFIX + componentId);
 
-            child.dependencyId = MavenTreeNode.COMPONENT_PREFIX + componentId;
+            child.xrayId = MavenTreeNode.COMPONENT_PREFIX + componentId;
             if (rawDependenciesPtr.index + 1 < rawDependenciesList.length) {
                 while (
                     rawDependenciesPtr.index + 1 < rawDependenciesList.length &&

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/mavenTree.ts
@@ -67,7 +67,7 @@ export class MavenTreeNode extends RootNode {
             child.label = group + ':' + name;
             let componentId: string = gavGeneralInfo.getComponentId();
 
-            child.xrayId = MavenTreeNode.COMPONENT_PREFIX + componentId;
+            child.xrayDependencyId = MavenTreeNode.COMPONENT_PREFIX + componentId;
             if (rawDependenciesPtr.index + 1 < rawDependenciesList.length) {
                 while (
                     rawDependenciesPtr.index + 1 < rawDependenciesList.length &&

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -65,8 +65,7 @@ export class NpmTreeNode extends RootNode {
                     : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode);
                 let componentId: string = key + ':' + version;
-                this.projectDetails.addDependency(NpmTreeNode.COMPONENT_PREFIX + componentId);
-                child.dependencyId = NpmTreeNode.COMPONENT_PREFIX + componentId;
+                child.xrayId = NpmTreeNode.COMPONENT_PREFIX + componentId;
                 this.populateDependenciesTree(child, childDependencies);
             }
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/npmTree.ts
@@ -65,7 +65,7 @@ export class NpmTreeNode extends RootNode {
                     : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode);
                 let componentId: string = key + ':' + version;
-                child.xrayId = NpmTreeNode.COMPONENT_PREFIX + componentId;
+                child.xrayDependencyId = NpmTreeNode.COMPONENT_PREFIX + componentId;
                 this.populateDependenciesTree(child, childDependencies);
             }
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -37,7 +37,7 @@ export class NugetTreeNode extends RootNode {
                     childDependencies.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode, '');
                 let combined: string = id + ':' + version;
-                child.xrayId = NugetTreeNode.COMPONENT_PREFIX + combined;
+                child.xrayDependencyId = NugetTreeNode.COMPONENT_PREFIX + combined;
                 this.populateDependenciesTree(child, childDependencies);
             }
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/nugetTree.ts
@@ -37,8 +37,7 @@ export class NugetTreeNode extends RootNode {
                     childDependencies.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode, '');
                 let combined: string = id + ':' + version;
-                this.projectDetails.addDependency(NugetTreeNode.COMPONENT_PREFIX + combined);
-                child.dependencyId = NugetTreeNode.COMPONENT_PREFIX + combined;
+                child.xrayId = NugetTreeNode.COMPONENT_PREFIX + combined;
                 this.populateDependenciesTree(child, childDependencies);
             }
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
@@ -40,7 +40,7 @@ export class PypiTreeNode extends RootNode {
                         : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode);
                 let componentId: string = dependency.key + ':' + version;
-                child.xrayId = PypiTreeNode.COMPONENT_PREFIX + componentId;
+                child.xrayDependencyId = PypiTreeNode.COMPONENT_PREFIX + componentId;
                 this.populateDependenciesTree(child, childDependencies);
             }
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/pypiTree.ts
@@ -40,8 +40,7 @@ export class PypiTreeNode extends RootNode {
                         : vscode.TreeItemCollapsibleState.None;
                 let child: DependenciesTreeNode = new DependenciesTreeNode(generalInfo, treeCollapsibleState, dependenciesTreeNode);
                 let componentId: string = dependency.key + ':' + version;
-                this.projectDetails.addDependency(PypiTreeNode.COMPONENT_PREFIX + componentId);
-                child.dependencyId = PypiTreeNode.COMPONENT_PREFIX + componentId;
+                child.xrayId = PypiTreeNode.COMPONENT_PREFIX + componentId;
                 this.populateDependenciesTree(child, childDependencies);
             }
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree.ts
@@ -79,15 +79,14 @@ export class RootNode extends DependenciesTreeNode {
     /**
      * Retrieves the impact paths of all child components, recursively from a given root,
      * The number of impact paths collected may be limited by the '{@link RootNode.IMPACT_PATHS_LIMIT}'.
-     * @param root - the root to get it's children impact
-     * @param componentWithIssue - the component to generate the impact path for it
-     * @param size - the total size of the impacted path
+     * @param vulnerableDependencyName - the name of the component used to build a path to the root.
+     * @param componentWithIssue -  the version of the component used to build a path to the root.
      */
-    public createImpactedGraph(vulnerableDependencyname: string, vulnerableDependencyversion: string): IImpactGraph {
-        return RootNode.collectPaths(vulnerableDependencyname + ':' + vulnerableDependencyversion, this.children, 0);
+    public createImpactedGraph(vulnerableDependencyName: string, vulnerableDependencyVersion: string): IImpactGraph {
+        return RootNode.collectPaths(vulnerableDependencyName + ':' + vulnerableDependencyVersion, this.children, 0);
     }
 
-    private static collectPaths(vulnerableDependencyId: string, children: DependenciesTreeNode[], size: number) {
+    private static collectPaths(vulnerableDependencyId: string, children: DependenciesTreeNode[], size: number): IImpactGraph {
         let impactPaths: IImpactGraphNode[] = [];
         for (let child of children) {
             if (impactPaths.find(node => node.name === child.componentId)) {
@@ -102,7 +101,7 @@ export class RootNode extends DependenciesTreeNode {
                 size++;
             }
 
-            let indirectImpact: IImpactGraph = this.collectPaths(vulnerableDependencyId, child.children, size);
+            let indirectImpact: IImpactGraph = RootNode.collectPaths(vulnerableDependencyId, child.children, size);
             RootNode.appendIndirectImpact(impactPaths, child.componentId, indirectImpact);
             size = indirectImpact.pathsCount ?? size;
         }

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/yarnTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/yarnTree.ts
@@ -9,7 +9,7 @@ import { BuildTreeErrorType, RootNode } from './rootTree';
 import { PackageType } from '../../../types/projectType';
 import { LogManager } from '../../../log/logManager';
 import { IImpactGraph } from 'jfrog-ide-webview';
-import { YarnImpactGraphUtil } from '../../utils/yarnImpactGraph';
+import { YarnImpactGraphCreator } from '../../utils/yarnImpactGraph';
 
 export class YarnTreeNode extends RootNode {
     private static readonly COMPONENT_PREFIX: string = 'npm://';
@@ -40,7 +40,7 @@ export class YarnTreeNode extends RootNode {
 
     /** @override */
     public createImpactedGraph(name: string, version: string): IImpactGraph {
-        return new YarnImpactGraphUtil(name, version, this.generalInfo.getComponentId(), this.workspaceFolder).create();
+        return new YarnImpactGraphCreator(name, version, this.generalInfo.getComponentId(), this.workspaceFolder).create();
     }
 
     /**
@@ -76,7 +76,7 @@ export class YarnTreeNode extends RootNode {
     private addDependency(parent: DependenciesTreeNode, node: any): void {
         const [dependencyName, dependencyVersion, scope] = this.extractDependencyInfo(node);
         const generalInfo: GeneralInfo = new GeneralInfo(dependencyName, dependencyVersion, scope !== '' ? [scope] : [], '', PackageType.Yarn);
-        new DependenciesTreeNode(generalInfo, vscode.TreeItemCollapsibleState.None, parent).xrayId =
+        new DependenciesTreeNode(generalInfo, vscode.TreeItemCollapsibleState.None, parent).xrayDependencyId =
             YarnTreeNode.COMPONENT_PREFIX + dependencyName + ':' + dependencyVersion;
     }
 

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/yarnTree.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesRoot/yarnTree.ts
@@ -40,7 +40,7 @@ export class YarnTreeNode extends RootNode {
 
     /** @override */
     public createImpactedGraph(name: string, version: string): IImpactGraph {
-        return new YarnImpactGraphCreator(name, version, this.generalInfo.getComponentId(), this.workspaceFolder).create();
+        return new YarnImpactGraphCreator(name, version, this.generalInfo.getComponentId(), this.workspaceFolder, this._logManager).create();
     }
 
     /**

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
@@ -12,7 +12,7 @@ export class DependenciesTreeNode extends vscode.TreeItem {
     private _licenses: Set<ILicenseKey> = new Set(license => license.licenseName);
     private _issues: Set<IIssueKey> = new Set(issue => issue.issue_id);
     private _topSeverity: Severity;
-    private _dependencyId: string = this._generalInfo.artifactId;
+    private _xrayDependencyId: string = this._generalInfo.artifactId;
 
     constructor(
         protected _generalInfo: GeneralInfo,
@@ -34,12 +34,12 @@ export class DependenciesTreeNode extends vscode.TreeItem {
         }
     }
 
-    public get xrayId(): string {
-        return this._dependencyId;
+    public get xrayDependencyId(): string {
+        return this._xrayDependencyId;
     }
 
-    public set xrayId(value: string) {
-        this._dependencyId = value;
+    public set xrayDependencyId(value: string) {
+        this._xrayDependencyId = value;
     }
 
     public get componentId(): string {

--- a/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
+++ b/src/main/treeDataProviders/dependenciesTree/dependenciesTreeNode.ts
@@ -34,11 +34,11 @@ export class DependenciesTreeNode extends vscode.TreeItem {
         }
     }
 
-    public get dependencyId(): string {
+    public get xrayId(): string {
         return this._dependencyId;
     }
 
-    public set dependencyId(value: string) {
+    public set xrayId(value: string) {
         this._dependencyId = value;
     }
 

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -332,7 +332,7 @@ export class DependencyUtils {
             let issue: IVulnerability = issues[i];
             for (let [componentId, component] of Object.entries(issue.components)) {
                 const impactedPaths: IImpactGraph = descriptorGraph.createImpactedGraph(component.package_name, component.package_version);
-                if(impactedPaths.root){
+                if (impactedPaths.root) {
                     paths.set(issue.issue_id + componentId, {
                         root: {
                             name: this.getGraphName(descriptorGraph),

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -331,15 +331,17 @@ export class DependencyUtils {
         for (let i: number = 0; i < issues.length; i++) {
             let issue: IVulnerability = issues[i];
             for (let [componentId, component] of Object.entries(issue.components)) {
-                const ImpactedPaths: IImpactGraph = descriptorGraph.createImpactedGraph(component.package_name, component.package_version);
-                paths.set(issue.issue_id + componentId, {
-                    root: {
-                        name: this.getGraphName(descriptorGraph),
-                        children: ImpactedPaths.root.children
-                    },
-                    pathsCount: ImpactedPaths.pathsCount,
-                    pathsLimit: RootNode.IMPACT_PATHS_LIMIT
-                } as IImpactGraph);
+                const impactedPaths: IImpactGraph = descriptorGraph.createImpactedGraph(component.package_name, component.package_version);
+                if(impactedPaths.root){
+                    paths.set(issue.issue_id + componentId, {
+                        root: {
+                            name: this.getGraphName(descriptorGraph),
+                            children: impactedPaths.root?.children
+                        },
+                        pathsCount: impactedPaths.pathsCount,
+                        pathsLimit: RootNode.IMPACT_PATHS_LIMIT
+                    } as IImpactGraph);
+                }
             }
         }
         return paths;

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -12,7 +12,7 @@ import { MavenUtils } from '../../utils/mavenUtils';
 import { NpmUtils } from '../../utils/npmUtils';
 import { PypiUtils } from '../../utils/pypiUtils';
 import { YarnUtils } from '../../utils/yarnUtils';
-import { IImpactGraph, IImpactGraphNode, ILicense } from 'jfrog-ide-webview';
+import { IImpactGraph, ILicense } from 'jfrog-ide-webview';
 import { IssueTreeNode } from '../issuesTree/issueTreeNode';
 import { FocusType } from '../../constants/contextKeys';
 import { DependencyScanResults, ScanResults } from '../../types/workspaceIssuesDetails';
@@ -32,7 +32,6 @@ import { FileTreeNode } from '../issuesTree/fileTreeNode';
 
 export class DependencyUtils {
     public static readonly FAIL_TO_SCAN: string = '[Fail to scan]';
-    public static IMPACT_PATHS_LIMIT: number = 50;
 
     /**
      * Scan all the dependencies of a given package for security issues and populate the given data and view objects with the information.
@@ -328,17 +327,18 @@ export class DependencyUtils {
         if (!issues) {
             return paths;
         }
+
         for (let i: number = 0; i < issues.length; i++) {
             let issue: IVulnerability = issues[i];
             for (let [componentId, component] of Object.entries(issue.components)) {
-                const childGraph: IImpactGraph = this.getChildrenGraph(descriptorGraph, component, 0);
+                const ImpactedPaths: IImpactGraph = descriptorGraph.createImpactedGraph(component.package_name, component.package_version);
                 paths.set(issue.issue_id + componentId, {
                     root: {
                         name: this.getGraphName(descriptorGraph),
-                        children: childGraph.root.children
+                        children: ImpactedPaths.root.children
                     },
-                    pathsCount: childGraph.pathsCount,
-                    pathsLimit: DependencyUtils.IMPACT_PATHS_LIMIT
+                    pathsCount: ImpactedPaths.pathsCount,
+                    pathsLimit: RootNode.IMPACT_PATHS_LIMIT
                 } as IImpactGraph);
             }
         }
@@ -349,41 +349,6 @@ export class DependencyUtils {
         return descriptorGraph.componentId.endsWith(':')
             ? descriptorGraph.componentId.slice(0, descriptorGraph.componentId.length - 1)
             : descriptorGraph.componentId;
-    }
-
-    /**
-     * Retrieves the impact paths of all child components, recursively from a given root,
-     * The number of impact paths collected may be limited by the '{@link DependencyUtils.IMPACT_PATHS_LIMIT}'.
-     * @param root - the root to get it's children impact
-     * @param componentWithIssue - the component to generate the impact path for it
-     * @param size - the total size of the impacted path
-     */
-    private static getChildrenGraph(root: DependenciesTreeNode, componentWithIssue: IComponent, size: number): IImpactGraph {
-        let impactPaths: IImpactGraphNode[] = [];
-        for (let child of root.children) {
-            let impactChild: IImpactGraphNode | undefined = impactPaths.find(p => p.name === child.componentId);
-            if (!impactChild) {
-                if (child.componentId === componentWithIssue.package_name + ':' + componentWithIssue.package_version) {
-                    // Direct impact
-                    if (size < DependencyUtils.IMPACT_PATHS_LIMIT) {
-                        impactPaths.push({
-                            name: child.componentId
-                        } as IImpactGraphNode);
-                    }
-                    size++;
-                }
-                // indirect impact
-                let indirectImpact: IImpactGraph = this.getChildrenGraph(child, componentWithIssue, size);
-                if (!!indirectImpact.root.children?.length) {
-                    impactPaths.push({
-                        name: child.componentId,
-                        children: indirectImpact.root.children
-                    } as IImpactGraphNode);
-                }
-                size = indirectImpact.pathsCount ?? size;
-            }
-        }
-        return { root: { children: impactPaths }, pathsCount: size } as IImpactGraph;
     }
 
     /**

--- a/src/main/treeDataProviders/utils/yarnImpactGraph.ts
+++ b/src/main/treeDataProviders/utils/yarnImpactGraph.ts
@@ -5,7 +5,7 @@ import { ScanUtils } from '../../utils/scanUtils';
 type YarnWhyItem = StepItem | InfoItem;
 
 /**
- * Represents a step item in the Yarn "why" output.
+ * Represents a step item in the "yarn why" output.
  */
 interface StepItem {
     type: 'list';
@@ -13,7 +13,7 @@ interface StepItem {
 }
 
 /**
- * Represents an info item in the Yarn "why" output.
+ * Represents an info item in the "yarn why" output.
  */
 interface InfoItem {
     type: 'info';
@@ -28,7 +28,7 @@ interface ListData {
     items: string[];
 }
 /**
- * Utility class for creating an impact graph based on Yarn package manager's "why" command output.
+ * Utility class for creating an impact graph based on "yarn why" command output.
  */
 export class YarnImpactGraphUtil {
     /**
@@ -41,7 +41,7 @@ export class YarnImpactGraphUtil {
     constructor(private dependencyName: string, private dependencyVersion: string, private projectName: string, private workspaceFolder: string) {}
 
     /**
-     * Creates and returns an impact graph based on Yarn's "why" command output.
+     * Creates and returns an impact graph based on "yarn why" command output.
      * @returns An impact graph.
      */
     public create(): IImpactGraph {
@@ -54,7 +54,7 @@ export class YarnImpactGraphUtil {
     }
 
     /**
-     * Finds the dependency chain, aka, the path from the dependency to the root, based on the supplied Yarn "why" command output.
+     * Finds the dependency chain, aka, the path from the dependency to the root, based on the supplied "yarn why" command output.
      * The dependency chain may appear as a part of a text or in a list of reasons.
      *
      * Example 1 (Text):
@@ -63,7 +63,7 @@ export class YarnImpactGraphUtil {
      * Example 2 (List):
      * {"type":"list","data":{"type":"reasons","items":["Specified in \"dependencies\"","Hoisted from \"jest-cli#node-notifier#minimist\"","Hoisted from \"jest-cli#sane#minimist\""]}}
      *
-     * @param output - The Yarn "why" command output to analyze.
+     * @param output - The "yarn why" command output to analyze.
      * @returns A list of vulnerable dependency chains to the root.
      */
     private findDependencyChain(output: YarnWhyItem[]): string[] {
@@ -87,9 +87,9 @@ export class YarnImpactGraphUtil {
     }
 
     /**
-     * Dependency may present in multiple versions in yarn why output, therefore, finds the position of the specified version in the Yarn "why" command output.
+     * Dependency may present in multiple versions in yarn why output, therefore, finds the position of the specified version in the "yarn why" command output.
      * @param version - The version to search for.
-     * @param output - The Yarn "why" command output to search within.
+     * @param output - The "yarn why" command output to search within.
      * @returns The index of the found version or undefined if not found.
      */
     private findDependencyPosition(version: string, output: YarnWhyItem[]): number | undefined {
@@ -252,7 +252,7 @@ export class YarnImpactGraphUtil {
     }
 
     /**
-     * Executes the Yarn "why" command and parses its JSON output.
+     * Executes the "yarn why" command and parses its JSON output.
      */
     private runYarnWhy(): YarnWhyItem[] {
         const output: string = ScanUtils.executeCmd('yarn why --json --no-progress ' + this.dependencyName, this.workspaceFolder).toString();

--- a/src/main/treeDataProviders/utils/yarnImpactGraph.ts
+++ b/src/main/treeDataProviders/utils/yarnImpactGraph.ts
@@ -1,0 +1,264 @@
+import { IImpactGraph, IImpactGraphNode } from 'jfrog-ide-webview';
+import { RootNode } from '../dependenciesTree/dependenciesRoot/rootTree';
+import { ScanUtils } from '../../utils/scanUtils';
+
+type YarnWhyItem = StepItem | InfoItem;
+
+/**
+ * Represents a step item in the Yarn "why" output.
+ */
+interface StepItem {
+    type: 'list';
+    data: ListData;
+}
+
+/**
+ * Represents an info item in the Yarn "why" output.
+ */
+interface InfoItem {
+    type: 'info';
+    data: string;
+}
+
+/**
+ * Represents data within a step item, specifically a list of reasons.
+ */
+interface ListData {
+    type: 'reasons';
+    items: string[];
+}
+/**
+ * Utility class for creating an impact graph based on Yarn package manager's "why" command output.
+ */
+export class YarnImpactGraphUtil {
+    /**
+     * Creates an instance of YarnImpactGraphUtil.
+     * @param dependencyName - The name of the impact dependency.
+     * @param dependencyVersion - The version of the impact dependency.
+     * @param projectName - The name of the project.
+     * @param workspaceFolder - The folder where the project is located.
+     */
+    constructor(private dependencyName: string, private dependencyVersion: string, private projectName: string, private workspaceFolder: string) {}
+
+    /**
+     * Creates and returns an impact graph based on Yarn's "why" command output.
+     * @returns An impact graph.
+     */
+    public create(): IImpactGraph {
+        const dependencyChain: string[] | undefined = this.findDependencyChain(this.runYarnWhy());
+        if (dependencyChain) {
+            return this.createImpactGraphFromChains(dependencyChain);
+        }
+
+        return {} as IImpactGraph;
+    }
+
+    /**
+     * Finds the dependency chain, aka, the path from the dependency to the root, based on the supplied Yarn "why" command output.
+     * The dependency chain may appear as a part of a text or in a list of reasons.
+     *
+     * Example 1 (Text):
+     * {"type":"info","data":"This module exists because \"jest-cli#istanbul-api#mkdirp\" depends on it."}
+     *
+     * Example 2 (List):
+     * {"type":"list","data":{"type":"reasons","items":["Specified in \"dependencies\"","Hoisted from \"jest-cli#node-notifier#minimist\"","Hoisted from \"jest-cli#sane#minimist\""]}}
+     *
+     * @param output - The Yarn "why" command output to analyze.
+     * @returns A list of vulnerable dependency chains to the root.
+     */
+    private findDependencyChain(output: YarnWhyItem[]): string[] {
+        const startIndex: number | undefined = this.findDependencyPosition(this.dependencyVersion, output);
+        if (!startIndex) {
+            return [];
+        }
+        for (let i: number = startIndex + 1; i < output.length; i++) {
+            const item: YarnWhyItem = output[i];
+            switch (item.type) {
+                case 'list':
+                    return this.extractMultipleChain(item.data.items);
+                case 'info':
+                    if (item.data.startsWith('This module exists because')) {
+                        return this.extractMultipleChain([item.data]);
+                    }
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Dependency may present in multiple versions in yarn why output, therefore, finds the position of the specified version in the Yarn "why" command output.
+     * @param version - The version to search for.
+     * @param output - The Yarn "why" command output to search within.
+     * @returns The index of the found version or undefined if not found.
+     */
+    private findDependencyPosition(version: string, output: YarnWhyItem[]): number | undefined {
+        for (let i: number = 0; i < output.length; i++) {
+            const item: YarnWhyItem = output[i];
+            if (item.type === 'info' && item.data.includes(version)) {
+                return i;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Extracts multiple dependency chains from a list raw dependency string.
+     * @param list - An array of strings representing raw dependency chains.
+     * @returns An array of extracted dependency chains.
+     *
+     *  input - ["Specified in \"dependencies\"","Hoisted from \"jest-cli#node-notifier#minimist\"","Hoisted from \"jest-cli#sane#minimist\""]
+     *  output - ["minimist","jest-cli#node-notifier#minimist","jest-cli#sane#minimist"]
+     */
+    private extractMultipleChain(list: string[]): string[] {
+        const results: string[] = [];
+        list.forEach(item => {
+            const chain: string | undefined = this.extractChain(item);
+            if (chain) {
+                results.push(chain);
+            }
+        });
+        return results;
+    }
+
+    /**
+     * Extracts a single dependency chain from a raw dependency string.
+     * @param rawDependencyChain - The raw dependency chain string.
+     * @returns The extracted dependency chain or undefined if not found.
+     */
+    private extractChain(rawDependencyChain: string): string | undefined {
+        if (rawDependencyChain.toLocaleLowerCase().includes('specified in')) {
+            return this.dependencyName;
+        }
+        // Extract the path from the dependency chain using quotes
+        const startIndex: number = rawDependencyChain.indexOf('"');
+        const endIndex: number = rawDependencyChain.lastIndexOf('"');
+        if (startIndex !== -1 && endIndex !== -1) {
+            return rawDependencyChain.substring(startIndex + 1, endIndex);
+        }
+        return;
+    }
+
+    /**
+     * Creates an impact graph based on a list of dependency chains.
+     * @param chains - An array of dependency chains as strings.
+     * @returns An impact graph object.
+     */
+    private createImpactGraphFromChains(chains: string[]): IImpactGraph {
+        const trees: IImpactGraphNode[] = [];
+        for (let index: number = 0; index < chains.length && index < RootNode.IMPACT_PATHS_LIMIT; index++) {
+            trees.push(this.createImpactGraphNodeFromChain(chains[index]));
+        }
+        return {
+            root: this.mergeAllTrees(trees),
+            pathsCount: Math.min(RootNode.IMPACT_PATHS_LIMIT, chains.length),
+            pathsLimit: RootNode.IMPACT_PATHS_LIMIT
+        } as IImpactGraph;
+    }
+
+    /**
+     * Merges two impact graph trees into a single tree.
+     * @param root1 - The root of the first tree to be merged.
+     * @param root2 - The root of the second tree to be merged.
+     * @returns The merged impact graph tree.
+     */
+    public mergeTrees(root1: IImpactGraphNode | null, root2: IImpactGraphNode | null): IImpactGraphNode | null {
+        if (!root1 && !root2) {
+            return null;
+        }
+        if (!root1) {
+            return root2;
+        }
+        if (!root2) {
+            return root1;
+        }
+
+        // Create a merged node with the same name
+        const mergedNode: IImpactGraphNode = { name: root1.name };
+
+        // Merge the children recursively
+        if (root1.children && root2.children) {
+            const mergedChildren: IImpactGraphNode[] = [];
+
+            for (const child1 of root1.children) {
+                const matchingChild2: IImpactGraphNode | undefined = root2.children.find(child2 => child2.name === child1.name);
+
+                if (matchingChild2) {
+                    const tmp: IImpactGraphNode | null = this.mergeTrees(child1, matchingChild2);
+                    if (tmp) {
+                        mergedChildren.push(tmp);
+                    }
+                } else {
+                    mergedChildren.push(child1); // If not found in root2, keep the child from root1
+                }
+            }
+
+            for (const child2 of root2.children) {
+                const matchingChild1: IImpactGraphNode | undefined = root1.children.find(child1 => child1.name === child2.name);
+
+                if (!matchingChild1) {
+                    mergedChildren.push(child2); // Add children from root2 that are not present in root1
+                }
+            }
+
+            mergedNode.children = mergedChildren;
+        } else if (root1.children) {
+            mergedNode.children = root1.children;
+        } else {
+            mergedNode.children = root2.children;
+        }
+
+        return mergedNode;
+    }
+
+    /**
+     * Merges multiple impact graph trees into a single tree.
+     * @param trees - An array of impact graph trees.
+     * @returns The merged impact graph tree.
+     */
+    public mergeAllTrees(trees: IImpactGraphNode[]): IImpactGraphNode | null {
+        if (trees.length === 0) {
+            return null;
+        }
+
+        let mergedTree: IImpactGraphNode | null = trees[0];
+
+        for (let i: number = 1; i < trees.length; i++) {
+            mergedTree = this.mergeTrees(mergedTree, trees[i]);
+        }
+        return mergedTree;
+    }
+
+    /**
+     * Creates an impact graph node from a single dependency chain.
+     * @param chain - A single dependency chain as a string.
+     * @returns An impact graph node.
+     */
+    private createImpactGraphNodeFromChain(chain: string): IImpactGraphNode {
+        const splitted: string[] = chain.split('#');
+        let currentNode: IImpactGraphNode = { name: this.projectName };
+        const root: IImpactGraphNode = currentNode;
+        for (const item of splitted) {
+            const child: IImpactGraphNode = { name: item };
+            currentNode.children = [child];
+            currentNode = child;
+        }
+        if (currentNode.name !== this.dependencyName) {
+            currentNode.children = [{ name: this.dependencyName + ':' + this.dependencyVersion }];
+        } else {
+            currentNode.name = this.dependencyName + ':' + this.dependencyVersion;
+        }
+        return root;
+    }
+
+    /**
+     * Executes the Yarn "why" command and parses its JSON output.
+     */
+    private runYarnWhy(): YarnWhyItem[] {
+        const output: string = ScanUtils.executeCmd('yarn why --json --no-progress ' + this.dependencyName, this.workspaceFolder).toString();
+        return output
+            .split('\n')
+            .filter(line => line.trim() !== '')
+            .map((line: string) => JSON.parse(line));
+    }
+}

--- a/src/main/treeDataProviders/utils/yarnImpactGraph.ts
+++ b/src/main/treeDataProviders/utils/yarnImpactGraph.ts
@@ -2,7 +2,7 @@ import { IImpactGraph, IImpactGraphNode } from 'jfrog-ide-webview';
 import { RootNode } from '../dependenciesTree/dependenciesRoot/rootTree';
 import { ScanUtils } from '../../utils/scanUtils';
 
-type YarnWhyItem = StepItem | InfoItem;
+export type YarnWhyItem = StepItem | InfoItem;
 
 /**
  * Represents a step item in the "yarn why" output.
@@ -68,7 +68,8 @@ export class YarnImpactGraphUtil {
      */
     private findDependencyChain(output: YarnWhyItem[]): string[] {
         const startIndex: number | undefined = this.findDependencyPosition(this.dependencyVersion, output);
-        if (!startIndex) {
+        // Zero could be a valid index
+        if (startIndex === undefined) {
             return [];
         }
         for (let i: number = startIndex + 1; i < output.length; i++) {
@@ -254,7 +255,7 @@ export class YarnImpactGraphUtil {
     /**
      * Executes the "yarn why" command and parses its JSON output.
      */
-    private runYarnWhy(): YarnWhyItem[] {
+    protected runYarnWhy(): YarnWhyItem[] {
         const output: string = ScanUtils.executeCmd('yarn why --json --no-progress ' + this.dependencyName, this.workspaceFolder).toString();
         return output
             .split('\n')

--- a/src/main/types/projectDetails.ts
+++ b/src/main/types/projectDetails.ts
@@ -1,10 +1,7 @@
-import { ComponentDetails } from 'jfrog-client-js';
 import * as path from 'path';
 import { PackageType } from './projectType';
-import Set from 'typescript-collections/dist/lib/Set';
 
 export class ProjectDetails {
-    private _dependencies: Set<ComponentDetails> = new Set<ComponentDetails>();
     private _name: string;
 
     constructor(private _path: string, private _type: PackageType) {
@@ -33,24 +30,5 @@ export class ProjectDetails {
 
     public set path(value: string) {
         this._path = value;
-    }
-
-    public get dependencies(): Set<ComponentDetails> {
-        return this._dependencies;
-    }
-
-    public set dependencies(value: Set<ComponentDetails>) {
-        this._dependencies = value;
-    }
-
-    /**
-     * @param dependencyId - component id of the dependency
-     */
-    public addDependency(dependencyId: string) {
-        this._dependencies.add(new ComponentDetails(dependencyId));
-    }
-
-    public toArray(): ComponentDetails[] {
-        return this._dependencies.toArray();
     }
 }

--- a/src/main/utils/yarnUtils.ts
+++ b/src/main/utils/yarnUtils.ts
@@ -74,7 +74,7 @@ export class YarnUtils {
             }
             checkCanceled();
 
-            root.refreshDependencies();
+            root.loadYarnDependencies();
         }
     }
 

--- a/src/test/tests/dependencyUtils.test.ts
+++ b/src/test/tests/dependencyUtils.test.ts
@@ -83,7 +83,7 @@ describe('Dependency Utils Tests', () => {
                 ]
             } as IImpactGraphNode,
             pathsCount: 2,
-            pathsLimit: DependencyUtils.IMPACT_PATHS_LIMIT
+            pathsLimit: RootNode.IMPACT_PATHS_LIMIT
         } as IImpactGraph);
         map.set('XRAY-191882' + 'C:2.0.0', {
             root: {
@@ -91,7 +91,7 @@ describe('Dependency Utils Tests', () => {
                 children: [{ name: 'C:2.0.0' } as IImpactGraphNode]
             },
             pathsCount: 1,
-            pathsLimit: DependencyUtils.IMPACT_PATHS_LIMIT
+            pathsLimit: RootNode.IMPACT_PATHS_LIMIT
         } as IImpactGraph);
         // issue XRAY-94201, for components B:1.0.0
         map.set('XRAY-94201' + 'B:1.0.0', {
@@ -100,7 +100,7 @@ describe('Dependency Utils Tests', () => {
                 children: [{ name: 'B:1.0.0' } as IImpactGraphNode]
             },
             pathsCount: 1,
-            pathsLimit: DependencyUtils.IMPACT_PATHS_LIMIT
+            pathsLimit: RootNode.IMPACT_PATHS_LIMIT
         } as IImpactGraph);
         // issue XRAY-142007, for components [A:1.0.1, C:2.0.0]
         map.set('XRAY-142007' + 'A:1.0.1', {
@@ -109,7 +109,7 @@ describe('Dependency Utils Tests', () => {
                 children: [{ name: 'B:1.0.0', children: [{ name: 'A:1.0.1' } as IImpactGraphNode] } as IImpactGraphNode]
             },
             pathsCount: 1,
-            pathsLimit: DependencyUtils.IMPACT_PATHS_LIMIT
+            pathsLimit: RootNode.IMPACT_PATHS_LIMIT
         } as IImpactGraph);
         map.set('XRAY-142007' + 'C:2.0.0', {
             root: {
@@ -117,7 +117,7 @@ describe('Dependency Utils Tests', () => {
                 children: [{ name: 'C:2.0.0' } as IImpactGraphNode]
             },
             pathsCount: 1,
-            pathsLimit: DependencyUtils.IMPACT_PATHS_LIMIT
+            pathsLimit: RootNode.IMPACT_PATHS_LIMIT
         } as IImpactGraph);
         return map;
     }
@@ -139,15 +139,15 @@ describe('Dependency Utils Tests', () => {
 
     describe('Limit impacted graph', () => {
         it('Set paths limit to 1', () => {
-            const ORIGIN_IMPACT_PATHS_LIMIT: number = DependencyUtils.IMPACT_PATHS_LIMIT;
-            DependencyUtils.IMPACT_PATHS_LIMIT = 1;
+            const ORIGIN_IMPACT_PATHS_LIMIT: number = RootNode.IMPACT_PATHS_LIMIT;
+            RootNode.IMPACT_PATHS_LIMIT = 1;
 
             let impactedTree: Map<string, IImpactGraph> = DependencyUtils.createImpactedGraph(root, getGraphResponse('scanGraphVulnerabilities'));
 
             assert.equal(impactedTree.get('XRAY-191882A:1.0.0')?.pathsCount, 2);
             assert.equal(impactedTree.get('XRAY-191882A:1.0.0')?.root.children?.length, 1);
 
-            DependencyUtils.IMPACT_PATHS_LIMIT = ORIGIN_IMPACT_PATHS_LIMIT;
+            RootNode.IMPACT_PATHS_LIMIT = ORIGIN_IMPACT_PATHS_LIMIT;
         });
     });
 

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -97,14 +97,14 @@ describe('Go Utils Tests', async () => {
         let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(
             new GeneralInfo('github.com/jfrog/jfrog-cli-core', '1.9.1', [], '', PackageType.Go)
         );
-        let dependencyPos: vscode.Range[] = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.xrayId, FocusType.Dependency);
+        let dependencyPos: vscode.Range[] = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.xrayDependencyId, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0].start, new vscode.Position(5, 1));
         assert.deepEqual(dependencyPos[0].end, new vscode.Position(5, 39));
 
         // Test 'resources/go/empty/go.mod'
         goMod = vscode.Uri.file(path.join(commonProjDir.fsPath, 'empty', 'go.mod'));
         textDocument = await vscode.workspace.openTextDocument(goMod);
-        dependencyPos = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.xrayId, FocusType.Dependency);
+        dependencyPos = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.xrayDependencyId, FocusType.Dependency);
         assert.isEmpty(dependencyPos);
     });
 

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -97,14 +97,14 @@ describe('Go Utils Tests', async () => {
         let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(
             new GeneralInfo('github.com/jfrog/jfrog-cli-core', '1.9.1', [], '', PackageType.Go)
         );
-        let dependencyPos: vscode.Range[] = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.dependencyId, FocusType.Dependency);
+        let dependencyPos: vscode.Range[] = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.xrayId, FocusType.Dependency);
         assert.deepEqual(dependencyPos[0].start, new vscode.Position(5, 1));
         assert.deepEqual(dependencyPos[0].end, new vscode.Position(5, 39));
 
         // Test 'resources/go/empty/go.mod'
         goMod = vscode.Uri.file(path.join(commonProjDir.fsPath, 'empty', 'go.mod'));
         textDocument = await vscode.workspace.openTextDocument(goMod);
-        dependencyPos = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.dependencyId, FocusType.Dependency);
+        dependencyPos = GoUtils.getDependencyPosition(textDocument, dependenciesTreeNode.xrayId, FocusType.Dependency);
         assert.isEmpty(dependencyPos);
     });
 

--- a/src/test/tests/utils/treeNodeUtils.test.ts
+++ b/src/test/tests/utils/treeNodeUtils.test.ts
@@ -59,7 +59,7 @@ export function createRootTestNode(pathOfWorkspace: string): IssuesRootTreeNode 
 
 export function createDependency(artifactId: string, version: string, parent?: DependenciesTreeNode): DependenciesTreeNode {
     let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo(artifactId, version, [], '', PackageType.Unknown));
-    dependenciesTreeNode.xrayId = artifactId + ':' + version;
+    dependenciesTreeNode.xrayDependencyId = artifactId + ':' + version;
     parent?.addChild(dependenciesTreeNode);
     return dependenciesTreeNode;
 }

--- a/src/test/tests/utils/treeNodeUtils.test.ts
+++ b/src/test/tests/utils/treeNodeUtils.test.ts
@@ -59,7 +59,7 @@ export function createRootTestNode(pathOfWorkspace: string): IssuesRootTreeNode 
 
 export function createDependency(artifactId: string, version: string, parent?: DependenciesTreeNode): DependenciesTreeNode {
     let dependenciesTreeNode: DependenciesTreeNode = new DependenciesTreeNode(new GeneralInfo(artifactId, version, [], '', PackageType.Unknown));
-    dependenciesTreeNode.dependencyId = artifactId + ':' + version;
+    dependenciesTreeNode.xrayId = artifactId + ':' + version;
     parent?.addChild(dependenciesTreeNode);
     return dependenciesTreeNode;
 }

--- a/src/test/tests/yarnImpactGraph.test.ts
+++ b/src/test/tests/yarnImpactGraph.test.ts
@@ -2,15 +2,16 @@ import { IImpactGraph } from 'jfrog-ide-webview';
 import { YarnImpactGraphCreator, YarnWhyItem } from '../../main/treeDataProviders/utils/yarnImpactGraph';
 import { assert } from 'chai';
 import { RootNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree';
+import { LogManager } from '../../main/log/logManager';
 
 describe('Yarn impact graph util', async () => {
-    it('Build single impact graph', async () => {
-        const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '0.0.8', 'Mock-Project', '').create();
+    it.only('Build single impact graph', async () => {
+        const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '0.0.8', 'Mock-Project', '', new LogManager().activate()).create();
         assert.deepEqual(results, generateExpectedSingleImpactGraph());
     });
 
     it('Build multiple impact graphs', async () => {
-        const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '1.2.0', 'Mock-Project', '').create();
+        const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '1.2.0', 'Mock-Project', '', new LogManager().activate()).create();
         assert.deepEqual(results, generateExpectedMultipleImpactGraphs());
     });
 });

--- a/src/test/tests/yarnImpactGraph.test.ts
+++ b/src/test/tests/yarnImpactGraph.test.ts
@@ -5,7 +5,7 @@ import { RootNode } from '../../main/treeDataProviders/dependenciesTree/dependen
 import { LogManager } from '../../main/log/logManager';
 
 describe('Yarn impact graph util', async () => {
-    it.only('Build single impact graph', async () => {
+    it('Build single impact graph', async () => {
         const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '0.0.8', 'Mock-Project', '', new LogManager().activate()).create();
         assert.deepEqual(results, generateExpectedSingleImpactGraph());
     });

--- a/src/test/tests/yarnImpactGraph.test.ts
+++ b/src/test/tests/yarnImpactGraph.test.ts
@@ -1,0 +1,144 @@
+import { IImpactGraph } from 'jfrog-ide-webview';
+import { YarnImpactGraphUtil, YarnWhyItem } from '../../main/treeDataProviders/utils/yarnImpactGraph';
+import { assert } from 'chai';
+import { RootNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree';
+
+describe('Yarn impact graph util', async () => {
+    it('Build single impact graph', async () => {
+        const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '0.0.8', 'Mock-Project', '').create();
+        assert.deepEqual(results, generateExpectedSingleImpactGraph());
+    });
+
+    it.only('Build multiple impact graphs', async () => {
+        const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '1.2.0', 'Mock-Project', '').create();
+        assert.deepEqual(results, generateExpectedMultipleImpactGraphs());
+    });
+});
+
+class YarnImpactGraphUtilMock extends YarnImpactGraphUtil {
+    protected runYarnWhy(): YarnWhyItem[] {
+        const yarnWhyOutput: YarnWhyItem[] = [
+            {
+                type: 'info',
+                data: '\r=> Found "minimist@1.2.0"'
+            },
+            {
+                type: 'info',
+                data: 'Has been hoisted to "minimist"'
+            },
+            {
+                type: 'info',
+                data: 'Reasons this module exists'
+            },
+            {
+                type: 'list',
+                data: {
+                    type: 'reasons',
+                    items: [
+                        'Specified in "dependencies"',
+                        'Hoisted from "jest-cli#node-notifier#minimist"',
+                        'Hoisted from "jest-cli#sane#minimist"',
+                        'Hoisted from "jest-cli#istanbul-lib-instrument#babel-generator#detect-indent#minimist"'
+                    ]
+                }
+            },
+            {
+                type: 'info',
+                data: 'Disk size without dependencies: "96KB"'
+            },
+            {
+                type: 'info',
+                data: '\r=> Found "mkdirp#minimist@0.0.8"'
+            },
+            {
+                type: 'info',
+                data: 'This module exists because "jest-cli#istanbul-api#mkdirp" depends on it.'
+            }
+        ];
+        return yarnWhyOutput;
+    }
+}
+
+function generateExpectedSingleImpactGraph(): IImpactGraph {
+    return {
+        root: {
+            name: 'Mock-Project',
+            children: [
+                {
+                    name: 'jest-cli',
+                    children: [
+                        {
+                            name: 'istanbul-api',
+                            children: [
+                                {
+                                    name: 'mkdirp',
+                                    children: [
+                                        {
+                                            name: 'minimist:0.0.8'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        pathsCount: 1,
+        pathsLimit: RootNode.IMPACT_PATHS_LIMIT
+    };
+}
+
+function generateExpectedMultipleImpactGraphs(): IImpactGraph {
+    return {
+        root: {
+            name: 'Mock-Project',
+            children: [
+                {
+                    name: 'minimist:1.2.0'
+                },
+                {
+                    name: 'jest-cli',
+                    children: [
+                        {
+                            name: 'node-notifier',
+                            children: [
+                                {
+                                    name: 'minimist:1.2.0'
+                                }
+                            ]
+                        },
+                        {
+                            name: 'sane',
+                            children: [
+                                {
+                                    name: 'minimist:1.2.0'
+                                }
+                            ]
+                        },
+                        {
+                            name: 'istanbul-lib-instrument',
+                            children: [
+                                {
+                                    name: 'babel-generator',
+                                    children: [
+                                        {
+                                            name: 'detect-indent',
+                                            children: [
+                                                {
+                                                    name: 'minimist:1.2.0'
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        pathsCount: 4,
+        pathsLimit: RootNode.IMPACT_PATHS_LIMIT
+    };
+}

--- a/src/test/tests/yarnImpactGraph.test.ts
+++ b/src/test/tests/yarnImpactGraph.test.ts
@@ -1,5 +1,5 @@
 import { IImpactGraph } from 'jfrog-ide-webview';
-import { YarnImpactGraphUtil, YarnWhyItem } from '../../main/treeDataProviders/utils/yarnImpactGraph';
+import { YarnImpactGraphCreator, YarnWhyItem } from '../../main/treeDataProviders/utils/yarnImpactGraph';
 import { assert } from 'chai';
 import { RootNode } from '../../main/treeDataProviders/dependenciesTree/dependenciesRoot/rootTree';
 
@@ -9,13 +9,13 @@ describe('Yarn impact graph util', async () => {
         assert.deepEqual(results, generateExpectedSingleImpactGraph());
     });
 
-    it.only('Build multiple impact graphs', async () => {
+    it('Build multiple impact graphs', async () => {
         const results: IImpactGraph = new YarnImpactGraphUtilMock('minimist', '1.2.0', 'Mock-Project', '').create();
         assert.deepEqual(results, generateExpectedMultipleImpactGraphs());
     });
 });
 
-class YarnImpactGraphUtilMock extends YarnImpactGraphUtil {
+class YarnImpactGraphUtilMock extends YarnImpactGraphCreator {
     protected runYarnWhy(): YarnWhyItem[] {
         const yarnWhyOutput: YarnWhyItem[] = [
             {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Prior to this PR, there was an issue with the way Yarn calculated the impact graph. The problem intruduced from using the 'yarn list' output. The 'yarn list' output did not accurately represent the project's dependencies as it removed duplicate leaves and flattened the tree structure.

In order to resolve this issue, this PR changes the following:

1. Instead of constructing the entire dependency tree, we now compute only a partial tree. This partial tree specifically represents the paths from the project's root to the vulnerable dependencies only. This modification eliminates the need to calculate the entire tree, which not only reduces memory consumption but also aligns with our goal of displaying **only** paths to vulnerable dependencies.

2. Rather than relying on `yarn list`, we have switched to using `yarn why` which provides the correct path to a specific dependency. This involves gathering all vulnerable dependencies and utilizing 'yarn why' to map out the path of each dependency from the root.