### PR TITLE
Applicability scanner scans the venv parent dir

### DIFF
--- a/src/main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode.ts
@@ -24,7 +24,7 @@ export class DependencyIssuesTreeNode extends vscode.TreeItem {
 
         this._name = component.package_name;
         this._version = component.package_version;
-        this._type = _parent.type
+        this._type = _parent.type;
         this.description = this._version + (_indirect ? ' (indirect)' : '');
         this.contextValue += ContextKeys.COPY_TO_CLIPBOARD_ENABLED;
     }

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -287,18 +287,28 @@ export class AnalyzerUtils {
         for (let [fileScanBundle, cvesToScan] of filteredBundles) {
             let descriptorIssues: DependencyScanResults = <DependencyScanResults>fileScanBundle.data;
             // Map information to similar directory space
-            let spacePath: string = path.dirname(descriptorIssues.fullPath);
-            if (fileScanBundle instanceof EnvironmentTreeNode) {
-                spacePath = descriptorIssues.fullPath;
+            let workspacePath: string = AnalyzerUtils.getWorkspacePath(fileScanBundle.dataNode, descriptorIssues.fullPath);
+            if (!workspaceToScanBundles.has(workspacePath)) {
+                workspaceToScanBundles.set(workspacePath, new Map<FileScanBundle, Set<string>>());
             }
-            if (!workspaceToScanBundles.has(spacePath)) {
-                workspaceToScanBundles.set(spacePath, new Map<FileScanBundle, Set<string>>());
-            }
-            workspaceToScanBundles.get(spacePath)?.set(fileScanBundle, cvesToScan);
+            workspaceToScanBundles.get(workspacePath)?.set(fileScanBundle, cvesToScan);
             logManager.logMessage('Adding data from descriptor ' + descriptorIssues.fullPath + ' for cve applicability scan', 'INFO');
         }
 
         return workspaceToScanBundles;
+    }
+
+    /**
+     * Retrieve the workspace path, whether it's a file or an environment.
+     * @param fileScanBundle - The data node for file tree, usually DescriptorTreeNode or EnvironmentTreeNode
+     * @param fullWorkspacePath - Full path to the scanning directory or file
+     * @returns the path to the workspace directory
+     */
+    private static getWorkspacePath(fileScanBundle: FileTreeNode | undefined, fullWorkspacePath: string): string {
+        if (fileScanBundle instanceof EnvironmentTreeNode) {
+            return fullWorkspacePath;
+        }
+        return path.dirname(fullWorkspacePath);
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

This problem pertains to the Applicability scan in Python projects:
When gathering the directories for running the applicability scan, we erroneously select the parent directory of the workspace instead of the workspace itself. This can lead to running the applicability scan on irrelevant directories, ultimately resulting in a timeout issue in my environment.

In a more technical sense, we perform `fileScanBundle instanceof EnvironmentTreeNode` instead of `fileScanBundle.dataNode instanceof EnvironmentTreeNode`.