### PR TITLE
Add Feedback button

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
             },
             {
                 "command": "jfrog.open.feedback",
-                "title": "Sends us feedback",
+                "title": "Send us feedback",
                 "icon": "$(feedback)",
                 "category": "JFrog"
             },

--- a/package.json
+++ b/package.json
@@ -138,6 +138,12 @@
                 "category": "JFrog"
             },
             {
+                "command": "jfrog.open.feedback",
+                "title": "Sends us feedback",
+                "icon": "$(feedback)",
+                "category": "JFrog"
+            },
+            {
                 "command": "jfrog.scan.refresh",
                 "title": "Refresh",
                 "icon": {
@@ -244,6 +250,11 @@
                     "command": "jfrog.open.settings",
                     "when": "view == jfrog.view.ci.issues || view == jfrog.issues",
                     "group": "navigation@5"
+                },
+                {
+                    "command": "jfrog.open.feedback",
+                    "when": "view == jfrog.view.ci.issues || view == jfrog.issues",
+                    "group": "navigation@6"
                 }
             ],
             "view/item/context": [

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -41,6 +41,7 @@ export class CommandManager implements ExtensionComponent {
         this.registerCommand(context, 'jfrog.xray.reConnect', () => this.doReconnect());
         // General
         this.registerCommand(context, 'jfrog.open.settings', () => Utils.openSettings());
+        this.registerCommand(context, 'jfrog.open.feedback', () => Utils.openFeedback());
         this.registerCommand(context, 'jfrog.xray.copyToClipboard', node => this.doCopyToClipboard(node));
         this.registerCommand(context, 'jfrog.xray.showOutput', () => this.showOutput());
         this.registerCommand(context, 'jfrog.scan.refresh', () => this.doRefresh());

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -20,7 +20,7 @@ export class Utils {
     }
 
     public static async openFeedback(): Promise<void> {
-        await vscode.env.openExternal(vscode.Uri.parse("https://github.com/jfrog/jfrog-vscode-extension/discussions/new?category=product-feedback"));
+        await vscode.env.openExternal(vscode.Uri.parse("https://github.com/jfrog/jfrog-vscode-extension/discussions/new/choose"));
     }
 
     public static combineSets(sets: Set<string>[]): Set<string> {

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -19,6 +19,10 @@ export class Utils {
         await vscode.commands.executeCommand('workbench.action.openSettings', `@ext:${Utils.getExtensionId()}` + (id ? ` ${id}` : ''));
     }
 
+    public static async openFeedback(): Promise<void> {
+        await vscode.env.openExternal(vscode.Uri.parse("https://github.com/jfrog/jfrog-vscode-extension/discussions/new?category=product-feedback"));
+    }
+
     public static combineSets(sets: Set<string>[]): Set<string> {
         return new Set<string>(...sets);
     }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
The navigation tool bar now includes a Feedback button. By clicking on it, the user will be redirected to the 'Product Feedback' category on Github.

![image](https://github.com/jfrog/jfrog-vscode-extension/assets/9606235/b240019e-5d1a-4c53-9d33-1c469301553f)
