### PR TITLE
Unreleased bug - Redundant read from SecretStore

### DIFF
--- a/src/main/connect/connectionManager.ts
+++ b/src/main/connect/connectionManager.ts
@@ -579,11 +579,7 @@ export class ConnectionManager implements ExtensionComponent, vscode.Disposable 
      * @returns The secret if found.
      */
     private async getSecretFromSecretStorage(keyPair: string): Promise<string> {
-        return (
-            (await this._context.secrets.get(this.createSecretStoreId(this._url, keyPair))) ||
-            (await this._context.secrets.get(this.createSecretStoreId(this._xrayUrl, keyPair))) ||
-            ''
-        );
+        return (await this._context.secrets.get(this.createSecretStoreId(this._xrayUrl, keyPair))) || '';
     }
 
     private async deletePasswordFromSecretStorage(): Promise<void> {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
