### PR TITLE
Change SAST log messages and  update config default root

### DIFF
--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -56,7 +56,7 @@ export class ApplicabilityRunner extends JasRunner {
         logManager: LogManager,
         binary?: Resource
     ) {
-        super(connectionManager, ScanType.AnalyzeApplicability, logManager, new AppsConfigModule(), binary);
+        super(connectionManager, ScanType.AnalyzeApplicability, logManager, new AppsConfigModule(__dirname), binary);
     }
 
     /** @override */

--- a/src/main/scanLogic/scanRunners/jasRunner.ts
+++ b/src/main/scanLogic/scanRunners/jasRunner.ts
@@ -51,7 +51,7 @@ export abstract class JasRunner {
     public static readonly RUNNER_VERSION: string = '1.3.2.2019257';
     private static readonly DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1/';
 
-    // 5 min
+    // 8 min
     public static readonly TIMEOUT_MILLISECS: number = 1000 * 60 * 8;
 
     public static readonly NOT_ENTITLED: number = 31;

--- a/src/main/scanLogic/scanRunners/jasRunner.ts
+++ b/src/main/scanLogic/scanRunners/jasRunner.ts
@@ -52,7 +52,7 @@ export abstract class JasRunner {
     private static readonly DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1/';
 
     // 5 min
-    public static readonly TIMEOUT_MILLISECS: number = 1000 * 60 * 5;
+    public static readonly TIMEOUT_MILLISECS: number = 1000 * 60 * 8;
 
     public static readonly NOT_ENTITLED: number = 31;
     public static readonly NOT_SUPPORTED: number = 13;
@@ -186,7 +186,7 @@ export abstract class JasRunner {
 
     protected logStartScanning(request: AnalyzeScanRequest): void {
         this._logManager.logMessage(
-            `Scanning directories ' ${request.roots} + ', for ${this._scanType} issues. Skipping folders: ${request.skipped_folders}`,
+            `Scanning directories '${request.roots}', for ${this._scanType} issues. Skipping folders: ${request.skipped_folders}`,
             'DEBUG'
         );
     }

--- a/src/main/scanLogic/scanRunners/sastScan.ts
+++ b/src/main/scanLogic/scanRunners/sastScan.ts
@@ -95,7 +95,7 @@ export class SastRunner extends JasRunner {
             excluded_rules: this._config.getExcludeRules(),
             exclude_patterns: this._config.GetExcludePatterns(this._scanType)
         } as SastScanRequest;
-        super.logStartScanning(request);
+        this.logStartScanning(request);
         let response: AnalyzerScanResponse | undefined = await this.executeRequest(this._progressManager.checkCancel, request);
         let sastScanResponse: SastScanResponse = this.generateScanResponse(response);
         if (response) {
@@ -108,6 +108,13 @@ export class SastRunner extends JasRunner {
         this._progressManager.reportProgress();
     }
 
+    /** @override */
+    protected logStartScanning(request: SastScanRequest): void {
+        this._logManager.logMessage(
+            `Scanning directory ' ${request.roots}', for ${this._scanType} Skipping folders: ${request.exclude_patterns}`,
+            'DEBUG'
+        );
+    }
     /**
      * Generate response from the run results
      * @param response - Run results generated from the binary

--- a/src/main/utils/jfrogAppsConfig/jfrogAppsConfig.ts
+++ b/src/main/utils/jfrogAppsConfig/jfrogAppsConfig.ts
@@ -19,13 +19,16 @@ export class JFrogAppsConfig {
             this._version = jfrogAppsConfig.version;
             if (jfrogAppsConfig.modules) {
                 for (let module of jfrogAppsConfig.modules) {
-                    this._modules.push(new AppsConfigModule(module));
+                    if (module.source_root) {
+                        module.source_root = workspace;
+                    }
+                    this._modules.push(new AppsConfigModule(workspace, module));
                 }
             }
         }
         // If no modules provides, push a default module
         if (this._modules.length === 0) {
-            this._modules.push(new AppsConfigModule({ source_root: workspace } as Module));
+            this._modules.push(new AppsConfigModule(workspace));
         }
     }
 
@@ -45,10 +48,10 @@ export class AppsConfigModule {
     private _excludeScanners: ScanType[] = [];
     private _scanners: Map<ScanType, Scanner> = new Map<ScanType, Scanner>();
 
-    constructor(module?: Module) {
+    constructor(defaultWorkspace: string, module?: Module) {
         module = module || ({} as Module);
         this._name = module.name;
-        this._sourceRoot = this.getModuleSourceRoot(module);
+        this._sourceRoot = this.getModuleSourceRoot(module, defaultWorkspace);
         this._excludePatterns = module.exclude_patterns || [];
         if (module.exclude_scanners) {
             for (let excludeScanner of module.exclude_scanners) {
@@ -127,12 +130,12 @@ export class AppsConfigModule {
         return scanner.excluded_rules;
     }
 
-    private getModuleSourceRoot(module: Module) {
+    private getModuleSourceRoot(module: Module, defaultWorkspace: string) {
         let sourceRoot: string = module.source_root || '';
         if (path.isAbsolute(sourceRoot)) {
             return sourceRoot;
         } else {
-            return path.join(__dirname, sourceRoot);
+            return path.join(defaultWorkspace, sourceRoot);
         }
     }
 

--- a/src/main/utils/jfrogAppsConfig/jfrogAppsConfig.ts
+++ b/src/main/utils/jfrogAppsConfig/jfrogAppsConfig.ts
@@ -19,9 +19,6 @@ export class JFrogAppsConfig {
             this._version = jfrogAppsConfig.version;
             if (jfrogAppsConfig.modules) {
                 for (let module of jfrogAppsConfig.modules) {
-                    if (module.source_root) {
-                        module.source_root = workspace;
-                    }
                     this._modules.push(new AppsConfigModule(workspace, module));
                 }
             }

--- a/src/test/tests/appsConfig.test.ts
+++ b/src/test/tests/appsConfig.test.ts
@@ -42,7 +42,7 @@ describe('JFrog Apps Config Tests', () => {
         { excludeScanners: [ExcludeScannerName.Secrets, ExcludeScannerName.ContextualAnalysis] as ExcludeScannerName[], shouldSkip: true }
     ].forEach(testCase => {
         it('Should skip scanner - ' + testCase.excludeScanners, () => {
-            let module: AppsConfigModule = new AppsConfigModule(__dirname, { exclude_scanners: testCase.excludeScanners } as Module);
+            let module: AppsConfigModule = new AppsConfigModule('', { exclude_scanners: testCase.excludeScanners } as Module);
             assert.equal(module.ShouldSkipScanner(ScanType.AnalyzeApplicability), testCase.shouldSkip);
         });
     });
@@ -96,7 +96,7 @@ describe('JFrog Apps Config Tests', () => {
         { scanner: { exclude_patterns: ['exclude-dir-1', 'exclude-dir-2'] } as Scanner }
     ].forEach(testCase => {
         it('Get exclude patterns - ' + testCase.scanner?.exclude_patterns, () => {
-            let module: AppsConfigModule = new AppsConfigModule(__dirname, {
+            let module: AppsConfigModule = new AppsConfigModule('', {
                 exclude_patterns: ['exclude-root'],
                 scanners: { secrets: testCase?.scanner }
             } as Module);

--- a/src/test/tests/appsConfig.test.ts
+++ b/src/test/tests/appsConfig.test.ts
@@ -42,7 +42,7 @@ describe('JFrog Apps Config Tests', () => {
         { excludeScanners: [ExcludeScannerName.Secrets, ExcludeScannerName.ContextualAnalysis] as ExcludeScannerName[], shouldSkip: true }
     ].forEach(testCase => {
         it('Should skip scanner - ' + testCase.excludeScanners, () => {
-            let module: AppsConfigModule = new AppsConfigModule({ exclude_scanners: testCase.excludeScanners } as Module);
+            let module: AppsConfigModule = new AppsConfigModule(__dirname, { exclude_scanners: testCase.excludeScanners } as Module);
             assert.equal(module.ShouldSkipScanner(ScanType.AnalyzeApplicability), testCase.shouldSkip);
         });
     });
@@ -56,7 +56,10 @@ describe('JFrog Apps Config Tests', () => {
     getSourceRootCases.forEach(testCase => {
         it('Get source roots - With module source - ' + testCase.scanner?.working_dirs, () => {
             let sourceRoot: string = path.join(__dirname, 'source-root');
-            let module: AppsConfigModule = new AppsConfigModule({ source_root: sourceRoot, scanners: { iac: testCase?.scanner } } as Module);
+            let module: AppsConfigModule = new AppsConfigModule(sourceRoot, {
+                source_root: sourceRoot,
+                scanners: { iac: testCase?.scanner }
+            } as Module);
             let actualSourceRoots: string[] = module.GetSourceRoots(ScanType.Iac);
             if (!testCase.scanner) {
                 assert.sameMembers(actualSourceRoots, [module.sourceRoot]);
@@ -73,7 +76,7 @@ describe('JFrog Apps Config Tests', () => {
     getSourceRootCases.forEach(testCase => {
         it('Get source roots - With module source ' + testCase.scanner?.working_dirs, () => {
             let sourceRoot: string = path.join(__dirname, 'source-root');
-            let module: AppsConfigModule = new AppsConfigModule({ source_root: sourceRoot, scanners: { iac: testCase?.scanner } } as Module);
+            let module: AppsConfigModule = new AppsConfigModule(sourceRoot, { scanners: { iac: testCase?.scanner } } as Module);
             let actualSourceRoots: string[] = module.GetSourceRoots(ScanType.Iac);
             if (!testCase.scanner) {
                 assert.sameMembers(actualSourceRoots, [module.sourceRoot]);
@@ -93,7 +96,7 @@ describe('JFrog Apps Config Tests', () => {
         { scanner: { exclude_patterns: ['exclude-dir-1', 'exclude-dir-2'] } as Scanner }
     ].forEach(testCase => {
         it('Get exclude patterns - ' + testCase.scanner?.exclude_patterns, () => {
-            let module: AppsConfigModule = new AppsConfigModule({
+            let module: AppsConfigModule = new AppsConfigModule(__dirname, {
                 exclude_patterns: ['exclude-root'],
                 scanners: { secrets: testCase?.scanner }
             } as Module);

--- a/src/test/tests/appsConfig.test.ts
+++ b/src/test/tests/appsConfig.test.ts
@@ -17,7 +17,7 @@ describe('JFrog Apps Config Tests', () => {
         // Check module
         let module: AppsConfigModule = appsConfig!.modules[0];
         assert.equal(module.name, 'FrogLeapApp');
-        assert.include(module.sourceRoot, 'src');
+        assert.include(module.sourceRoot, path.join(jfrogAppsConfigDir, 'src'));
         assert.deepEqual(module.excludePatterns, ['docs/']);
         assert.deepEqual(module.excludeScanners, [ScanType.Secrets]);
 

--- a/src/test/tests/iacScan.test.ts
+++ b/src/test/tests/iacScan.test.ts
@@ -129,7 +129,7 @@ describe('Iac Scan Tests', () => {
             createTestStepProgress(),
             {} as ConnectionManager,
             logManager,
-            new AppsConfigModule(__dirname)
+            new AppsConfigModule('')
         );
     }
 });

--- a/src/test/tests/iacScan.test.ts
+++ b/src/test/tests/iacScan.test.ts
@@ -129,7 +129,7 @@ describe('Iac Scan Tests', () => {
             createTestStepProgress(),
             {} as ConnectionManager,
             logManager,
-            new AppsConfigModule()
+            new AppsConfigModule(__dirname)
         );
     }
 });

--- a/src/test/tests/integration/iac.test.ts
+++ b/src/test/tests/integration/iac.test.ts
@@ -36,7 +36,7 @@ describe('Iac Integration Tests', async () => {
             createTestStepProgress(),
             integrationManager.connectionManager,
             integrationManager.logManager,
-            new AppsConfigModule(),
+            new AppsConfigModule(__dirname),
             integrationManager.resource
         );
         runner.verbose = true;

--- a/src/test/tests/integration/iac.test.ts
+++ b/src/test/tests/integration/iac.test.ts
@@ -36,7 +36,7 @@ describe('Iac Integration Tests', async () => {
             createTestStepProgress(),
             integrationManager.connectionManager,
             integrationManager.logManager,
-            new AppsConfigModule(__dirname),
+            new AppsConfigModule(testDataRoot),
             integrationManager.resource
         );
         runner.verbose = true;

--- a/src/test/tests/integration/secrets.test.ts
+++ b/src/test/tests/integration/secrets.test.ts
@@ -36,7 +36,7 @@ describe('Secrets Scan Integration Tests', async () => {
             createTestStepProgress(),
             integrationManager.connectionManager,
             integrationManager.logManager,
-            new AppsConfigModule(__dirname),
+            new AppsConfigModule(testDataRoot),
             integrationManager.resource
         );
         runner.verbose = true;

--- a/src/test/tests/integration/secrets.test.ts
+++ b/src/test/tests/integration/secrets.test.ts
@@ -36,7 +36,7 @@ describe('Secrets Scan Integration Tests', async () => {
             createTestStepProgress(),
             integrationManager.connectionManager,
             integrationManager.logManager,
-            new AppsConfigModule(),
+            new AppsConfigModule(__dirname),
             integrationManager.resource
         );
         runner.verbose = true;

--- a/src/test/tests/sastScan.test.ts
+++ b/src/test/tests/sastScan.test.ts
@@ -127,7 +127,7 @@ describe('Sast Tests', () => {
             createTestStepProgress(),
             {} as ConnectionManager,
             logManager,
-            new AppsConfigModule()
+            new AppsConfigModule(__dirname)
         );
     }
 });

--- a/src/test/tests/sastScan.test.ts
+++ b/src/test/tests/sastScan.test.ts
@@ -127,7 +127,7 @@ describe('Sast Tests', () => {
             createTestStepProgress(),
             {} as ConnectionManager,
             logManager,
-            new AppsConfigModule(__dirname)
+            new AppsConfigModule('')
         );
     }
 });

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -58,7 +58,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             ): Promise<void> {
                 await RunUtils.runWithTimeout(timeout, checkCancel, dummyAction());
             }
-        })(connection, dummyName, logManager, new AppsConfigModule(__dirname));
+        })(connection, dummyName, logManager, new AppsConfigModule(''));
     }
 
     [

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -58,7 +58,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             ): Promise<void> {
                 await RunUtils.runWithTimeout(timeout, checkCancel, dummyAction());
             }
-        })(connection, dummyName, logManager, new AppsConfigModule());
+        })(connection, dummyName, logManager, new AppsConfigModule(__dirname));
     }
 
     [

--- a/src/test/tests/secretsScan.test.ts
+++ b/src/test/tests/secretsScan.test.ts
@@ -127,7 +127,7 @@ describe('Secrets Scan Tests', () => {
             createTestStepProgress(),
             {} as ConnectionManager,
             logManager,
-            new AppsConfigModule()
+            new AppsConfigModule(__dirname)
         );
     }
 });

--- a/src/test/tests/secretsScan.test.ts
+++ b/src/test/tests/secretsScan.test.ts
@@ -127,7 +127,7 @@ describe('Secrets Scan Tests', () => {
             createTestStepProgress(),
             {} as ConnectionManager,
             logManager,
-            new AppsConfigModule(__dirname)
+            new AppsConfigModule('')
         );
     }
 });


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
* Remove leftovers from JasRunners log message and fix an issue where the SAST log message shows undefined for skip-folder
* When examining the [JFrog Applications Config](https://github.com/jfrog/jfrog-apps-config#jfrog-applications-config), note that the source_root has an incorrect default value when using debug mode. Essentially, this issue arises in debug mode when a configuration file exists without source_root, leading to the use of the original VSCode extension source code instead of the current project used in debug mode. The underlying cause of this problem can be traced back to the use of `__dirname`.