### PR TITLE
Use the platform specific path for JFrog config

### DIFF
--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -54,12 +54,12 @@ export class ScanManager implements ExtensionComponent {
             progressManager,
             await new SupportedScans(this._connectionManager, this._logManager).getSupportedScans()
         );
-        const jasRunners: JasRunner[] = await entitledJasRunnerFactory.createConfigurableJasRunner();
+        const jasRunners: JasRunner[] = await entitledJasRunnerFactory.createJasRunner();
         progressManager.startStep('🔎 Scanning for issues', ScanManager.calculateNumberOfTasks(jasRunners, workspaceDescriptors));
         checkCanceled();
         await Promise.all([
             ...this.runDependenciesScans(workspaceDescriptors, root, checkCanceled, scanResults, progressManager, entitledJasRunnerFactory),
-            ...this.runAMScans(jasRunners)
+            ...this.runSourceCodeScans(jasRunners)
         ]);
         UsageUtils.sendUsageReport(entitledJasRunnerFactory.uniqFeatures, workspaceDescriptors, this.connectionManager);
     }
@@ -91,7 +91,7 @@ export class ScanManager implements ExtensionComponent {
         return scansPromises;
     }
 
-    private runAMScans(jasRunners: JasRunner[]): Promise<void>[] {
+    private runSourceCodeScans(jasRunners: JasRunner[]): Promise<void>[] {
         const scansPromises: Promise<void>[] = [];
         for (const runner of jasRunners) {
             if (runner.shouldRun()) {

--- a/src/main/scanLogic/scanRunners/jasRunner.ts
+++ b/src/main/scanLogic/scanRunners/jasRunner.ts
@@ -57,6 +57,10 @@ export abstract class JasRunner {
      */
     public abstract scan(): Promise<void>;
 
+    public get config() {
+        return this._config;
+    }
+
     /**
      * Run the executeBinary method with the provided request path
      * @param yamlConfigPath        - Path to the request

--- a/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
+++ b/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
@@ -141,8 +141,8 @@ export class JasRunnerFactory {
         );
     }
 
-    private getModulesFromConfig(): AppsConfigModule[] {
-        const jfrogAppConfig: JFrogAppsConfig = new JFrogAppsConfig(this.root.workspace.uri.path);
+    private createModulesConfig(): AppsConfigModule[] {
+        const jfrogAppConfig: JFrogAppsConfig = new JFrogAppsConfig(this.root.workspace.uri.fsPath);
         return jfrogAppConfig.modules;
     }
 }

--- a/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
+++ b/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
@@ -39,7 +39,7 @@ export class JasRunnerFactory {
     }
 
     // Jas scanner support JFrog config file. Applicability is not supported by jfrog config so we create a default runner to run on the workspace.
-    public async createConfigurableJasRunner(): Promise<JasRunner[]> {
+    public async createJasRunner(): Promise<JasRunner[]> {
         let jasRunners: JasRunner[] = [];
 
         jasRunners.push(...this.createSastRunners());
@@ -55,7 +55,7 @@ export class JasRunnerFactory {
             this._logManager.logMessage('Static Application Security scanner is not entitled to scan workspace ', 'INFO');
             return sastRunners;
         }
-        for (const configModule of this.getModulesFromConfig()) {
+        for (const configModule of this.createModulesConfig()) {
             sastRunners.push(
                 new SastRunner(
                     this.scanResults,
@@ -80,7 +80,7 @@ export class JasRunnerFactory {
             this._logManager.logMessage('Infrastructure as Code scanner is not entitled to scan workspace', 'INFO');
             return iacRunners;
         }
-        for (const configModule of this.getModulesFromConfig()) {
+        for (const configModule of this.createModulesConfig()) {
             iacRunners.push(
                 new IacRunner(
                     this.scanResults,
@@ -105,7 +105,7 @@ export class JasRunnerFactory {
             this._logManager.logMessage('Secrets scanner is not entitled to scan workspace', 'INFO');
             return secretsRunners;
         }
-        for (const configModule of this.getModulesFromConfig()) {
+        for (const configModule of this.createModulesConfig()) {
             secretsRunners.push(
                 new SecretsRunner(
                     this.scanResults,

--- a/src/test/tests/integration/JasRunnerFactory.test.ts
+++ b/src/test/tests/integration/JasRunnerFactory.test.ts
@@ -1,0 +1,21 @@
+import { assert } from 'chai';
+import * as path from 'path';
+import { AnalyzerManagerIntegrationEnv } from '../utils/testIntegration.test';
+import { JasRunner } from '../../../main/scanLogic/scanRunners/jasRunner';
+
+describe('Jas Runner Factory', async () => {
+    const integrationManager: AnalyzerManagerIntegrationEnv = new AnalyzerManagerIntegrationEnv();
+    const testDataRoot: string = path.join(__dirname, '..', '..', 'resources', 'secretsScan');
+
+    before(async function() {
+        // Integration initialization
+        await integrationManager.initialize(testDataRoot);
+    });
+
+    it('Should create config source root for each jas runner', async () => {
+        const runner: JasRunner[] = await integrationManager.entitledJasRunnerFactory.createJasRunner();
+        runner.forEach(runner => {
+            assert.equal(testDataRoot, runner.config.sourceRoot);
+        });
+    });
+});

--- a/src/test/tests/utils/treeNodeUtils.test.ts
+++ b/src/test/tests/utils/treeNodeUtils.test.ts
@@ -53,7 +53,8 @@ export function createRootTestNode(pathOfWorkspace: string): IssuesRootTreeNode 
     return new IssuesRootTreeNode({
         uri: {
             fsPath: pathOfWorkspace,
-            path: pathOfWorkspace
+            // The usage of 'path' is avoided due to its lack of cross-platform compatibility. This placeholder is used to nullify any tests reliant on 'path'.
+            path: "incorrect path"
         } as vscode.Uri
     } as vscode.WorkspaceFolder);
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
When running on Windows, JFrog's configuration has a bad root path. In order to resolve the root project path, we use a different API