### PR TITLE
applicabilityScan: add "indirect-cve-whitelist" to scanner YAML confi…

### DIFF
--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -24,7 +24,13 @@ export class Utils {
     }
 
     public static combineSets(sets: Set<string>[]): Set<string> {
-        return new Set<string>(...sets);
+        const result: Set<string> = new Set<string>;
+        for (const set of sets) {
+            for (const elem of set) {
+                result.add(elem);
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/test/resources/applicableScan/npm/expectedScanResponse.json
+++ b/src/test/resources/applicableScan/npm/expectedScanResponse.json
@@ -4,6 +4,9 @@
         "CVE-2021-3807",
         "CVE-2021-3918"
     ],
+    "indirectCve": [
+        "CVE-2021-44228"
+    ],
     "applicableCve": {
         "CVE-2022-25878": {
             "fixReason": "Prototype pollution `Object.freeze` remediation was not detected, The vulnerable function protobufjs.parse is called with external input, The vulnerable function protobufjs.load(Sync) is called",
@@ -34,5 +37,10 @@
             ],
             "fullDescription": "The scanner checks whether any of the following vulnerable functions are called:\n\n* `util.setProperty` with external input to its 2nd (`path`) or 3rd (`value`) arguments.\n* `ReflectionObject.setParsedOption` with external input to its 2nd (`name`) or 3rd (`value`) arguments.\n* `parse` with external input to its 1st (`source`) argument.\n* `load`\n* `loadSync`\n\nThe scanner also checks whether the `Object.freeze()` remediation is not present."
         }
-    }
+    },
+    "nonapplicableCve": [
+        "CVE-2021-3807",
+        "CVE-2021-3918",
+        "CVE-2021-44228"
+    ]
 }

--- a/src/test/resources/applicableScan/python/expectedScanResponse.json
+++ b/src/test/resources/applicableScan/python/expectedScanResponse.json
@@ -4,6 +4,7 @@
         "CVE-2019-15605",
         "CVE-2019-20907"
     ],
+    "indirectCve": [],
     "applicableCve": {
         "CVE-2019-20907": {
             "fixReason": "The vulnerable function tarfile.open is called with external input",
@@ -25,5 +26,9 @@
             ],
             "fullDescription": "The scanner checks whether the vulnerable function `open` is called with external input to its 1st (`name`) argument."
         }
-    }
+    },
+    "nonapplicableCve": [
+        "CVE-2021-3918",
+        "CVE-2019-15605"
+    ]
 }

--- a/src/test/resources/applicableScan/requestMultipleRoots.yaml
+++ b/src/test/resources/applicableScan/requestMultipleRoots.yaml
@@ -8,5 +8,8 @@ scans:
       - CVE-2021-3918
       - CVE-2021-3807
       - CVE-2022-25878
+    indirect-cve-whitelist:
+      - CVE-2021-44228
+      - CVE-2023-1234
     skipped-folders:
       - /path/to/skip

--- a/src/test/resources/applicableScan/requestOneRoot.yaml
+++ b/src/test/resources/applicableScan/requestOneRoot.yaml
@@ -5,4 +5,6 @@ scans:
       - /path/to/root
     cve-whitelist:
       - CVE-2021-3918
+    indirect-cve-whitelist:
+      - CVE-2021-44228
     skipped-folders: []

--- a/src/test/tests/applicabilityScan.test.ts
+++ b/src/test/tests/applicabilityScan.test.ts
@@ -41,6 +41,7 @@ describe('Applicability Scan Tests', () => {
             expectedYaml: path.join(scanApplicable, 'requestOneRoot.yaml'),
             roots: ['/path/to/root'],
             cves: ['CVE-2021-3918'],
+            indirect_cves: ['CVE-2021-44228'],
             skip: []
         },
         {
@@ -48,11 +49,12 @@ describe('Applicability Scan Tests', () => {
             expectedYaml: path.join(scanApplicable, 'requestMultipleRoots.yaml'),
             roots: ['/path/to/root', '/path/to/other'],
             cves: ['CVE-2021-3918', 'CVE-2021-3807', 'CVE-2022-25878'],
+            indirect_cves: ['CVE-2021-44228', 'CVE-2023-1234'],
             skip: ['/path/to/skip']
         }
     ].forEach(test => {
         it('Check generated Yaml request for - ' + test.name, () => {
-            let request: ApplicabilityScanArgs = getApplicabilityScanRequest(test.roots, test.cves, test.skip);
+            let request: ApplicabilityScanArgs = getApplicabilityScanRequest(test.roots, test.cves, test.indirect_cves, test.skip);
             let actualYaml: string = path.join(tempFolder, test.name);
             fs.writeFileSync(actualYaml, getDummyRunner([], PackageType.Unknown).requestsToYaml(request));
             assert.deepEqual(
@@ -345,12 +347,13 @@ describe('Applicability Scan Tests', () => {
         });
     });
 
-    function getApplicabilityScanRequest(roots: string[], cves: string[], skipFolders: string[]): ApplicabilityScanArgs {
+    function getApplicabilityScanRequest(roots: string[], cves: string[], indirect_cves: string[], skipFolders: string[]): ApplicabilityScanArgs {
         return {
             type: 'analyze-applicability',
             output: '/path/to/output.json',
             roots: roots,
             cve_whitelist: cves,
+            indirect_cve_whitelist: indirect_cves,
             skipped_folders: skipFolders
         } as ApplicabilityScanArgs;
     }

--- a/src/test/tests/integration/applicability.test.ts
+++ b/src/test/tests/integration/applicability.test.ts
@@ -45,7 +45,7 @@ describe('Applicability Integration Tests', async () => {
                 assert.isDefined(expectedContent, 'Failed to read expected ApplicabilityScanResponse content from ' + expectedResponseContentPath);
                 // Run scan
                 response = await runner
-                    .executeRequest(() => undefined, { roots: [directoryToScan], cve_whitelist: expectedContent.scannedCve } as ApplicabilityScanArgs)
+                    .executeRequest(() => undefined, { roots: [directoryToScan], cve_whitelist: expectedContent.scannedCve, indirect_cve_whitelist: expectedContent.indirectCve } as ApplicabilityScanArgs)
                     .then(runResult => runner.convertResponse(runResult))
                     .catch(err => assert.fail(err));
             });
@@ -65,6 +65,10 @@ describe('Applicability Integration Tests', async () => {
 
             it('Check all expected applicable CVE detected', () => {
                 assert.includeDeepMembers(Object.keys(response.applicableCve), Object.keys(expectedContent.applicableCve));
+            });
+
+            it('Check all expected nonapplicable CVE detected', () => {
+                assert.sameDeepMembers(response.nonapplicableCve, expectedContent.nonapplicableCve);
             });
 
             describe('Applicable details data validations', () => {


### PR DESCRIPTION
…guration

Add support for applicability scanning of indirect (transitive) CVEs. This is done by sending a separate list of detected indirect CVEs (indirect-cve-whitelist) to the applicability scanner YAML configuration file.

- [v] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [v] I used `npm run format` for formatting the code before submitting the pull request.
-----
