### PR TITLE
Make sure the webview is loaded before sending requests

### DIFF
--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -51,7 +51,6 @@ export interface CveApplicableDetails {
 
 export class BundleCves extends Map<FileScanBundle, [Set<string>, Set<string>]> {}
 
-
 /**
  * Describes a runner for the Applicability scan.
  */
@@ -186,9 +185,7 @@ export class ApplicabilityRunner extends JasRunner {
      * @param filteredBundles - bundles to map
      * @returns mapped bundles to similar workspace
      */
-    private mapBundlesForApplicableScanning(
-        filteredBundles: BundleCves
-    ): Map<string, BundleCves> {
+    private mapBundlesForApplicableScanning(filteredBundles: BundleCves): Map<string, BundleCves> {
         let workspaceToScanBundles: Map<string, BundleCves> = new Map<string, BundleCves>();
 
         for (let [fileScanBundle, cvesTuple] of filteredBundles) {
@@ -295,8 +292,7 @@ export class ApplicabilityRunner extends JasRunner {
                         let fileIssues: FileIssues = this.getOrCreateFileIssues(applicableDetails, location.physicalLocation.artifactLocation.uri);
                         fileIssues.locations.push(location.physicalLocation.region);
                     });
-                }
-                else if (analyzeIssue.kind === 'pass') {
+                } else if (analyzeIssue.kind === 'pass') {
                     nonapplicable.push(this.getCveFromRuleId(analyzeIssue.ruleId));
                 }
                 scanned.add(this.getCveFromRuleId(analyzeIssue.ruleId));
@@ -306,7 +302,7 @@ export class ApplicabilityRunner extends JasRunner {
         return {
             scannedCve: Array.from(scanned),
             applicableCve: Object.fromEntries(applicable.entries()),
-            nonapplicableCve: nonapplicable,
+            nonapplicableCve: nonapplicable
         } as ApplicabilityScanResponse;
     }
 

--- a/src/main/webview/event/eventManager.ts
+++ b/src/main/webview/event/eventManager.ts
@@ -15,7 +15,7 @@ export class EventManager {
     private webviewAPILoaded: boolean = false;
     // 3 minutes
     private static TIMEOUT_MILLISECOND: number = 3 * 60 * 1000;
-    private static RETRY_DELAY_MILLISECOND: number = 10;
+    private static RETRY_DELAY_MILLISECOND: number = 100;
 
     private constructor(webview: vscode.Webview, private connectionManager: ConnectionManager, private logManager: LogManager) {
         this.setEventReceiver(webview);
@@ -38,11 +38,8 @@ export class EventManager {
      */
     private static async waitUntilWebviewLoaded(eventManager: EventManager) {
         const startedTime: number = Date.now();
-        for (let i: number = 1; !EventManager.timedOut(startedTime); i++) {
+        for (let i: number = 1; !EventManager.timedOut(startedTime) && !eventManager.webviewAPILoaded; i++) {
             eventManager.send.loadWebviewAPI();
-            if (eventManager.webviewAPILoaded) {
-                return;
-            }
             await RunUtils.delay(EventManager.RETRY_DELAY_MILLISECOND * i);
         }
     }

--- a/src/main/webview/event/eventSender.ts
+++ b/src/main/webview/event/eventSender.ts
@@ -7,13 +7,13 @@ import { LogManager } from '../../log/logManager';
  */
 export class EventSender {
     constructor(private webview: vscode.Webview, private logManager: LogManager) {
-        this.setEventEmitter();
+        this.loadWebviewAPI();
     }
 
     /**
      * Establishes the event emitter within the webview to enable sending messages from the webview back to the IDE.
      */
-    public async setEventEmitter(): Promise<void> {
+    public async loadWebviewAPI(): Promise<void> {
         await this.sendEvent(this.webview, {
             type: IdeEventType.SetEmitter,
             data: 'return acquireVsCodeApi().postMessage'

--- a/src/main/webview/webviewSidebar.ts
+++ b/src/main/webview/webviewSidebar.ts
@@ -15,15 +15,15 @@ export class WebviewSidebar extends WebView implements vscode.WebviewViewProvide
 
     public async resolveWebviewView(webviewView: vscode.WebviewView) {
         if (this.webview === undefined) {
-            this.webview = await this.createWebview(webviewView);
-            this.eventManager = this.createEventManager(this.webview);
+            this.webview = this.createWebview(webviewView);
+            this.eventManager = await this.createEventManager(this.webview);
         }
         if (this.currentPage != undefined) {
             this.eventManager?.loadPage(this.currentPage);
         }
     }
 
-    private async createWebview(currentWebview: vscode.WebviewView) {
+    private createWebview(currentWebview: vscode.WebviewView) {
         currentWebview.webview.html = this.getHtml(this.context, currentWebview.webview);
         currentWebview.onDidDispose(
             () => {
@@ -41,13 +41,13 @@ export class WebviewSidebar extends WebView implements vscode.WebviewViewProvide
         return currentWebview;
     }
 
-    private createEventManager(webview: vscode.WebviewView) {
-        const eventManager: EventManager = new EventManager(webview.webview, this.connectionManager, this._logManager);
-        webview.onDidChangeVisibility(() => {
+    private async createEventManager(webview: vscode.WebviewView) {
+        const eventManager: EventManager = await EventManager.createEventManager(webview.webview, this.connectionManager, this._logManager);
+        webview.onDidChangeVisibility(async () => {
             if (!webview.visible) {
                 return;
             }
-            this.eventManager = new EventManager(webview.webview, this.connectionManager, this._logManager);
+            this.eventManager = await EventManager.createEventManager(webview.webview, this.connectionManager, this._logManager);
             if (this.currentPage) {
                 eventManager.loadPage(this.currentPage);
             }

--- a/src/main/webview/webviewSidebar.ts
+++ b/src/main/webview/webviewSidebar.ts
@@ -43,15 +43,17 @@ export class WebviewSidebar extends WebView implements vscode.WebviewViewProvide
 
     private async createEventManager(webview: vscode.WebviewView) {
         const eventManager: EventManager = await EventManager.createEventManager(webview.webview, this.connectionManager, this._logManager);
-        webview.onDidChangeVisibility(async () => {
-            if (!webview.visible) {
-                return;
-            }
-            this.eventManager = await EventManager.createEventManager(webview.webview, this.connectionManager, this._logManager);
-            if (this.currentPage) {
-                eventManager.loadPage(this.currentPage);
-            }
-        });
+        this.context.subscriptions.push(
+            webview.onDidChangeVisibility(async () => {
+                if (!webview.visible) {
+                    return;
+                }
+                this.eventManager = await EventManager.createEventManager(webview.webview, this.connectionManager, this._logManager);
+                if (this.currentPage) {
+                    eventManager.loadPage(this.currentPage);
+                }
+            })
+        );
         return eventManager;
     }
 }

--- a/src/main/webview/webviewTab.ts
+++ b/src/main/webview/webviewTab.ts
@@ -4,13 +4,11 @@ import { LogManager } from '../log/logManager';
 import { EventManager } from './event/eventManager';
 import { WebView } from './webview';
 import { ConnectionManager } from '../connect/connectionManager';
-import { RunUtils } from '../utils/runUtils';
 
 /**
  * Show a webview panel with details about objects in the project
  */
 export class WebviewTab extends WebView {
-    private static readonly WEBVIEW_DELAY_MILLISECS: number = 2000;
     private panel: vscode.WebviewPanel | undefined;
 
     constructor(logManager: LogManager, private connectionManager: ConnectionManager, private context: vscode.ExtensionContext) {
@@ -25,11 +23,7 @@ export class WebviewTab extends WebView {
     public async resolveWebviewView() {
         if (!this.panel) {
             this.panel = this.createWebview();
-            this.eventManager = this.createEventManager(this.panel);
-            // Workaround: Delay the initial page load to ensure proper message delivery in the Webview.
-            // This is necessary because in the Webview, messages are only delivered when the webview is alive.
-            // This workaround applies specifically to VS-Code remote development environments.
-            await RunUtils.delay(WebviewTab.WEBVIEW_DELAY_MILLISECS);
+            this.eventManager = await this.createEventManager(this.panel);
         } else {
             this.panel.reveal();
         }
@@ -67,8 +61,8 @@ export class WebviewTab extends WebView {
         return panel;
     }
 
-    private createEventManager(panel: vscode.WebviewPanel) {
-        const eventManager: EventManager = new EventManager(panel.webview, this.connectionManager, this._logManager);
+    private async createEventManager(panel: vscode.WebviewPanel) {
+        const eventManager: EventManager = await EventManager.createEventManager(panel.webview, this.connectionManager, this._logManager);
         panel.onDidChangeViewState(() => {
             if (this.currentPage) {
                 eventManager.loadPage(this.currentPage);

--- a/src/test/tests/integration/applicability.test.ts
+++ b/src/test/tests/integration/applicability.test.ts
@@ -45,7 +45,11 @@ describe('Applicability Integration Tests', async () => {
                 assert.isDefined(expectedContent, 'Failed to read expected ApplicabilityScanResponse content from ' + expectedResponseContentPath);
                 // Run scan
                 response = await runner
-                    .executeRequest(() => undefined, { roots: [directoryToScan], cve_whitelist: expectedContent.scannedCve, indirect_cve_whitelist: expectedContent.indirectCve } as ApplicabilityScanArgs)
+                    .executeRequest(() => undefined, {
+                        roots: [directoryToScan],
+                        cve_whitelist: expectedContent.scannedCve,
+                        indirect_cve_whitelist: expectedContent.indirectCve
+                    } as ApplicabilityScanArgs)
                     .then(runResult => runner.convertResponse(runResult))
                     .catch(err => assert.fail(err));
             });

--- a/src/test/tests/webview/event/eventManager.test.ts
+++ b/src/test/tests/webview/event/eventManager.test.ts
@@ -9,9 +9,9 @@ describe('EventManager', () => {
     let webview: MockWebview;
     let eventManager: EventManager;
     let loadPageStub: any;
-    beforeEach(() => {
+    beforeEach(async () => {
         webview = new MockWebview();
-        eventManager = new EventManager(webview, {} as ConnectionManager, {} as LogManager);
+        eventManager = await EventManager.createEventManager(webview, {} as ConnectionManager, {} as LogManager);
         loadPageStub = sinon.stub(eventManager, 'loadPage').resolves();
     });
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Before this pull request, there was a potential for the Webview to take longer to load than the duration between the IDE sending the first request to the Webview. To address this issue, we now ensure that we wait for a signal indicating the completion of the webview's full loading process before sending any requests.

Dependent on: 
* https://github.com/jfrog/jfrog-ide-webview/pull/51