### PR TITLE
Fix Go scanning when Go version is partial

### DIFF
--- a/src/main/utils/goUtils.ts
+++ b/src/main/utils/goUtils.ts
@@ -28,6 +28,8 @@ export class GoUtils {
             .toString()
             .substring('go version go'.length);
         let versionNumber: string = versionStr.substring(0, versionStr.indexOf(' '));
+        // Add patch version if not exists
+        versionNumber += versionNumber.split('.').length < 3 ? '.0' : '';
         return new SemVer(versionNumber);
     }
 

--- a/src/test/tests/goUtils.test.ts
+++ b/src/test/tests/goUtils.test.ts
@@ -245,4 +245,9 @@ describe('Go Utils Tests', async () => {
             assert.isFalse(fs.existsSync(targetDir), 'The target directory should not exist since all files should be excluded');
         });
     });
+
+    it('Get go version', () => {
+        let goVersion: string = GoUtils.getGoVersion().format();
+        assert.isNotEmpty(goVersion);
+    });
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

When scanning project with Go version 1.x, the `SemVer` can't parse the string to create a version object:
![image](https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/8d5d0eb6-041f-4970-89a1-260988698b1f)

This fix adds a `.0` suffix to the version so it can parse, allowing to scan them