### PR TITLE
Dont run pnpm tests in node 14 or less

### DIFF
--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -36,9 +36,11 @@ describe('Pnpm Utils Tests', async () => {
         fs.rmdirSync(testFolder.fsPath, { recursive: true });
     });
 
-    describe('Pnpm commands', async () => {        
+    describe('Pnpm commands', async () => {
         it('Verify pnpm installed', async () => {
-            initPnpmTests();
+            if (checkNodeVersionSupported()) {
+                test.skip('Skip pnpm tests for Node.js v14 or less');
+            }
             assert.isTrue(PnpmUtils.verifyPnpmInstalled());
         });
     });
@@ -69,7 +71,9 @@ describe('Pnpm Utils Tests', async () => {
         let sortedDescriptorTrees: DependenciesTreeNode[] = [];
 
         before(async () => {
-            initPnpmTests();
+            if (checkNodeVersionSupported()) {
+                test.skip('Skip pnpm tests for Node.js v14 or less');
+            }
             // Install projects
             projectDirs.forEach(projectDir => {
                 PnpmUtils.runPnpmInstall(path.join(testFolder.fsPath, projectDir));
@@ -80,7 +84,9 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptors node general information', async () => {
-            initPnpmTests();
+            if (checkNodeVersionSupported()) {
+                test.skip('Skip pnpm tests for Node.js v14 or less');
+            }
             // Check number of descriptor trees
             assert.lengthOf(sortedDescriptorTrees, 2);
             // Check parents
@@ -89,7 +95,9 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with empty dependency tree', async () => {
-            initPnpmTests();
+            if (checkNodeVersionSupported()) {
+                test.skip('Skip pnpm tests for Node.js v14 or less');
+            }
             let tree: DependenciesTreeNode = sortedDescriptorTrees[0];
             // Check labels
             assert.deepEqual(tree.label, 'jfrog-vscode-tests1');
@@ -98,7 +106,9 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with dependency tree', async () => {
-            initPnpmTests();
+            if (checkNodeVersionSupported()) {
+                test.skip('Skip pnpm tests for Node.js v14 or less');
+            }
             let tree: DependenciesTreeNode = sortedDescriptorTrees[1];
             // Check labels
             assert.deepEqual(tree.label, 'jfrog-vscode-tests2');
@@ -146,10 +156,8 @@ describe('Pnpm Utils Tests', async () => {
         }
     });
 
-    function initPnpmTests(): void {
+    function checkNodeVersionSupported(): boolean {
         // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
-        if (parseInt(process.version.slice(1).split('.')[0]) <= 14) {
-            test.skip('Skip pnpm tests for Node.js v14 or less');
-        }
+        return parseInt(process.version.slice(1).split('.')[0]) > 14;
     }
 });

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -14,7 +14,7 @@ import { GeneralInfo } from '../../main/types/generalInfo';
 /**
  * Test functionality of @class PnpmUtils.
  */
-describe.only('Pnpm Utils Tests', async () => {
+describe('Pnpm Utils Tests', async () => {
     checkNodeVersionSupported();
     let logManager: LogManager = new LogManager().activate();
     let workspaceFolders: vscode.WorkspaceFolder[];
@@ -144,9 +144,7 @@ describe.only('Pnpm Utils Tests', async () => {
 
     function checkNodeVersionSupported(): void {
         // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
-        let nodeVersion: string = process.versions.node;
-        logManager.logMessage('Node.js version: ' + nodeVersion, 'INFO');
-        if (parseInt(nodeVersion.slice(1).split('.')[0]) <= 14) {
+        if (parseInt(process.versions.node.slice(1).split('.')[0]) <= 14) {
             test.skip('Skip pnpm tests for Node.js v14 or less');
         }
     }

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -14,7 +14,7 @@ import { GeneralInfo } from '../../main/types/generalInfo';
 /**
  * Test functionality of @class PnpmUtils.
  */
-describe('Pnpm Utils Tests', async () => {
+describe.only('Pnpm Utils Tests', async () => {
     let logManager: LogManager = new LogManager().activate();
     let workspaceFolders: vscode.WorkspaceFolder[];
 
@@ -38,7 +38,7 @@ describe('Pnpm Utils Tests', async () => {
 
     describe('Pnpm commands', async () => {
         it('Verify pnpm installed', async () => {
-            if (checkNodeVersionSupported()) {
+            if (!checkNodeVersionSupported()) {
                 test.skip('Skip pnpm tests for Node.js v14 or less');
             }
             assert.isTrue(PnpmUtils.verifyPnpmInstalled());
@@ -71,7 +71,7 @@ describe('Pnpm Utils Tests', async () => {
         let sortedDescriptorTrees: DependenciesTreeNode[] = [];
 
         before(async () => {
-            if (checkNodeVersionSupported()) {
+            if (!checkNodeVersionSupported()) {
                 test.skip('Skip pnpm tests for Node.js v14 or less');
             }
             // Install projects
@@ -84,7 +84,7 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptors node general information', async () => {
-            if (checkNodeVersionSupported()) {
+            if (!checkNodeVersionSupported()) {
                 test.skip('Skip pnpm tests for Node.js v14 or less');
             }
             // Check number of descriptor trees
@@ -95,7 +95,7 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with empty dependency tree', async () => {
-            if (checkNodeVersionSupported()) {
+            if (!checkNodeVersionSupported()) {
                 test.skip('Skip pnpm tests for Node.js v14 or less');
             }
             let tree: DependenciesTreeNode = sortedDescriptorTrees[0];
@@ -106,7 +106,7 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with dependency tree', async () => {
-            if (checkNodeVersionSupported()) {
+            if (!checkNodeVersionSupported()) {
                 test.skip('Skip pnpm tests for Node.js v14 or less');
             }
             let tree: DependenciesTreeNode = sortedDescriptorTrees[1];

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -24,6 +24,10 @@ describe('Pnpm Utils Tests', async () => {
     let packageDescriptors: Map<PackageType, vscode.Uri[]> = new Map<PackageType, vscode.Uri[]>();
 
     before(async () => {
+        // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
+        if (parseInt(process.version.slice(1).split('.')[0]) <= 14) {
+            test.skip('Skip pnpm tests for Node.js v14 or less');
+        }
         // Copy test projects to temp folder
         fs.copySync(testProjectsDir, testFolder.fsPath);
         workspaceFolders = [{ uri: testFolder, name: '', index: 0 } as vscode.WorkspaceFolder];

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -15,6 +15,7 @@ import { GeneralInfo } from '../../main/types/generalInfo';
  * Test functionality of @class PnpmUtils.
  */
 describe('Pnpm Utils Tests', async () => {
+    initPnpmTests()
     let logManager: LogManager = new LogManager().activate();
     let workspaceFolders: vscode.WorkspaceFolder[];
 
@@ -24,10 +25,6 @@ describe('Pnpm Utils Tests', async () => {
     let packageDescriptors: Map<PackageType, vscode.Uri[]> = new Map<PackageType, vscode.Uri[]>();
 
     before(async () => {
-        // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
-        if (parseInt(process.version.slice(1).split('.')[0]) <= 14) {
-            test.skip('Skip pnpm tests for Node.js v14 or less');
-        }
         // Copy test projects to temp folder
         fs.copySync(testProjectsDir, testFolder.fsPath);
         workspaceFolders = [{ uri: testFolder, name: '', index: 0 } as vscode.WorkspaceFolder];
@@ -144,4 +141,11 @@ describe('Pnpm Utils Tests', async () => {
             assert.deepEqual(child?.parent, parent);
         }
     });
+
+    function initPnpmTests(): void {
+        // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
+        if (parseInt(process.version.slice(1).split('.')[0]) <= 14) {
+            test.skip('Skip pnpm tests for Node.js v14 or less');
+        }
+    }
 });

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -15,6 +15,7 @@ import { GeneralInfo } from '../../main/types/generalInfo';
  * Test functionality of @class PnpmUtils.
  */
 describe.only('Pnpm Utils Tests', async () => {
+    checkNodeVersionSupported();
     let logManager: LogManager = new LogManager().activate();
     let workspaceFolders: vscode.WorkspaceFolder[];
 
@@ -38,9 +39,6 @@ describe.only('Pnpm Utils Tests', async () => {
 
     describe('Pnpm commands', async () => {
         it('Verify pnpm installed', async () => {
-            if (!checkNodeVersionSupported()) {
-                test.skip('Skip pnpm tests for Node.js v14 or less');
-            }
             assert.isTrue(PnpmUtils.verifyPnpmInstalled());
         });
     });
@@ -71,9 +69,6 @@ describe.only('Pnpm Utils Tests', async () => {
         let sortedDescriptorTrees: DependenciesTreeNode[] = [];
 
         before(async () => {
-            if (!checkNodeVersionSupported()) {
-                test.skip('Skip pnpm tests for Node.js v14 or less');
-            }
             // Install projects
             projectDirs.forEach(projectDir => {
                 PnpmUtils.runPnpmInstall(path.join(testFolder.fsPath, projectDir));
@@ -84,9 +79,6 @@ describe.only('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptors node general information', async () => {
-            if (!checkNodeVersionSupported()) {
-                test.skip('Skip pnpm tests for Node.js v14 or less');
-            }
             // Check number of descriptor trees
             assert.lengthOf(sortedDescriptorTrees, 2);
             // Check parents
@@ -95,9 +87,6 @@ describe.only('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with empty dependency tree', async () => {
-            if (!checkNodeVersionSupported()) {
-                test.skip('Skip pnpm tests for Node.js v14 or less');
-            }
             let tree: DependenciesTreeNode = sortedDescriptorTrees[0];
             // Check labels
             assert.deepEqual(tree.label, 'jfrog-vscode-tests1');
@@ -106,9 +95,6 @@ describe.only('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with dependency tree', async () => {
-            if (!checkNodeVersionSupported()) {
-                test.skip('Skip pnpm tests for Node.js v14 or less');
-            }
             let tree: DependenciesTreeNode = sortedDescriptorTrees[1];
             // Check labels
             assert.deepEqual(tree.label, 'jfrog-vscode-tests2');
@@ -156,8 +142,12 @@ describe.only('Pnpm Utils Tests', async () => {
         }
     });
 
-    function checkNodeVersionSupported(): boolean {
+    function checkNodeVersionSupported(): void {
         // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
-        return parseInt(process.version.slice(1).split('.')[0]) > 14;
+        let nodeVersion: string = process.versions.node;
+        logManager.logMessage('Node.js version: ' + nodeVersion, 'INFO');
+        if (parseInt(nodeVersion.slice(1).split('.')[0]) <= 14) {
+            test.skip('Skip pnpm tests for Node.js v14 or less');
+        }
     }
 });

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -15,7 +15,6 @@ import { GeneralInfo } from '../../main/types/generalInfo';
  * Test functionality of @class PnpmUtils.
  */
 describe('Pnpm Utils Tests', async () => {
-    initPnpmTests()
     let logManager: LogManager = new LogManager().activate();
     let workspaceFolders: vscode.WorkspaceFolder[];
 
@@ -37,8 +36,9 @@ describe('Pnpm Utils Tests', async () => {
         fs.rmdirSync(testFolder.fsPath, { recursive: true });
     });
 
-    describe('Pnpm commands', async () => {
+    describe('Pnpm commands', async () => {        
         it('Verify pnpm installed', async () => {
+            initPnpmTests();
             assert.isTrue(PnpmUtils.verifyPnpmInstalled());
         });
     });
@@ -69,6 +69,7 @@ describe('Pnpm Utils Tests', async () => {
         let sortedDescriptorTrees: DependenciesTreeNode[] = [];
 
         before(async () => {
+            initPnpmTests();
             // Install projects
             projectDirs.forEach(projectDir => {
                 PnpmUtils.runPnpmInstall(path.join(testFolder.fsPath, projectDir));
@@ -79,6 +80,7 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptors node general information', async () => {
+            initPnpmTests();
             // Check number of descriptor trees
             assert.lengthOf(sortedDescriptorTrees, 2);
             // Check parents
@@ -87,6 +89,7 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with empty dependency tree', async () => {
+            initPnpmTests();
             let tree: DependenciesTreeNode = sortedDescriptorTrees[0];
             // Check labels
             assert.deepEqual(tree.label, 'jfrog-vscode-tests1');
@@ -95,6 +98,7 @@ describe('Pnpm Utils Tests', async () => {
         });
 
         it('Check descriptor node with dependency tree', async () => {
+            initPnpmTests();
             let tree: DependenciesTreeNode = sortedDescriptorTrees[1];
             // Check labels
             assert.deepEqual(tree.label, 'jfrog-vscode-tests2');


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

pnpm not supported at node 14 or less: https://pnpm.io/installation
adding skip tests