### PR TITLE
Add XSC analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4708,7 +4708,7 @@
         },
         "node_modules/jfrog-client-js": {
             "version": "2.7.1",
-            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#a8835e1d60d09dfe7e6fdacbabb9fffc4fdad6cd",
+            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#0baa7d27156004a4586b0bcb50592a0d1d4df34b",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "adm-zip": "~0.5.9",
                 "fs-extra": "~10.1.0",
-                "jfrog-client-js": "github:attiasas/jfrog-client-js#add_xsc",
+                "jfrog-client-js": "^2.8.0",
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.2.13.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
@@ -60,225 +60,21 @@
                 "vscode": "^1.80.0"
             }
         },
-        "node_modules/@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-            "peer": true,
-            "dependencies": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
-            },
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
             "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "peer": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "peer": true
-        },
-        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-            "peer": true,
-            "dependencies": {
-                "@babel/types": "^7.22.15"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-            "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-            "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "peer": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "peer": true
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+            "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/types": {
-            "version": "7.22.17",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
-            "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.15",
-                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -293,34 +89,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/@emotion/babel-plugin": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-            "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/runtime": "^7.18.3",
-                "@emotion/hash": "^0.9.1",
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/serialize": "^1.1.2",
-                "babel-plugin-macros": "^3.1.0",
-                "convert-source-map": "^1.5.0",
-                "escape-string-regexp": "^4.0.0",
-                "find-root": "^1.1.0",
-                "source-map": "^0.5.7",
-                "stylis": "4.2.0"
-            }
-        },
-        "node_modules/@emotion/babel-plugin/node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@emotion/cache": {
             "version": "11.11.0",
             "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
@@ -333,104 +101,15 @@
                 "stylis": "4.2.0"
             }
         },
-        "node_modules/@emotion/hash": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-            "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
-            "peer": true
-        },
-        "node_modules/@emotion/is-prop-valid": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-            "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
-            "dependencies": {
-                "@emotion/memoize": "^0.8.1"
-            }
-        },
         "node_modules/@emotion/memoize": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
             "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
         },
-        "node_modules/@emotion/react": {
-            "version": "11.11.1",
-            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
-            "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.11.0",
-                "@emotion/cache": "^11.11.0",
-                "@emotion/serialize": "^1.1.2",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-                "@emotion/utils": "^1.2.1",
-                "@emotion/weak-memoize": "^0.3.1",
-                "hoist-non-react-statics": "^3.3.1"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@emotion/serialize": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
-            "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
-            "peer": true,
-            "dependencies": {
-                "@emotion/hash": "^0.9.1",
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/unitless": "^0.8.1",
-                "@emotion/utils": "^1.2.1",
-                "csstype": "^3.0.2"
-            }
-        },
         "node_modules/@emotion/sheet": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
             "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
-        },
-        "node_modules/@emotion/styled": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
-            "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.11.0",
-                "@emotion/is-prop-valid": "^1.2.1",
-                "@emotion/serialize": "^1.1.2",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-                "@emotion/utils": "^1.2.1"
-            },
-            "peerDependencies": {
-                "@emotion/react": "^11.0.0-rc.0",
-                "react": ">=16.8.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@emotion/unitless": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
-            "peer": true
-        },
-        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-            "peer": true,
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            }
         },
         "node_modules/@emotion/utils": {
             "version": "1.2.1",
@@ -458,23 +137,23 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-            "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-            "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.1",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -490,9 +169,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
-            "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -509,28 +188,28 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-            "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
             "dependencies": {
-                "@floating-ui/utils": "^0.1.1"
+                "@floating-ui/utils": "^0.2.1"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
-            "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
             "dependencies": {
-                "@floating-ui/core": "^1.4.1",
-                "@floating-ui/utils": "^0.1.1"
+                "@floating-ui/core": "^1.0.0",
+                "@floating-ui/utils": "^0.2.0"
             }
         },
         "node_modules/@floating-ui/react-dom": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-            "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+            "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
             "dependencies": {
-                "@floating-ui/dom": "^1.5.1"
+                "@floating-ui/dom": "^1.6.1"
             },
             "peerDependencies": {
                 "react": ">=16.8.0",
@@ -538,18 +217,18 @@
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-            "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -570,84 +249,82 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "dev": true
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.18",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@mui/base": {
-            "version": "5.0.0-beta.14",
-            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.14.tgz",
-            "integrity": "sha512-Je/9JzzYObsuLCIClgE8XvXNFb55IEz8n2NtStUfASfNiVrwiR8t6VVFFuhofehkyTIN34tq1qbBaOjCnOovBw==",
+            "version": "5.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+            "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
-                "@emotion/is-prop-valid": "^1.2.1",
-                "@floating-ui/react-dom": "^2.0.1",
-                "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.14.8",
+                "@babel/runtime": "^7.23.9",
+                "@floating-ui/react-dom": "^2.0.8",
+                "@mui/types": "^7.2.14",
+                "@mui/utils": "^5.15.14",
                 "@popperjs/core": "^2.11.8",
-                "clsx": "^2.0.0",
-                "prop-types": "^15.8.1",
-                "react-is": "^18.2.0"
+                "clsx": "^2.1.0",
+                "prop-types": "^15.8.1"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0",
@@ -661,20 +338,20 @@
             }
         },
         "node_modules/@mui/core-downloads-tracker": {
-            "version": "5.14.8",
-            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.8.tgz",
-            "integrity": "sha512-8V7ZOC/lKkM03TRHqaThQFIq6bWPnj7L/ZWPh0ymldYFFyh8XdF0ywTgafsofDNYT4StlNknbaTjVHBma3SNjQ==",
+            "version": "5.15.15",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz",
+            "integrity": "sha512-aXnw29OWQ6I5A47iuWEI6qSSUfH6G/aCsW9KmW3LiFqr7uXZBK4Ks+z8G+qeIub8k0T5CMqlT2q0L+ZJTMrqpg==",
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             }
         },
         "node_modules/@mui/icons-material": {
-            "version": "5.14.19",
-            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.19.tgz",
-            "integrity": "sha512-yjP8nluXxZGe3Y7pS+yxBV+hWZSsSBampCxkZwaw+1l+feL+rfP74vbEFbMrX/Kil9I/Y1tWfy5bs/eNvwNpWw==",
+            "version": "5.15.15",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.15.tgz",
+            "integrity": "sha512-kkeU/pe+hABcYDH6Uqy8RmIsr2S/y5bP2rp+Gat4CcRjCcVne6KudS1NrZQhUCRysrTDCAhcbcf9gt+/+pGO2g==",
             "dependencies": {
-                "@babel/runtime": "^7.23.4"
+                "@babel/runtime": "^7.23.9"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -695,31 +372,29 @@
             }
         },
         "node_modules/@mui/lab": {
-            "version": "5.0.0-alpha.143",
-            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.143.tgz",
-            "integrity": "sha512-2lpzJCSyrb0yNhxzKK2G25w9+Tk+vjlmjgAXh+j8NS2fyRD7F992DuChRqNaoZmg1aoAbFli6qZh6XJE/5cymA==",
+            "version": "5.0.0-alpha.170",
+            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.170.tgz",
+            "integrity": "sha512-0bDVECGmrNjd3+bLdcLiwYZ0O4HP5j5WSQm5DV6iA/Z9kr8O6AnvZ1bv9ImQbbX7Gj3pX4o43EKwCutj3EQxQg==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
-                "@mui/base": "5.0.0-beta.14",
-                "@mui/system": "^5.14.8",
-                "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.14.8",
-                "@mui/x-tree-view": "https://pkg.csb.dev/mui/mui-x/commit/1f23b33d/@mui/x-tree-view",
-                "clsx": "^2.0.0",
-                "prop-types": "^15.8.1",
-                "react-is": "^18.2.0"
+                "@babel/runtime": "^7.23.9",
+                "@mui/base": "5.0.0-beta.40",
+                "@mui/system": "^5.15.15",
+                "@mui/types": "^7.2.14",
+                "@mui/utils": "^5.15.14",
+                "clsx": "^2.1.0",
+                "prop-types": "^15.8.1"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
                 "@emotion/styled": "^11.3.0",
-                "@mui/material": "^5.0.0",
+                "@mui/material": ">=5.15.0",
                 "@types/react": "^17.0.0 || ^18.0.0",
                 "react": "^17.0.0 || ^18.0.0",
                 "react-dom": "^17.0.0 || ^18.0.0"
@@ -737,19 +412,19 @@
             }
         },
         "node_modules/@mui/material": {
-            "version": "5.14.8",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.8.tgz",
-            "integrity": "sha512-fqvDGGF1pXwOOL/f0Gw+KHo/67hasRpf2ApTIJkbuONOk9AUb2jnYMEqCWmL2sUcbbE3ShMbHl8N7HPSsRv1/A==",
+            "version": "5.15.15",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.15.tgz",
+            "integrity": "sha512-3zvWayJ+E1kzoIsvwyEvkTUKVKt1AjchFFns+JtluHCuvxgKcLSRJTADw37k0doaRtVAsyh8bz9Afqzv+KYrIA==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
-                "@mui/base": "5.0.0-beta.14",
-                "@mui/core-downloads-tracker": "^5.14.8",
-                "@mui/system": "^5.14.8",
-                "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.14.8",
-                "@types/react-transition-group": "^4.4.6",
-                "clsx": "^2.0.0",
-                "csstype": "^3.1.2",
+                "@babel/runtime": "^7.23.9",
+                "@mui/base": "5.0.0-beta.40",
+                "@mui/core-downloads-tracker": "^5.15.15",
+                "@mui/system": "^5.15.15",
+                "@mui/types": "^7.2.14",
+                "@mui/utils": "^5.15.14",
+                "@types/react-transition-group": "^4.4.10",
+                "clsx": "^2.1.0",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1",
                 "react-is": "^18.2.0",
                 "react-transition-group": "^4.4.5"
@@ -759,7 +434,7 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
@@ -781,12 +456,12 @@
             }
         },
         "node_modules/@mui/private-theming": {
-            "version": "5.14.8",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.8.tgz",
-            "integrity": "sha512-iBzpcl3Mh92XaYpYPdgzzRxNGkjpoDz8rf8/q5m+EBPowFEHV+CCS9hC0Q2pOKLW3VFFikA7w/GHt7n++40JGQ==",
+            "version": "5.15.14",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
+            "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
-                "@mui/utils": "^5.14.8",
+                "@babel/runtime": "^7.23.9",
+                "@mui/utils": "^5.15.14",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -794,7 +469,7 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0",
@@ -807,13 +482,13 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "5.14.8",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.8.tgz",
-            "integrity": "sha512-LGwOav/Y40PZWZ2yDk4beUoRlc57Vg+Vpxi9V9BBtT2ESAucCgFobkt+T8eVLMWF9huUou5pwKgLSU5pF90hBg==",
+            "version": "5.15.14",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
+            "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
+                "@babel/runtime": "^7.23.9",
                 "@emotion/cache": "^11.11.0",
-                "csstype": "^3.1.2",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -821,7 +496,7 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.4.1",
@@ -838,17 +513,17 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "5.14.8",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.8.tgz",
-            "integrity": "sha512-Dxnasv7Pj5hYe4ZZFKJZu4ufKm6cxpitWt3A+qMPps22YhqyeEqgDBq/HsAB3GOjqDP40fTAvQvS/Hguf4SJuw==",
+            "version": "5.15.15",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
+            "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
-                "@mui/private-theming": "^5.14.8",
-                "@mui/styled-engine": "^5.14.8",
-                "@mui/types": "^7.2.4",
-                "@mui/utils": "^5.14.8",
-                "clsx": "^2.0.0",
-                "csstype": "^3.1.2",
+                "@babel/runtime": "^7.23.9",
+                "@mui/private-theming": "^5.15.14",
+                "@mui/styled-engine": "^5.15.14",
+                "@mui/types": "^7.2.14",
+                "@mui/utils": "^5.15.14",
+                "clsx": "^2.1.0",
+                "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -856,7 +531,7 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
@@ -877,11 +552,11 @@
             }
         },
         "node_modules/@mui/types": {
-            "version": "7.2.4",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-            "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+            "version": "7.2.14",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
+            "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
             "peerDependencies": {
-                "@types/react": "*"
+                "@types/react": "^17.0.0 || ^18.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -890,13 +565,12 @@
             }
         },
         "node_modules/@mui/utils": {
-            "version": "5.14.8",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.8.tgz",
-            "integrity": "sha512-1Ls2FfyY2yVSz9NEqedh3J8JAbbZAnUWkOWLE2f4/Hc4T5UWHMfzBLLrCqExfqyfyU+uXYJPGeNIsky6f8Gh5Q==",
+            "version": "5.15.14",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
+            "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
             "dependencies": {
-                "@babel/runtime": "^7.22.10",
-                "@types/prop-types": "^15.7.5",
-                "@types/react-is": "^18.2.1",
+                "@babel/runtime": "^7.23.9",
+                "@types/prop-types": "^15.7.11",
                 "prop-types": "^15.8.1",
                 "react-is": "^18.2.0"
             },
@@ -905,48 +579,16 @@
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/mui"
+                "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
                 "react": "^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@mui/x-tree-view": {
-            "version": "6.0.0-alpha.0",
-            "resolved": "https://pkg.csb.dev/mui/mui-x/commit/1f23b33d/@mui/x-tree-view",
-            "integrity": "sha512-oSayM+RvqJdjPW8BW4Vmmj99pHIaOJogumOqnFSd+zOzxZk0wFpf7/67LyGD4wNY0MVHj/EkjyE/LljTad5mCw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.22.6",
-                "@mui/utils": "^5.13.7",
-                "@types/react-transition-group": "^4.4.6",
-                "clsx": "^1.2.1",
-                "prop-types": "^15.8.1",
-                "react-transition-group": "^4.4.5"
             },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui"
-            },
-            "peerDependencies": {
-                "@emotion/react": "^11.9.0",
-                "@emotion/styled": "^11.8.1",
-                "@mui/base": "^5.0.0-alpha.87",
-                "@mui/material": "^5.8.6",
-                "@mui/system": "^5.8.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@mui/x-tree-view/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1038,9 +680,9 @@
             }
         },
         "node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
@@ -1091,50 +733,50 @@
             }
         },
         "node_modules/@types/adm-zip": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
-            "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
+            "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/chai": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-            "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+            "version": "4.3.14",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
+            "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
             "dev": true
         },
         "node_modules/@types/debug": {
-            "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dependencies": {
                 "@types/ms": "*"
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.37.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
-            "integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
+            "version": "8.56.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
+            "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
             }
         },
         "node_modules/@types/eslint-scope": {
-            "version": "3.7.4",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
         },
         "node_modules/@types/fs-extra": {
             "version": "9.0.13",
@@ -1156,39 +798,39 @@
             }
         },
         "node_modules/@types/hast": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-            "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+            "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
             "dependencies": {
-                "@types/unist": "*"
+                "@types/unist": "^2"
             }
         },
         "node_modules/@types/js-yaml": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
-            "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
             "dev": true
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
         },
         "node_modules/@types/json2csv": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@types/json2csv/-/json2csv-5.0.3.tgz",
-            "integrity": "sha512-ZJEv6SzhPhgpBpxZU4n/TZekbZqI4EcyXXRwms1lAITG2kIAtj85PfNYafUOY1zy8bWs5ujaub0GU4copaA0sw==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/@types/json2csv/-/json2csv-5.0.7.tgz",
+            "integrity": "sha512-Ma25zw9G9GEBnX8b12R4EYvnFT6dBh8L3jwsN5EUFXa+fl2dqmbLDbNWN0XuQU3rSXdsbBeCYjI9uHU2PUBxhA==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/mdast": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
-            "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+            "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
             "dependencies": {
-                "@types/unist": "*"
+                "@types/unist": "^2"
             }
         },
         "node_modules/@types/minimatch": {
@@ -1204,88 +846,71 @@
             "dev": true
         },
         "node_modules/@types/ms": {
-            "version": "0.7.31",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+            "version": "0.7.34",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+            "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
         },
         "node_modules/@types/node": {
-            "version": "18.16.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-            "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
-        },
-        "node_modules/@types/parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "peer": true
+            "version": "20.12.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+            "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/prop-types": {
-            "version": "15.7.5",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+            "version": "15.7.12",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+            "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
         },
         "node_modules/@types/react": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
-            "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
+            "version": "18.2.74",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
+            "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
             "dependencies": {
                 "@types/prop-types": "*",
-                "@types/scheduler": "*",
                 "csstype": "^3.0.2"
             }
         },
-        "node_modules/@types/react-is": {
-            "version": "18.2.1",
-            "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
-            "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
-            "dependencies": {
-                "@types/react": "*"
-            }
-        },
         "node_modules/@types/react-transition-group": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
-            "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
+            "version": "4.4.10",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+            "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
             "dependencies": {
                 "@types/react": "*"
             }
-        },
-        "node_modules/@types/scheduler": {
-            "version": "0.16.3",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-            "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
         },
         "node_modules/@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/sinon": {
-            "version": "10.0.15",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.15.tgz",
-            "integrity": "sha512-3lrFNQG0Kr2LDzvjyjB6AMJk4ge+8iYhQfdnSwIwlG88FUOV43kPcQqDZkDa/h3WSZy6i8Fr0BSjfQtB1B3xuQ==",
+            "version": "10.0.20",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+            "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
             "dev": true,
             "dependencies": {
                 "@types/sinonjs__fake-timers": "*"
             }
         },
         "node_modules/@types/sinonjs__fake-timers": {
-            "version": "8.1.2",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-            "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+            "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
             "dev": true
         },
         "node_modules/@types/tmp": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
-            "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
             "dev": true
         },
         "node_modules/@types/unist": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-            "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+            "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
         },
         "node_modules/@types/vscode": {
             "version": "1.64.0",
@@ -1294,17 +919,17 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
-            "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+            "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
-                "@typescript-eslint/scope-manager": "5.59.1",
-                "@typescript-eslint/type-utils": "5.59.1",
-                "@typescript-eslint/utils": "5.59.1",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/type-utils": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
                 "debug": "^4.3.4",
-                "grapheme-splitter": "^1.0.4",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
                 "semver": "^7.3.7",
@@ -1328,14 +953,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
-            "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.59.1",
-                "@typescript-eslint/types": "5.59.1",
-                "@typescript-eslint/typescript-estree": "5.59.1",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1355,13 +980,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
-            "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.59.1",
-                "@typescript-eslint/visitor-keys": "5.59.1"
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1372,13 +997,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
-            "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+            "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.59.1",
-                "@typescript-eslint/utils": "5.59.1",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -1399,9 +1024,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
-            "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1412,13 +1037,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
-            "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.59.1",
-                "@typescript-eslint/visitor-keys": "5.59.1",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1439,17 +1064,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
-            "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+            "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.59.1",
-                "@typescript-eslint/types": "5.59.1",
-                "@typescript-eslint/typescript-estree": "5.59.1",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
                 "eslint-scope": "^5.1.1",
                 "semver": "^7.3.7"
             },
@@ -1465,12 +1090,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
-            "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.59.1",
+                "@typescript-eslint/types": "5.62.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -1481,10 +1106,16 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
+        },
         "node_modules/@vscode/vsce": {
-            "version": "2.21.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.21.1.tgz",
-            "integrity": "sha512-f45/aT+HTubfCU2oC7IaWnH9NjOWp668ML002QiFObFRVUCoLtcwepp9mmql/ArFUy+HCHp54Xrq4koTcOD6TA==",
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.24.0.tgz",
+            "integrity": "sha512-p6CIXpH5HXDqmUkgFXvIKTjZpZxy/uDx4d/UsfhS9vQUun43KDNUbYeZocyAHgqcJlPEurgArHz9te1PPiqPyA==",
             "dev": true,
             "dependencies": {
                 "azure-devops-node-api": "^11.0.1",
@@ -1518,56 +1149,6 @@
                 "keytar": "^7.7.0"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@vscode/vsce/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/@vscode/vsce/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1588,168 +1169,134 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/xml2js": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-            "dev": true,
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.5.tgz",
-            "integrity": "sha512-LHY/GSAZZRpsNQH+/oHqhRQ5FT7eoULcBqgfyTB5nQHogFnK3/7QoN7dLnwSE/JkUAF0SrRuclT7ODqMFtWxxQ==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+            "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
             "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5"
+                "@webassemblyjs/helper-numbers": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.5.tgz",
-            "integrity": "sha512-1j1zTIC5EZOtCplMBG/IEwLtUojtwFVwdyVMbL/hwWqbzlQoJsWCOavrdnLkemwNoC/EOwtUFch3fuo+cbcXYQ=="
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
         },
         "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.5.tgz",
-            "integrity": "sha512-L65bDPmfpY0+yFrsgz8b6LhXmbbs38OnwDCf6NpnMUYqa+ENfE5Dq9E42ny0qz/PdR0LJyq/T5YijPnU8AXEpA=="
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.5.tgz",
-            "integrity": "sha512-fDKo1gstwFFSfacIeH5KfwzjykIE6ldh1iH9Y/8YkAZrhmu4TctqYjSh7t0K2VyDSXOZJ1MLhht/k9IvYGcIxg=="
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+            "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
         },
         "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.5.tgz",
-            "integrity": "sha512-DhykHXM0ZABqfIGYNv93A5KKDw/+ywBFnuWybZZWcuzWHfbp21wUfRkbtz7dMGwGgT4iXjWuhRMA2Mzod6W4WA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
             "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.5",
-                "@webassemblyjs/helper-api-error": "1.11.5",
+                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.5.tgz",
-            "integrity": "sha512-oC4Qa0bNcqnjAowFn7MPCETQgDYytpsfvz4ujZz63Zu/a/v71HeCAAmZsgZ3YVKec3zSPYytG3/PrRCqbtcAvA=="
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.5.tgz",
-            "integrity": "sha512-uEoThA1LN2NA+K3B9wDo3yKlBfVtC6rh0i4/6hvbz071E8gTNZD/pT0MsBf7MeD6KbApMSkaAK0XeKyOZC7CIA==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+            "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5"
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.12.1"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.5.tgz",
-            "integrity": "sha512-37aGq6qVL8A8oPbPrSGMBcp38YZFXcHfiROflJn9jxSdSMMM5dS5P/9e2/TpaJuhE+wFrbukN2WI6Hw9MH5acg==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "node_modules/@webassemblyjs/leb128": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.5.tgz",
-            "integrity": "sha512-ajqrRSXaTJoPW+xmkfYN6l8VIeNnR4vBOTQO9HzR7IygoCcKWkICbKFbVTNMjMgMREqXEr0+2M6zukzM47ZUfQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/utf8": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.5.tgz",
-            "integrity": "sha512-WiOhulHKTZU5UPlRl53gHR8OxdGsSOxqfpqWeA2FmcwBMaoEdz6b2x2si3IwC9/fSPLfe8pBMRTHVMk5nlwnFQ=="
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.5.tgz",
-            "integrity": "sha512-C0p9D2fAu3Twwqvygvf42iGCQ4av8MFBLiTb+08SZ4cEdwzWx9QeAHDo1E2k+9s/0w1DM40oflJOpkZ8jW4HCQ==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+            "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/helper-wasm-section": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5",
-                "@webassemblyjs/wasm-opt": "1.11.5",
-                "@webassemblyjs/wasm-parser": "1.11.5",
-                "@webassemblyjs/wast-printer": "1.11.5"
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/helper-wasm-section": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-opt": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1",
+                "@webassemblyjs/wast-printer": "1.12.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.5.tgz",
-            "integrity": "sha512-14vteRlRjxLK9eSyYFvw1K8Vv+iPdZU0Aebk3j6oB8TQiQYuO6hj9s4d7qf6f2HJr2khzvNldAFG13CgdkAIfA==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+            "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/ieee754": "1.11.5",
-                "@webassemblyjs/leb128": "1.11.5",
-                "@webassemblyjs/utf8": "1.11.5"
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.5.tgz",
-            "integrity": "sha512-tcKwlIXstBQgbKy1MlbDMlXaxpucn42eb17H29rawYLxm5+MsEmgPzeCP8B1Cl69hCice8LeKgZpRUAPtqYPgw==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+            "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5",
-                "@webassemblyjs/wasm-parser": "1.11.5"
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.5.tgz",
-            "integrity": "sha512-SVXUIwsLQlc8srSD7jejsfTU83g7pIGr2YYNb9oHdtldSxaOhvA5xwvIiWIfcX8PlSakgqMXsLpLfbbJ4cBYew==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+            "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-api-error": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/ieee754": "1.11.5",
-                "@webassemblyjs/leb128": "1.11.5",
-                "@webassemblyjs/utf8": "1.11.5"
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.5.tgz",
-            "integrity": "sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+            "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
+                "@webassemblyjs/ast": "1.12.1",
                 "@xtuc/long": "4.2.2"
             }
         },
@@ -1811,9 +1358,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1822,9 +1369,9 @@
             }
         },
         "node_modules/acorn-import-assertions": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
             "peerDependencies": {
                 "acorn": "^8"
             }
@@ -1839,9 +1386,9 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
+            "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==",
             "engines": {
                 "node": ">=6.0"
             }
@@ -1899,18 +1446,15 @@
             }
         },
         "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "dependencies": {
-                "color-convert": "^2.0.1"
+                "color-convert": "^1.9.0"
             },
             "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+                "node": ">=4"
             }
         },
         "node_modules/anymatch": {
@@ -1941,14 +1485,13 @@
             }
         },
         "node_modules/asn1.js": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dependencies": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "safer-buffer": "^2.1.0"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "node_modules/asn1.js/node_modules/bn.js": {
@@ -1957,14 +1500,15 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/assert": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-            "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+            "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
             "dependencies": {
-                "es6-object-assign": "^1.1.0",
-                "is-nan": "^1.2.1",
-                "object-is": "^1.0.1",
-                "util": "^0.12.0"
+                "call-bind": "^1.0.2",
+                "is-nan": "^1.3.2",
+                "object-is": "^1.1.5",
+                "object.assign": "^4.1.4",
+                "util": "^0.12.5"
             }
         },
         "node_modules/assertion-error": {
@@ -1990,9 +1534,12 @@
             }
         },
         "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2026,21 +1573,6 @@
             "dependencies": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
-            }
-        },
-        "node_modules/babel-plugin-macros": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "cosmiconfig": "^7.0.0",
-                "resolve": "^1.19.0"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">=6"
             }
         },
         "node_modules/bail": {
@@ -2078,9 +1610,9 @@
             ]
         },
         "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
             "dev": true,
             "engines": {
                 "node": ">=0.6"
@@ -2100,12 +1632,15 @@
             }
         },
         "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/bl": {
@@ -2254,36 +1789,56 @@
             }
         },
         "node_modules/browserify-sign": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
-            "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+            "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
             "dependencies": {
                 "bn.js": "^5.2.1",
                 "browserify-rsa": "^4.1.0",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.5.4",
+                "elliptic": "^6.5.5",
+                "hash-base": "~3.0",
                 "inherits": "^2.0.4",
-                "parse-asn1": "^5.1.6",
-                "readable-stream": "^3.6.2",
+                "parse-asn1": "^5.1.7",
+                "readable-stream": "^2.3.8",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
-                "node": ">= 4"
+                "node": ">= 0.12"
             }
         },
         "node_modules/browserify-sign/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/browserify-zlib": {
             "version": "0.2.0",
@@ -2294,9 +1849,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2305,13 +1860,17 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001449",
-                "electron-to-chromium": "^1.4.284",
-                "node-releases": "^2.0.8",
-                "update-browserslist-db": "^1.0.10"
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
+                "node-releases": "^2.0.14",
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2386,12 +1945,18 @@
             "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2401,6 +1966,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2418,9 +1984,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001481",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
-            "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
+            "version": "1.0.30001606",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+            "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2437,18 +2003,18 @@
             ]
         },
         "node_modules/chai": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-            "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+            "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
             "dev": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^4.1.2",
-                "get-func-name": "^2.0.0",
-                "loupe": "^2.3.1",
+                "check-error": "^1.0.3",
+                "deep-eql": "^4.1.3",
+                "get-func-name": "^2.0.2",
+                "loupe": "^2.3.6",
                 "pathval": "^1.1.1",
-                "type-detect": "^4.0.5"
+                "type-detect": "^4.0.8"
             },
             "engines": {
                 "node": ">=4"
@@ -2467,19 +2033,17 @@
             }
         },
         "node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
+                "node": ">=4"
             }
         },
         "node_modules/character-entities": {
@@ -2510,10 +2074,13 @@
             }
         },
         "node_modules/check-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
             "dev": true,
+            "dependencies": {
+                "get-func-name": "^2.0.2"
+            },
             "engines": {
                 "node": "*"
             }
@@ -2659,29 +2226,26 @@
             }
         },
         "node_modules/clsx": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-            "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+            "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
             "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
+                "color-name": "1.1.3"
             }
         },
         "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
             "dev": true
         },
         "node_modules/colorette": {
@@ -2734,33 +2298,10 @@
             "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
             "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ=="
         },
-        "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "peer": true
-        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
-        },
-        "node_modules/cosmiconfig": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-            "peer": true,
-            "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
         },
         "node_modules/create-ecdh": {
             "version": "4.0.4",
@@ -2865,9 +2406,9 @@
             }
         },
         "node_modules/csstype": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/d3-ease": {
             "version": "2.0.0",
@@ -2972,11 +2513,28 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-        "node_modules/define-properties": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-            "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             },
@@ -3004,18 +2562,18 @@
             }
         },
         "node_modules/des.js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+            "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
             "dependencies": {
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
             }
         },
         "node_modules/detect-libc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
             "dev": true,
             "optional": true,
             "engines": {
@@ -3093,9 +2651,9 @@
             }
         },
         "node_modules/domain-browser": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
-            "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
+            "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
             "engines": {
                 "node": ">=10"
             },
@@ -3131,14 +2689,14 @@
             }
         },
         "node_modules/domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "dev": true,
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -3184,14 +2742,14 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.374",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.374.tgz",
-            "integrity": "sha512-dNP9tQNTrjgVlSXMqGaj0BdrCS+9pcUvy5/emB6x8kh0YwCoDZ0Z4ce1+7aod+KhybHUd5o5LgKrc5al4kVmzQ=="
+            "version": "1.4.729",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+            "integrity": "sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA=="
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -3224,9 +2782,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-            "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+            "version": "5.16.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
+            "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -3248,9 +2806,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-            "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+            "version": "7.12.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.12.0.tgz",
+            "integrity": "sha512-Iw9rQJBGpJRd3rwXm9ft/JiGoAZmLxxJZELYDQoPRZ4USVhkKtIcNBPw6U+/K2mBpaqM25JSV6Yl4Az9vO2wJg==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -3259,66 +2817,70 @@
                 "node": ">=4"
             }
         },
-        "node_modules/error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "peer": true,
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
             "dependencies": {
-                "is-arrayish": "^0.2.1"
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
-            "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
-        },
-        "node_modules/es6-object-assign": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
+            "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw=="
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=0.8.0"
             }
         },
         "node_modules/eslint": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
-            "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.0.2",
-                "@eslint/js": "8.39.0",
-                "@humanwhocodes/config-array": "^0.11.8",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.0",
-                "eslint-visitor-keys": "^3.4.0",
-                "espree": "^9.5.1",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -3326,22 +2888,19 @@
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
                 "globals": "^13.19.0",
-                "grapheme-splitter": "^1.0.4",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
-                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
+                "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
             },
             "bin": {
@@ -3355,9 +2914,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+            "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -3379,9 +2938,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-            "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3390,10 +2949,71 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/eslint/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -3415,15 +3035,36 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/espree": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-            "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+        "node_modules/eslint/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/espree": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.0"
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3552,9 +3193,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -3591,9 +3232,9 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
-            "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
+            "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
             "funding": [
                 {
                     "type": "github",
@@ -3621,9 +3262,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -3682,12 +3323,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/find-root": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "peer": true
-        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3714,12 +3349,13 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "dependencies": {
-                "flatted": "^3.1.0",
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.3",
                 "rimraf": "^3.0.2"
             },
             "engines": {
@@ -3727,15 +3363,15 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
@@ -3807,9 +3443,9 @@
             "dev": true
         },
         "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
@@ -3868,9 +3504,12 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
@@ -3891,13 +3530,18 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3968,9 +3612,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -4018,37 +3662,38 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
-        "node_modules/grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=4"
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4066,11 +3711,11 @@
             }
         },
         "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4080,29 +3725,15 @@
             }
         },
         "node_modules/hash-base": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
             "dependencies": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.6.0",
-                "safe-buffer": "^5.2.0"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/hash-base/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/hash.js": {
@@ -4112,6 +3743,17 @@
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hast-util-parse-selector": {
@@ -4205,21 +3847,6 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "peer": true,
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
-        "node_modules/hoist-non-react-statics/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "peer": true
-        },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -4302,9 +3929,9 @@
             ]
         },
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -4314,6 +3941,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -4426,12 +4054,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "peer": true
-        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4490,11 +4112,12 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "dev": true,
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4630,15 +4253,11 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
+                "which-typed-array": "^1.1.14"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4662,8 +4281,7 @@
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -4692,6 +4310,14 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/jest-worker/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4707,8 +4333,9 @@
             }
         },
         "node_modules/jfrog-client-js": {
-            "version": "2.7.1",
-            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#e051beca70f478a8279d5c0d43648c2a24d77a39",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.8.0.tgz",
+            "integrity": "sha512-Q2gYG6vKKeKi6bu8crIRBTFz3AABzROg+CtxFqH5Z9u5yyD24bReUvjujfwxu3aYTq8VUdojVbHVg9A6jBw6mg==",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5",
@@ -4732,16 +4359,6 @@
                 "react-tree-graph": "8.0.1"
             }
         },
-        "node_modules/js-sdsl": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
-            "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/js-sdsl"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4757,6 +4374,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -4799,9 +4422,9 @@
             }
         },
         "node_modules/jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
             "dev": true
         },
         "node_modules/jsonfile": {
@@ -4824,9 +4447,9 @@
             ]
         },
         "node_modules/just-extend": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+            "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
             "dev": true
         },
         "node_modules/keytar": {
@@ -4839,6 +4462,15 @@
             "dependencies": {
                 "node-addon-api": "^4.3.0",
                 "prebuild-install": "^7.0.1"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
             }
         },
         "node_modules/kind-of": {
@@ -4879,12 +4511,6 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
-        },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "peer": true
         },
         "node_modules/linkify-it": {
             "version": "3.0.3",
@@ -4956,10 +4582,80 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/log-symbols/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/log-symbols/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/log-symbols/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/log-symbols/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/loglevel": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
-            "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+            "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
             "engines": {
                 "node": ">= 0.6.0"
             },
@@ -4980,12 +4676,12 @@
             }
         },
         "node_modules/loupe": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-            "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
             "dev": true,
             "dependencies": {
-                "get-func-name": "^2.0.0"
+                "get-func-name": "^2.0.1"
             }
         },
         "node_modules/lowlight": {
@@ -5062,9 +4758,9 @@
             }
         },
         "node_modules/mdast-util-from-markdown": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz",
-            "integrity": "sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+            "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
             "dependencies": {
                 "@types/mdast": "^3.0.0",
                 "@types/unist": "^2.0.0",
@@ -5136,9 +4832,9 @@
             }
         },
         "node_modules/micromark": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
-            "integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+            "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5170,9 +4866,9 @@
             }
         },
         "node_modules/micromark-core-commonmark": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
-            "integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+            "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5203,9 +4899,9 @@
             }
         },
         "node_modules/micromark-factory-destination": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
-            "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+            "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5223,9 +4919,9 @@
             }
         },
         "node_modules/micromark-factory-label": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
-            "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+            "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5244,9 +4940,9 @@
             }
         },
         "node_modules/micromark-factory-space": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
-            "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+            "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5263,9 +4959,9 @@
             }
         },
         "node_modules/micromark-factory-title": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
-            "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+            "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5280,14 +4976,13 @@
                 "micromark-factory-space": "^1.0.0",
                 "micromark-util-character": "^1.0.0",
                 "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "micromark-util-types": "^1.0.0"
             }
         },
         "node_modules/micromark-factory-whitespace": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
-            "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+            "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5306,9 +5001,9 @@
             }
         },
         "node_modules/micromark-util-character": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
-            "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+            "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5325,9 +5020,9 @@
             }
         },
         "node_modules/micromark-util-chunked": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
-            "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+            "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5343,9 +5038,9 @@
             }
         },
         "node_modules/micromark-util-classify-character": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
-            "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+            "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5363,9 +5058,9 @@
             }
         },
         "node_modules/micromark-util-combine-extensions": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
-            "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+            "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5382,9 +5077,9 @@
             }
         },
         "node_modules/micromark-util-decode-numeric-character-reference": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
-            "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+            "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5400,9 +5095,9 @@
             }
         },
         "node_modules/micromark-util-decode-string": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
-            "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+            "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5421,9 +5116,9 @@
             }
         },
         "node_modules/micromark-util-encode": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
-            "integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+            "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5436,9 +5131,9 @@
             ]
         },
         "node_modules/micromark-util-html-tag-name": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
-            "integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+            "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5451,9 +5146,9 @@
             ]
         },
         "node_modules/micromark-util-normalize-identifier": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
-            "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+            "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5469,9 +5164,9 @@
             }
         },
         "node_modules/micromark-util-resolve-all": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
-            "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+            "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5487,9 +5182,9 @@
             }
         },
         "node_modules/micromark-util-sanitize-uri": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
-            "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+            "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5507,9 +5202,9 @@
             }
         },
         "node_modules/micromark-util-subtokenize": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
-            "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+            "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5528,9 +5223,9 @@
             }
         },
         "node_modules/micromark-util-symbol": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
-            "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+            "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5543,9 +5238,9 @@
             ]
         },
         "node_modules/micromark-util-types": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
-            "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+            "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -5682,9 +5377,9 @@
             "optional": true
         },
         "node_modules/mocha": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-            "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
+            "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
             "dev": true,
             "dependencies": {
                 "ansi-colors": "4.1.1",
@@ -5694,13 +5389,12 @@
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.2.0",
+                "glob": "8.1.0",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
                 "minimatch": "5.0.1",
                 "ms": "2.1.3",
-                "nanoid": "3.3.3",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
@@ -5715,42 +5409,36 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mochajs"
             }
         },
-        "node_modules/mocha/node_modules/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "node_modules/mocha/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
             "engines": {
-                "node": "*"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
@@ -5763,15 +5451,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -5814,18 +5493,6 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
-        "node_modules/nanoid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-            "dev": true,
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -5851,36 +5518,35 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
         "node_modules/nise": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-            "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
+            "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@sinonjs/text-encoding": "^0.7.1",
-                "just-extend": "^4.0.2",
-                "path-to-regexp": "^1.7.0"
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^11.2.2",
+                "@sinonjs/text-encoding": "^0.7.2",
+                "just-extend": "^6.2.0",
+                "path-to-regexp": "^6.2.1"
             }
         },
-        "node_modules/nise/node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+        "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+            "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
             "dev": true,
             "dependencies": {
-                "type-detect": "4.0.8"
+                "@sinonjs/commons": "^3.0.0"
             }
         },
         "node_modules/nock": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
-            "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+            "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.1.0",
                 "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.21",
                 "propagate": "^2.0.0"
             },
             "engines": {
@@ -5888,9 +5554,9 @@
             }
         },
         "node_modules/node-abi": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
-            "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
+            "version": "3.57.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.57.0.tgz",
+            "integrity": "sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -5957,9 +5623,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -6025,21 +5691,20 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-            "dev": true,
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6056,6 +5721,23 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/object.assign": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+            "dependencies": {
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
+                "has-symbols": "^1.0.3",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6066,17 +5748,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -6093,9 +5775,9 @@
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="
         },
         "node_modules/ovsx": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.3.tgz",
-            "integrity": "sha512-LG7wTzy4eYV/KolFeO4AwWPzQSARvCONzd5oHQlNvYOlji2r/zjbdK8pyObZN84uZlk6rQBWrJrAdJfh/SX0Hg==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.4.tgz",
+            "integrity": "sha512-RMtGSVNM4NWSF9uVWCUqaYiA7ID8Vqm/rSk2W37eYVrDLOI/3do2IRY7rQYkvJqb6sS6LAnALODBkD50tIM1kw==",
             "dev": true,
             "dependencies": {
                 "@vscode/vsce": "^2.19.0",
@@ -6195,6 +5877,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -6203,15 +5886,19 @@
             }
         },
         "node_modules/parse-asn1": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+            "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+            "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
             "dependencies": {
-                "asn1.js": "^5.2.0",
-                "browserify-aes": "^1.0.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3",
-                "safe-buffer": "^5.1.1"
+                "asn1.js": "^4.10.1",
+                "browserify-aes": "^1.2.0",
+                "evp_bytestokey": "^1.0.3",
+                "hash-base": "~3.0",
+                "pbkdf2": "^3.1.2",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/parse-entities": {
@@ -6229,24 +5916,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parse-semver": {
@@ -6327,27 +5996,20 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "node_modules/path-to-regexp": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-            "dev": true,
-            "dependencies": {
-                "isarray": "0.0.1"
-            }
-        },
-        "node_modules/path-to-regexp/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
             "dev": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6463,10 +6125,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+            "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/prebuild-install": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-            "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+            "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -6530,8 +6200,7 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -6558,9 +6227,9 @@
             }
         },
         "node_modules/property-information": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-            "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+            "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -6596,35 +6265,25 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/qs": {
-            "version": "6.11.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
-            "dev": true,
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
+            "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/querystring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-            "engines": {
-                "node": ">=0.4.x"
             }
         },
         "node_modules/querystring-es3": {
@@ -6813,14 +6472,15 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-            "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
                 "events": "^3.3.0",
-                "process": "^0.11.10"
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6873,14 +6533,14 @@
             }
         },
         "node_modules/regenerator-runtime": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/remark-parse": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
-            "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+            "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
             "dependencies": {
                 "@types/mdast": "^3.0.0",
                 "mdast-util-from-markdown": "^1.0.0",
@@ -6916,11 +6576,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "dev": true,
             "dependencies": {
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -6956,6 +6617,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -7072,15 +6734,10 @@
                 }
             ]
         },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
         "node_modules/sax": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+            "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
             "dev": true
         },
         "node_modules/scheduler": {
@@ -7092,9 +6749,9 @@
             }
         },
         "node_modules/schema-utils": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-            "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -7109,9 +6766,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -7129,6 +6786,22 @@
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/setimmediate": {
@@ -7182,14 +6855,17 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-            "dev": true,
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7246,6 +6922,7 @@
             "version": "15.2.0",
             "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
             "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
+            "deprecated": "16.1.1",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0",
@@ -7261,12 +6938,33 @@
             }
         },
         "node_modules/sinon/node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/sinon/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/sinon/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/slash": {
@@ -7279,11 +6977,12 @@
             }
         },
         "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+            "dev": true,
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">= 8"
             }
         },
         "node_modules/source-map-support": {
@@ -7293,6 +6992,14 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/space-separated-tokens": {
@@ -7407,9 +7114,9 @@
             "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "node_modules/style-to-object": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-            "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+            "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
             "dependencies": {
                 "inline-style-parser": "0.1.1"
             }
@@ -7420,21 +7127,22 @@
             "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
         },
         "node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
             "dependencies": {
-                "has-flag": "^4.0.0"
+                "has-flag": "^3.0.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=4"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7496,12 +7204,12 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-            "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+            "version": "5.30.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
+            "integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
             "dependencies": {
-                "@jridgewell/source-map": "^0.3.2",
-                "acorn": "^8.5.0",
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -7513,15 +7221,15 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
-            "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
+            "version": "5.3.10",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+            "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@jridgewell/trace-mapping": "^0.3.20",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.1",
-                "terser": "^5.16.5"
+                "terser": "^5.26.0"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -7546,9 +7254,9 @@
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -7576,24 +7284,12 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
             "dev": true,
-            "dependencies": {
-                "rimraf": "^3.0.0"
-            },
             "engines": {
-                "node": ">=8.17.0"
-            }
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
+                "node": ">=14.14"
             }
         },
         "node_modules/to-regex-range": {
@@ -7627,24 +7323,25 @@
             }
         },
         "node_modules/trough": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
-            "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/ts-loader": {
-            "version": "9.4.2",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
-            "integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+            "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
                 "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^7.3.4"
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -7652,6 +7349,76 @@
             "peerDependencies": {
                 "typescript": "*",
                 "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/ts-loader/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ts-loader/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ts-loader/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ts-loader/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/ts-loader/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ts-loader/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/tslib": {
@@ -7736,9 +7503,9 @@
             }
         },
         "node_modules/typed-rest-client": {
-            "version": "1.8.9",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-            "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+            "version": "1.8.11",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+            "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
             "dev": true,
             "dependencies": {
                 "qs": "^6.9.1",
@@ -7775,6 +7542,11 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
             "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
             "dev": true
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "node_modules/unified": {
             "version": "10.1.2",
@@ -7867,17 +7639,17 @@
             }
         },
         "node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
         "node_modules/unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
             "dev": true,
             "dependencies": {
                 "big-integer": "^1.6.17",
@@ -7923,9 +7695,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7960,12 +7732,12 @@
             }
         },
         "node_modules/url": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+            "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
             "dependencies": {
-                "punycode": "1.3.2",
-                "querystring": "0.2.0"
+                "punycode": "^1.4.1",
+                "qs": "^6.11.2"
             }
         },
         "node_modules/url-join": {
@@ -7975,9 +7747,9 @@
             "dev": true
         },
         "node_modules/url/node_modules/punycode": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
         },
         "node_modules/util": {
             "version": "0.12.5",
@@ -8071,9 +7843,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
+            "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -8083,33 +7855,33 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.81.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.81.0.tgz",
-            "integrity": "sha512-AAjaJ9S4hYCVODKLQTgG5p5e11hiMawBwV2v8MYLE0C/6UAGLuAF4n1qa9GOwdxnicaP+5k6M5HrLmD4+gIB8Q==",
+            "version": "5.91.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
+            "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
-                "@types/estree": "^1.0.0",
-                "@webassemblyjs/ast": "^1.11.5",
-                "@webassemblyjs/wasm-edit": "^1.11.5",
-                "@webassemblyjs/wasm-parser": "^1.11.5",
+                "@types/estree": "^1.0.5",
+                "@webassemblyjs/ast": "^1.12.1",
+                "@webassemblyjs/wasm-edit": "^1.12.1",
+                "@webassemblyjs/wasm-parser": "^1.12.1",
                 "acorn": "^8.7.1",
-                "acorn-import-assertions": "^1.7.6",
-                "browserslist": "^4.14.5",
+                "acorn-import-assertions": "^1.9.0",
+                "browserslist": "^4.21.10",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.13.0",
+                "enhanced-resolve": "^5.16.0",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.9",
+                "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^3.1.2",
+                "schema-utils": "^3.2.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.7",
-                "watchpack": "^2.4.0",
+                "terser-webpack-plugin": "^5.3.10",
+                "watchpack": "^2.4.1",
                 "webpack-sources": "^3.2.3"
             },
             "bin": {
@@ -8185,12 +7957,13 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
             "dev": true,
             "dependencies": {
                 "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
                 "wildcard": "^2.0.0"
             },
             "engines": {
@@ -8220,16 +7993,15 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+            "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.10"
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -8243,15 +8015,6 @@
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true
-        },
-        "node_modules/word-wrap": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/workerpool": {
             "version": "6.2.1",
@@ -8276,11 +8039,57 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "dev": true,
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
@@ -8346,15 +8155,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "peer": true,
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/yargs": {
             "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4708,7 +4708,7 @@
         },
         "node_modules/jfrog-client-js": {
             "version": "2.7.1",
-            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#4d625e0122a7457aacf4bb4b59b210c2b45e4fba",
+            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#a8835e1d60d09dfe7e6fdacbabb9fffc4fdad6cd",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "adm-zip": "~0.5.9",
                 "fs-extra": "~10.1.0",
-                "jfrog-client-js": "^2.7.1",
+                "jfrog-client-js": "github:attiasas/jfrog-client-js#add_xsc",
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.2.13.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
@@ -4708,8 +4708,7 @@
         },
         "node_modules/jfrog-client-js": {
             "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/jfrog-client-js/-/jfrog-client-js-2.7.1.tgz",
-            "integrity": "sha512-hAhuScJm6HDxGDWXPqm7uB+RLn+Y457umv6qDUSateTEx1SidG7ibfnJLvNtZyPQh9su7Uia/2rXz2SItS+Qeg==",
+            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#4d625e0122a7457aacf4bb4b59b210c2b45e4fba",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4708,7 +4708,7 @@
         },
         "node_modules/jfrog-client-js": {
             "version": "2.7.1",
-            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#0baa7d27156004a4586b0bcb50592a0d1d4df34b",
+            "resolved": "git+ssh://git@github.com/attiasas/jfrog-client-js.git#e051beca70f478a8279d5c0d43648c2a24d77a39",
             "dependencies": {
                 "axios": "~0.27.2",
                 "axios-retry": "~3.2.5",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,12 @@
                     "scope": "application",
                     "markdownDescription": "Add one or more Xray Watches, to reflect the security policies required by your organization.\n\nIf both “Project Key” and “Watches” are configured, VS Code will use the configured Watches, and not the Project Key to determine the policy for the security scanning."
                 },
+                "jfrog.reportAnalytics": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "application",
+                    "markdownDescription": "Help us improve the JFrog extension by sending anonymous usage data to JFrog."
+                },
                 "jfrog.logLevel": {
                     "type": "string",
                     "default": "info",
@@ -304,7 +310,7 @@
     "dependencies": {
         "adm-zip": "~0.5.9",
         "fs-extra": "~10.1.0",
-        "jfrog-client-js": "^2.7.1",
+        "jfrog-client-js": "github:attiasas/jfrog-client-js#add_xsc",
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.2.13.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",
@@ -332,6 +338,7 @@
         "@types/vscode": "1.64.0",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
+        "@vscode/vsce": "^2.21.0",
         "chai": "^4.3.6",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
@@ -344,7 +351,6 @@
         "tmp": "^0.2.1",
         "ts-loader": "^9.3.0",
         "typescript": "^4.7.2",
-        "@vscode/vsce": "^2.21.0",
         "vscode-test": "^1.6.1",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2"

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "dependencies": {
         "adm-zip": "~0.5.9",
         "fs-extra": "~10.1.0",
-        "jfrog-client-js": "github:attiasas/jfrog-client-js#add_xsc",
+        "jfrog-client-js": "^2.8.0",
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.2.13.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,12 @@
                     "scope": "application",
                     "markdownDescription": "Help us improve the JFrog extension by sending anonymous usage data to JFrog."
                 },
+                "jfrog.saveAdvanceLog": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "application",
+                    "markdownDescription": "Save Jfrog Advance Security logs when running the scan."
+                },
                 "jfrog.logLevel": {
                     "type": "string",
                     "default": "info",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
                     "type": "boolean",
                     "default": true,
                     "scope": "application",
-                    "markdownDescription": "Help us improve the JFrog extension by sending anonymous usage data to JFrog."
+                    "markdownDescription": "Help us improve the JFrog extension by sending analytic data and errors to JFrog."
                 },
                 "jfrog.showAdvanceScanLog": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -120,11 +120,11 @@
                     "scope": "application",
                     "markdownDescription": "Help us improve the JFrog extension by sending anonymous usage data to JFrog."
                 },
-                "jfrog.saveAdvanceLog": {
+                "jfrog.showAdvanceScanLog": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "scope": "application",
-                    "markdownDescription": "Save Jfrog Advance Security logs when running the scan."
+                    "markdownDescription": "Show the detailed advance scan logs at debug level."
                 },
                 "jfrog.logLevel": {
                     "type": "string",

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -272,11 +272,12 @@ export class CommandManager implements ExtensionComponent {
     private async showConnectionStatus() {
         if (await this._connectionManager.isSignedIn()) {
             vscode.window.showInformationMessage(this.xrayConnectionDetails());
-            if (this._connectionManager.rtUrl) {
-                return vscode.window.showInformationMessage(this.artifactoryConnectionDetails());
+            if (this._connectionManager.xscUrl && this._connectionManager.xscVersion !== '') {
+                // Optional for compatible platforms
+                vscode.window.showInformationMessage(this.xscConnectionDetails());
             }
-            if (this._connectionManager.xscUrl) {
-                return vscode.window.showInformationMessage(this.xscConnectionDetails());
+            if (this._connectionManager.rtUrl) {
+                vscode.window.showInformationMessage(this.artifactoryConnectionDetails());
             }
             return;
         }
@@ -292,7 +293,7 @@ export class CommandManager implements ExtensionComponent {
     }
 
     private xscConnectionDetails(): string {
-        return this.createServerDetailsMessage('Xsc', this._connectionManager.xscUrl, this._connectionManager.xscVersion);
+        return this.createServerDetailsMessage('Xray Source Control', this._connectionManager.xscUrl, this._connectionManager.xscVersion);
     }
 
     private artifactoryConnectionDetails(): string {

--- a/src/main/commands/commandManager.ts
+++ b/src/main/commands/commandManager.ts
@@ -275,6 +275,9 @@ export class CommandManager implements ExtensionComponent {
             if (this._connectionManager.rtUrl) {
                 return vscode.window.showInformationMessage(this.artifactoryConnectionDetails());
             }
+            if (this._connectionManager.xscUrl) {
+                return vscode.window.showInformationMessage(this.xscConnectionDetails());
+            }
             return;
         }
         if (await this._connectionManager.isConnectionLost()) {
@@ -286,6 +289,10 @@ export class CommandManager implements ExtensionComponent {
 
     private xrayConnectionDetails(): string {
         return this.createServerDetailsMessage('Xray', this._connectionManager.xrayUrl, this._connectionManager.xrayVersion);
+    }
+
+    private xscConnectionDetails(): string {
+        return this.createServerDetailsMessage('Xsc', this._connectionManager.xscUrl, this._connectionManager.xscVersion);
     }
 
     private artifactoryConnectionDetails(): string {

--- a/src/main/connect/connectionManager.ts
+++ b/src/main/connect/connectionManager.ts
@@ -782,9 +782,9 @@ export class ConnectionManager implements ExtensionComponent, vscode.Disposable 
         progress: XrayScanProgress,
         checkCanceled: () => void,
         project: string,
-        watches: string[], 
+        watches: string[],
         msi?: string,
-        packageType?: string,
+        packageType?: string
     ): Promise<IGraphResponse> {
         let client: JfrogClient = this.createJfrogClient();
         let scanService: XrayScanClient = client.xray().scan();
@@ -797,27 +797,22 @@ export class ConnectionManager implements ExtensionComponent, vscode.Disposable 
         return await scanService.graph(graphRequest, progress, checkCanceled, project, watches, msi, technology);
     }
 
-    private getScanLog(
-        componentId: string,
-        project: string,
-        watches: string[], 
-        msi?: string,
-        packageType?: string): string {
-            let service: string = 'Xray';
-            let message: string = '';
-            if (msi && msi !== '') {
-                service = 'XSC';
-                message += ` Scan MSI: ${msi}`;
-                if (packageType) {
-                    message += ` Scan Technology: ${packageType}`;
-                }
+    private getScanLog(componentId: string, project: string, watches: string[], msi?: string, packageType?: string): string {
+        let service: string = 'Xray';
+        let message: string = '';
+        if (msi && msi !== '') {
+            service = 'XSC';
+            message += ` Scan MSI: ${msi}`;
+            if (packageType) {
+                message += ` Scan Technology: ${packageType}`;
             }
-            if (watches.length > 0) {
-                message += ` Using Watches: [${watches.join(', ')}]`;
-            } else if (project && project !== '') {
-                message += ` Using Project key: ${project}`;
-            }
-            return `Sending dependency graph "` + componentId + `" to ` + service + ` for analyzing.` + message;
+        }
+        if (watches.length > 0) {
+            message += ` Using Watches: [${watches.join(', ')}]`;
+        } else if (project && project !== '') {
+            message += ` Using Project key: ${project}`;
+        }
+        return `Sending dependency graph "` + componentId + `" to ` + service + ` for analyzing.` + message;
     }
 
     public async startScan(request: StartScanRequest): Promise<ScanEvent> {
@@ -871,6 +866,7 @@ export class ConnectionManager implements ExtensionComponent, vscode.Disposable 
             this._logManager.logMessage('Xsc is not configured. Skipping analytics...', 'DEBUG');
             return false;
         }
+        return true;
         let xscSemver: semver.SemVer = new semver.SemVer(this.xscVersion);
         if (xscSemver.compare(ConnectionManager.MINIMAL_XSC_VERSION_SUPPORTED) < 0) {
             this._logManager.logMessage(

--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -253,7 +253,7 @@ export class ConnectionUtils {
         return xrayVersion.xray_version;
     }
 
-    public static async getXscVersion(logger: LogManager, jfrogClient: JfrogClient): Promise<string> {
+    public static async getXscVersion(jfrogClient: JfrogClient): Promise<string> {
         try {
             let xscVersion: IXscVersion = await jfrogClient
                 .xsc()

--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -104,7 +104,7 @@ export class ConnectionUtils {
         try {
             return (await this.testXscVersion(jfrogClient)) !== '';
         } catch (error) {
-            logManager.logMessage(error, 'DEBUG');
+            logManager.logMessage(<string>error, 'DEBUG');
             return false;
         }
     }

--- a/src/main/log/logUtils.ts
+++ b/src/main/log/logUtils.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { ScanUtils } from '../utils/scanUtils';
+import { ConnectionManager } from '../connect/connectionManager';
+import { Configuration } from '../utils/configuration';
 
 export class LogUtils {
     // keep up to 100 logs
@@ -24,5 +26,13 @@ export class LogUtils {
 
     public static getLogFileName(...args: string[]): string {
         return args.join('-') + '.log';
+    }
+
+    public static logErrorWithAnalytics(error: Error, connectionManager: ConnectionManager, shouldToast: boolean = false) {
+        connectionManager.logManager.logError(error, shouldToast);
+        if (!Configuration.getReportAnalytics()) {
+            return;
+        }
+        connectionManager.logWithAnalytics(`${error.name}: ${error.message}\n${error.stack}`, 'ERR');
     }
 }

--- a/src/main/scanLogic/scanGraphLogic.ts
+++ b/src/main/scanLogic/scanGraphLogic.ts
@@ -3,6 +3,7 @@ import { ConnectionManager } from '../connect/connectionManager';
 import { RootNode } from '../treeDataProviders/dependenciesTree/dependenciesRoot/rootTree';
 import { DependenciesTreeNode } from '../treeDataProviders/dependenciesTree/dependenciesTreeNode';
 import { Configuration } from '../utils/configuration';
+import { fromPackageType } from '../types/projectType';
 
 /**
  * Supported in Xray >= 3.29.0.
@@ -21,7 +22,7 @@ export class GraphScanLogic {
      * @param checkCanceled - method to check if the action was canceled
      * @returns the result of the scan
      */
-    public async scan(graphRoot: RootNode, progress: XrayScanProgress, checkCanceled: () => void): Promise<IGraphResponse> {
+    public async scan(graphRoot: RootNode, progress: XrayScanProgress, checkCanceled: () => void, msi?: string): Promise<IGraphResponse> {
         let graphRequest: IGraphRequestModel = {
             component_id: graphRoot.generalInfo.artifactId ?? graphRoot.xrayDependencyId,
             nodes: this.getFlattenRequestModelNodes(graphRoot, new Set<string>())
@@ -35,7 +36,9 @@ export class GraphScanLogic {
             progress,
             checkCanceled,
             Configuration.getProjectKey(),
-            Configuration.getWatches()
+            Configuration.getWatches(),
+            msi,
+            fromPackageType(graphRoot.generalInfo.pkgType)
         );
     }
 

--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -103,10 +103,12 @@ export class ScanManager implements ExtensionComponent {
         const scansPromises: Promise<void>[] = [];
         for (const runner of jasRunners) {
             if (runner.shouldRun()) {
-                scansPromises.push(runner.scan({ msi: scanDetails.multiScanId }).catch(error => {
-                    this._connectionManager.logErrorWithAnalytics(error, false);
-                    scanDetails.status = ScanEventStatus.Failed;
-                }));
+                scansPromises.push(
+                    runner.scan({ msi: scanDetails.multiScanId }).catch(error => {
+                        this._connectionManager.logErrorWithAnalytics(error, false);
+                        scanDetails.status = ScanEventStatus.Failed;
+                    })
+                );
             }
         }
         return scansPromises;
@@ -121,7 +123,12 @@ export class ScanManager implements ExtensionComponent {
      * @param flatten - if true will flatten the graph and send only distinct dependencies, other wise will keep the graph as is
      * @returns the result of the scan
      */
-    public async scanDependencyGraph(progress: XrayScanProgress, graphRoot: RootNode, checkCanceled: () => void, msi?: string): Promise<IGraphResponse> {
+    public async scanDependencyGraph(
+        progress: XrayScanProgress,
+        graphRoot: RootNode,
+        checkCanceled: () => void,
+        msi?: string
+    ): Promise<IGraphResponse> {
         let scanLogic: GraphScanLogic = new GraphScanLogic(this._connectionManager);
         return await scanLogic.scan(graphRoot, progress, checkCanceled, msi);
     }

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -9,6 +9,7 @@ import { ConnectionUtils } from '../../connect/connectionUtils';
 import { Configuration } from '../../utils/configuration';
 import { Translators } from '../../utils/translators';
 import { BinaryEnvParams } from './jasRunner';
+import { LogUtils } from '../../log/logUtils';
 
 /**
  * Analyzer manager is responsible for running the analyzer on the workspace.
@@ -83,7 +84,7 @@ export class AnalyzerManager {
             try {
                 return await this._binary.update();
             } catch (error) {
-                this._connectionManager.logErrorWithAnalytics(new Error('Failed to check if extension is outdated: ' + error));
+                LogUtils.logErrorWithAnalytics(new Error('Failed to check if extension is outdated: ' + error), this._connectionManager);
             }
         }
         return false;
@@ -190,7 +191,7 @@ export class AnalyzerManager {
                 this._version = match[1];
             }
         } catch (error) {
-            this._connectionManager.logErrorWithAnalytics(<Error>error);
+            LogUtils.logErrorWithAnalytics(<Error>error, this._connectionManager);
             return undefined;
         }
         return this._version;

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -97,7 +97,7 @@ export class AnalyzerManager {
      */
     public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined): Promise<string> {
         await AnalyzerManager.FINISH_UPDATE_PROMISE;
-        return await this._binary.run(args, checkCancel, env);
+        return await this._binary.run(args, checkCancel, env, false);
     }
 
     /**
@@ -148,12 +148,12 @@ export class AnalyzerManager {
             binaryVars[AnalyzerManager.ENV_HTTPS_PROXY] = this.addOptionalProxyAuthInformation(proxyHttpsUrl);
         }
         // Optional log destination
-        if (params?.executionLogDirectory) {
+        if (Configuration.getShouldSaveJasLogs() && params?.executionLogDirectory) {
             binaryVars.AM_LOG_DIRECTORY = params.executionLogDirectory;
         }
         // Optional Multi scan id
         if (params?.msi) {
-            binaryVars.ENV_MSI = params.msi;
+            binaryVars[AnalyzerManager.ENV_MSI] = params.msi;
         }
     }
 

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -8,6 +8,7 @@ import { IProxyConfig, JfrogClient } from 'jfrog-client-js';
 import { ConnectionUtils } from '../../connect/connectionUtils';
 import { Configuration } from '../../utils/configuration';
 import { Translators } from '../../utils/translators';
+import { BinaryEnvParams } from './jasRunner';
 
 /**
  * Analyzer manager is responsible for running the analyzer on the workspace.
@@ -19,19 +20,23 @@ export class AnalyzerManager {
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
     );
     private static readonly DOWNLOAD_URL: string = Utils.addZipSuffix(
-        AnalyzerManager.RELATIVE_DOWNLOAD_URL + '/' + Utils.getArchitecture() + '/' + AnalyzerManager.BINARY_NAME
+        AnalyzerManager.RELATIVE_DOWNLOAD_URL + '/' + Utils.getPlatformAndArch() + '/' + AnalyzerManager.BINARY_NAME
     );
+
     private static readonly JFROG_RELEASES_URL: string = 'https://releases.jfrog.io';
+    public static readonly JF_RELEASES_REPO: string = 'JF_RELEASES_REPO';
+
     public static readonly ENV_PLATFORM_URL: string = 'JF_PLATFORM_URL';
     public static readonly ENV_TOKEN: string = 'JF_TOKEN';
     public static readonly ENV_USER: string = 'JF_USER';
     public static readonly ENV_PASSWORD: string = 'JF_PASS';
+    public static readonly ENV_MSI: string = 'JF_MSI';
     public static readonly ENV_LOG_DIR: string = 'AM_LOG_DIRECTORY';
     public static readonly ENV_HTTP_PROXY: string = 'HTTP_PROXY';
     public static readonly ENV_HTTPS_PROXY: string = 'HTTPS_PROXY';
-    public static readonly JF_RELEASES_REPO: string = 'JF_RELEASES_REPO';
 
     protected _binary: Resource;
+    private _version: string = '';
     private static FINISH_UPDATE_PROMISE: Promise<boolean>;
 
     constructor(private _connectionManager: ConnectionManager, protected _logManager: LogManager) {
@@ -78,7 +83,7 @@ export class AnalyzerManager {
             try {
                 return await this._binary.update();
             } catch (error) {
-                this._logManager.logMessage('Failed to check if extension is outdated: ' + error, 'ERR');
+                this._connectionManager.logErrorWithAnalytics(new Error('Failed to check if extension is outdated: ' + error));
             }
         }
         return false;
@@ -90,9 +95,9 @@ export class AnalyzerManager {
      * @param checkCancel - A function that throws ScanCancellationError if the user chose to stop the scan
      * @param executionLogDirectory - the directory to save the execution log in
      */
-    public async run(args: string[], checkCancel: () => void, executionLogDirectory?: string): Promise<void> {
+    public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined): Promise<string> {
         await AnalyzerManager.FINISH_UPDATE_PROMISE;
-        await this._binary.run(args, checkCancel, this.createEnvForRun(executionLogDirectory));
+        return await this._binary.run(args, checkCancel, env);
     }
 
     /**
@@ -100,7 +105,7 @@ export class AnalyzerManager {
      * @param executionLogDirectory - the directory that the log will be written into, if not provided the log will be written in stdout/stderr
      * @returns list of environment variables to use while executing the runner or unidentified if credential not set
      */
-    public createEnvForRun(executionLogDirectory?: string): NodeJS.ProcessEnv | undefined {
+    public createEnvForRun(params?: BinaryEnvParams): NodeJS.ProcessEnv | undefined {
         if (!this._connectionManager.areXrayCredentialsSet()) {
             return undefined;
         }
@@ -116,7 +121,7 @@ export class AnalyzerManager {
             binaryVars[AnalyzerManager.ENV_PASSWORD] = this._connectionManager.password;
         }
 
-        this.populateOptionalInformation(binaryVars, executionLogDirectory);
+        this.populateOptionalInformation(binaryVars, params);
 
         return {
             ...process.env,
@@ -124,7 +129,7 @@ export class AnalyzerManager {
         };
     }
 
-    private populateOptionalInformation(binaryVars: NodeJS.ProcessEnv, executionLogDirectory?: string) {
+    private populateOptionalInformation(binaryVars: NodeJS.ProcessEnv, params?: BinaryEnvParams) {
         // Optional proxy information - environment variable
         let proxyHttpUrl: string | undefined = process.env['HTTP_PROXY'];
         let proxyHttpsUrl: string | undefined = process.env['HTTPS_PROXY'];
@@ -143,8 +148,12 @@ export class AnalyzerManager {
             binaryVars[AnalyzerManager.ENV_HTTPS_PROXY] = this.addOptionalProxyAuthInformation(proxyHttpsUrl);
         }
         // Optional log destination
-        if (executionLogDirectory) {
-            binaryVars.AM_LOG_DIRECTORY = executionLogDirectory;
+        if (params?.executionLogDirectory) {
+            binaryVars.AM_LOG_DIRECTORY = params.executionLogDirectory;
+        }
+        // Optional Multi scan id
+        if (params?.msi) {
+            binaryVars.ENV_MSI = params.msi;
         }
     }
 
@@ -165,5 +174,25 @@ export class AnalyzerManager {
             }
         }
         return url;
+    }
+
+    public async version(): Promise<string | undefined> {
+        if (this._version !== '') {
+            return this._version;
+        }
+        await AnalyzerManager.FINISH_UPDATE_PROMISE;
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            let versionString: string = await this._binary.run(['version'], () => {});
+            // Extract the version from the output
+            const match: RegExpMatchArray | null = versionString.match('/analyzer manager version:\\s*(\\S+)/');
+            if (match && match.length > 1) {
+                this._version = match[1];
+            }
+        } catch (error) {
+            this._connectionManager.logErrorWithAnalytics(<Error>error);
+            return undefined;
+        }
+        return this._version;
     }
 }

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -148,7 +148,7 @@ export class AnalyzerManager {
             binaryVars[AnalyzerManager.ENV_HTTPS_PROXY] = this.addOptionalProxyAuthInformation(proxyHttpsUrl);
         }
         // Optional log destination
-        if (Configuration.getShouldSaveJasLogs() && params?.executionLogDirectory) {
+        if (!Configuration.getShouldShowJasLogs() && params?.executionLogDirectory) {
             binaryVars.AM_LOG_DIRECTORY = params.executionLogDirectory;
         }
         // Optional Multi scan id
@@ -185,7 +185,7 @@ export class AnalyzerManager {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             let versionString: string = await this._binary.run(['version'], () => {});
             // Extract the version from the output
-            const match: RegExpMatchArray | null = versionString.match('/analyzer manager version:\\s*(\\S+)/');
+            const match: RegExpMatchArray | null = versionString.match('analyzer manager version:\\s*(\\S+)');
             if (match && match.length > 1) {
                 this._version = match[1];
             }

--- a/src/main/scanLogic/scanRunners/jasRunner.ts
+++ b/src/main/scanLogic/scanRunners/jasRunner.ts
@@ -15,7 +15,7 @@ import { AnalyzerManager } from './analyzerManager';
 /**
  * Arguments for running binary async
  */
-class RunArgs {
+export class RunArgs {
     // The requests for the run
     public request: RunRequest = {} as RunRequest;
     // The directory that the requests/responses are expected
@@ -34,6 +34,12 @@ interface RunRequest {
     requestPath: string;
     roots: string[];
     responsePath: string;
+}
+
+// Parameters that are passed to the analyzer manager when running a scan
+export interface BinaryEnvParams {
+    executionLogDirectory?: string;
+    msi?: string;
 }
 
 /**
@@ -55,7 +61,7 @@ export abstract class JasRunner {
     /**
      * Run full JAS scan for the specific scanner.
      */
-    public abstract scan(): Promise<void>;
+    public abstract scan(params?: BinaryEnvParams): Promise<void>;
 
     public get config() {
         return this._config;
@@ -68,12 +74,7 @@ export abstract class JasRunner {
      * @param checkCancel           - Check if should cancel
      * @param responsePath          - Path to the output file
      */
-    protected abstract runBinary(
-        yamlConfigPath: string,
-        executionLogDirectory: string,
-        checkCancel: () => void,
-        responsePath: string | undefined
-    ): Promise<void>;
+    protected abstract runBinary(checkCancel: () => void, args: RunArgs, params?: BinaryEnvParams): Promise<void>;
 
     /**
      * @returns true if should run the JAS scanner
@@ -92,16 +93,18 @@ export abstract class JasRunner {
      * @param args - Arguments for the command
      * @param executionLogDirectory - Directory to save the execution log in
      */
-    protected async runAnalyzerManager(checkCancel: () => void, args: string[], executionLogDirectory?: string): Promise<void> {
+    protected async runAnalyzerManager(checkCancel: () => void, args: string[], env?: NodeJS.ProcessEnv | undefined): Promise<void> {
         checkCancel();
-        await this._analyzerManager.run(args, checkCancel, executionLogDirectory);
+        await this._analyzerManager.run(args, checkCancel, env);
     }
 
-    protected logStartScanning(request: AnalyzeScanRequest): void {
-        this._logManager.logMessage(
-            `Scanning directories '${request.roots}', for ${this._scanType} issues. Skipping folders: ${request.skipped_folders}`,
-            'DEBUG'
-        );
+    protected logStartScanning(request: AnalyzeScanRequest, msi?: string): void {
+        let msg: string = `Scanning directories '${request.roots}', for ${this._scanType} issues.`;
+        if (msi) {
+            msg += `\nMultiScanId: ${msi}`;
+        }
+        msg += ` Skipping folders: ${request.skipped_folders}`;
+        this._logManager.logMessage(msg, 'DEBUG');
     }
 
     protected logNumberOfIssues(issuesCount: number, workspace: string, startTime: number, endTime: number): void {
@@ -118,17 +121,21 @@ export abstract class JasRunner {
      * @param request     - Request to perform in YAML format
      * @returns
      */
-    public async executeRequest(checkCancel: () => void, request: AnalyzeScanRequest): Promise<AnalyzerScanResponse | undefined> {
+    public async executeRequest(
+        checkCancel: () => void,
+        request: AnalyzeScanRequest,
+        params?: BinaryEnvParams
+    ): Promise<AnalyzerScanResponse | undefined> {
         let args: RunArgs = this.createRunArguments(request);
         let execErr: Error | undefined;
         try {
-            return await this.runRequest(checkCancel, args.request.requestContent, args.request.requestPath, args.request.responsePath);
+            return await this.runRequest(checkCancel, args, params);
         } catch (err) {
             execErr = <Error>err;
             if (err instanceof ScanCancellationError || err instanceof NotEntitledError || err instanceof NotSupportedError) {
                 throw err;
             }
-            this._logManager.logError(execErr);
+            this._connectionManager.logErrorWithAnalytics(execErr);
         } finally {
             this.handleExecutionLog(args, execErr);
             ScanUtils.removeFolder(args.directory);
@@ -233,14 +240,19 @@ export abstract class JasRunner {
      * @param responsePath - Path of the response for request in the run
      * @returns the response from all the binary runs
      */
-    public async runRequest(checkCancel: () => void, request: string, requestPath: string, responsePath: string): Promise<AnalyzerScanResponse> {
+    public async runRequest(checkCancel: () => void, args: RunArgs, params?: BinaryEnvParams): Promise<AnalyzerScanResponse> {
+        // 0. Prepare args.request.requestContent, args.request.requestPath, args.request.responsePath
+        if (params && !params.executionLogDirectory) {
+            params.executionLogDirectory = path.dirname(args.request.requestPath);
+        }
+
         // 1. Save requests as yaml file in folder
-        fs.writeFileSync(requestPath, request);
-        this._logManager.debug('Input YAML:\n' + request);
+        fs.writeFileSync(args.request.requestPath, args.request.requestContent);
+        this._logManager.debug('Input YAML:\n' + args.request.requestContent);
 
         // 2. Run the binary
         try {
-            await this.runBinary(requestPath, path.dirname(requestPath), checkCancel, responsePath);
+            await this.runBinary(checkCancel, args, params);
         } catch (error) {
             let code: number | undefined = (<any>error).code;
             if (code) {
@@ -262,12 +274,15 @@ export abstract class JasRunner {
             throw error;
         }
         // 3. Collect responses
-        if (!fs.existsSync(responsePath)) {
+        if (!fs.existsSync(args.request.responsePath)) {
             throw new Error(
-                "Running '" + Translators.toAnalyzerTypeString(this._scanType) + "' binary didn't produce response.\nRequest: " + request
+                "Running '" +
+                    Translators.toAnalyzerTypeString(this._scanType) +
+                    "' binary didn't produce response.\nRequest: " +
+                    args.request.requestContent
             );
         }
         // Load result and parse as response
-        return JSON.parse(fs.readFileSync(responsePath, 'utf8').toString());
+        return JSON.parse(fs.readFileSync(args.request.responsePath, 'utf8').toString());
     }
 }

--- a/src/main/scanLogic/scanRunners/jasRunner.ts
+++ b/src/main/scanLogic/scanRunners/jasRunner.ts
@@ -130,9 +130,9 @@ export abstract class JasRunner {
         let execErr: Error | undefined;
         try {
             return await this.runRequest(checkCancel, args, params);
-        } catch (err: any) {
-            execErr = <Error>err;throw err;
-
+        } catch (err) {
+            execErr = <Error>err;
+            throw err;
         } finally {
             this.handleExecutionLog(args, execErr);
             ScanUtils.removeFolder(args.directory);

--- a/src/main/scanLogic/scanRunners/jasRunner.ts
+++ b/src/main/scanLogic/scanRunners/jasRunner.ts
@@ -6,7 +6,7 @@ import { ConnectionManager } from '../../connect/connectionManager';
 import { LogManager } from '../../log/logManager';
 import { LogUtils } from '../../log/logUtils';
 import { AppsConfigModule } from '../../utils/jfrogAppsConfig/jfrogAppsConfig';
-import { NotEntitledError, NotSupportedError, OsNotSupportedError, ScanCancellationError, ScanUtils } from '../../utils/scanUtils';
+import { NotEntitledError, NotSupportedError, OsNotSupportedError, ScanUtils } from '../../utils/scanUtils';
 import { Translators } from '../../utils/translators';
 import { Utils } from '../../utils/utils';
 import { AnalyzeScanRequest, AnalyzerRequest, AnalyzerScanResponse, ScanType } from './analyzerModels';
@@ -130,17 +130,13 @@ export abstract class JasRunner {
         let execErr: Error | undefined;
         try {
             return await this.runRequest(checkCancel, args, params);
-        } catch (err) {
-            execErr = <Error>err;
-            if (err instanceof ScanCancellationError || err instanceof NotEntitledError || err instanceof NotSupportedError) {
-                throw err;
-            }
-            this._connectionManager.logErrorWithAnalytics(execErr);
+        } catch (err: any) {
+            execErr = <Error>err;throw err;
+
         } finally {
             this.handleExecutionLog(args, execErr);
             ScanUtils.removeFolder(args.directory);
         }
-        return;
     }
 
     /**

--- a/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
+++ b/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
@@ -25,9 +25,9 @@ export class JasRunnerFactory {
         private scanResults: ScanResults,
         private root: IssuesRootTreeNode,
         private progressManager: StepProgress,
-        private supportedScans: SupportedScans
+        private _supportedScans: SupportedScans
     ) {
-        if (this.supportedScans.hasSupportedScan()) {
+        if (this._supportedScans.hasSupportedScan()) {
             this._analyzerManager = new AnalyzerManager(this._connectionManager, this._logManager);
         } else {
             this._logManager.logMessage('JFrog Advanced Security features are not entitled.', 'INFO');
@@ -40,6 +40,10 @@ export class JasRunnerFactory {
 
     public get analyzerManager(): AnalyzerManager | undefined {
         return this._analyzerManager;
+    }
+
+    public get supportedScans(): SupportedScans {
+        return this._supportedScans;
     }
 
     // Jas scanner support JFrog config file. Applicability is not supported by jfrog config so we create a default runner to run on the workspace.
@@ -55,7 +59,7 @@ export class JasRunnerFactory {
 
     private createSastRunners(): SastRunner[] {
         const sastRunners: SastRunner[] = [];
-        if (!this.supportedScans?.sast || !this._analyzerManager) {
+        if (!this._supportedScans?.sast || !this._analyzerManager) {
             this._logManager.logMessage('Static Application Security scanner is not entitled to scan workspace ', 'INFO');
             return sastRunners;
         }
@@ -80,7 +84,7 @@ export class JasRunnerFactory {
 
     protected createIacRunners(): IacRunner[] {
         const iacRunners: IacRunner[] = [];
-        if (!this.supportedScans?.iac || !this._analyzerManager) {
+        if (!this._supportedScans?.iac || !this._analyzerManager) {
             this._logManager.logMessage('Infrastructure as Code scanner is not entitled to scan workspace', 'INFO');
             return iacRunners;
         }
@@ -105,7 +109,7 @@ export class JasRunnerFactory {
 
     protected createSecretsRunners(): SecretsRunner[] {
         const secretsRunners: SecretsRunner[] = [];
-        if (!this.supportedScans?.secrets || !this._analyzerManager) {
+        if (!this._supportedScans?.secrets || !this._analyzerManager) {
             this._logManager.logMessage('Secrets scanner is not entitled to scan workspace', 'INFO');
             return secretsRunners;
         }
@@ -130,7 +134,7 @@ export class JasRunnerFactory {
 
     // Applicability is not supported by jfrog config so we create a default runner to run on the workspace.
     public async createApplicabilityRunner(bundlesWithIssues: FileScanBundle[], packageType: PackageType): Promise<ApplicabilityRunner | undefined> {
-        if (!this.supportedScans?.applicability || !this._analyzerManager) {
+        if (!this._supportedScans?.applicability || !this._analyzerManager) {
             this._logManager.logMessage('CVE Applicability scanner is not entitled to scan workspace', 'INFO');
             return undefined;
         }

--- a/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
+++ b/src/main/scanLogic/sourceCodeScan/jasRunnerFactory.ts
@@ -38,8 +38,12 @@ export class JasRunnerFactory {
         return this._uniqueFeatures;
     }
 
+    public get analyzerManager(): AnalyzerManager | undefined {
+        return this._analyzerManager;
+    }
+
     // Jas scanner support JFrog config file. Applicability is not supported by jfrog config so we create a default runner to run on the workspace.
-    public async createJasRunner(): Promise<JasRunner[]> {
+    public createJasRunner(): JasRunner[] {
         let jasRunners: JasRunner[] = [];
 
         jasRunners.push(...this.createSastRunners());

--- a/src/main/scanLogic/sourceCodeScan/supportedScans.ts
+++ b/src/main/scanLogic/sourceCodeScan/supportedScans.ts
@@ -100,7 +100,6 @@ export class SupportedScans {
      * Check if SAST scan is supported for the user
      */
     public async isSastSupported(): Promise<boolean> {
-        // TODO: change to SAST feature when Xray entitlement service support it.
-        return await ConnectionUtils.testXrayEntitlementForFeature(this._connectionManager.createJfrogClient(), EntitlementScanFeature.Applicability);
+        return await ConnectionUtils.testXrayEntitlementForFeature(this._connectionManager.createJfrogClient(), EntitlementScanFeature.Sast);
     }
 }

--- a/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
+++ b/src/main/treeDataProviders/issuesTree/issuesTreeDataProvider.ts
@@ -25,6 +25,7 @@ import { ProjectDependencyTreeNode } from './descriptorTree/projectDependencyTre
 import { FileTreeNode } from './fileTreeNode';
 import { IssueTreeNode } from './issueTreeNode';
 import { IssuesRootTreeNode } from './issuesRootTreeNode';
+import { LogUtils } from '../../log/logUtils';
 
 /**
  * Describes Xray issues data provider for the 'Issues' tree view and provides API to get issues data for files.
@@ -89,7 +90,7 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
         ScanUtils.setFirstScanForWorkspace(false);
         const startRefreshTimestamp: number = Date.now();
         await this.scanWorkspaces()
-            .catch(error => this._scanManager.connectionManager.logErrorWithAnalytics(error, true))
+            .catch(error => LogUtils.logErrorWithAnalytics(error, this._scanManager.connectionManager, true))
             .finally(() => {
                 this.scanInProgress = false;
                 this.onChangeFire();
@@ -137,7 +138,7 @@ export class IssuesTreeDataProvider implements vscode.TreeDataProvider<IssuesRoo
                                 root.title = 'Scan canceled';
                             } else {
                                 this._logManager.logMessage("Workspace '" + workspace.name + "' scan task ended with error:", 'ERR');
-                                this._scanManager.connectionManager.logErrorWithAnalytics(error, true);
+                                LogUtils.logErrorWithAnalytics(error, this._scanManager.connectionManager, true);
                                 root.title = 'Scan failed';
                             }
                         })

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -111,9 +111,7 @@ export class DependencyUtils {
             type
         );
         if (applicableRunners?.shouldRun()) {
-            await applicableRunners
-                .scan({ msi: scanDetails.multiScanId })
-                .catch(err => ScanUtils.onScanError(err, scanManager.logManager, true));
+            await applicableRunners.scan({ msi: scanDetails.multiScanId }).catch(err => ScanUtils.onScanError(err, scanManager.logManager, true));
         }
     }
 
@@ -257,10 +255,12 @@ export class DependencyUtils {
         scanManager.logManager.logMessage('Scanning descriptor ' + dependencyIssues.fullPath + ' for dependencies issues', 'INFO');
         // Scan
         let startGraphScan: number = Date.now();
-        dependencyIssues.dependenciesGraphScan = await scanManager.scanDependencyGraph(scanProgress, descriptorGraph, checkCanceled, msi).finally(() => {
-            scanProgress.setPercentage(100);
-            dependencyIssues.graphScanTimestamp = Date.now();
-        });
+        dependencyIssues.dependenciesGraphScan = await scanManager
+            .scanDependencyGraph(scanProgress, descriptorGraph, checkCanceled, msi)
+            .finally(() => {
+                scanProgress.setPercentage(100);
+                dependencyIssues.graphScanTimestamp = Date.now();
+            });
         if (!dependencyIssues.dependenciesGraphScan.vulnerabilities && !dependencyIssues.dependenciesGraphScan.violations) {
             return 0;
         }

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -7,7 +7,7 @@ import { ScanManager } from '../../scanLogic/scanManager';
 import { GeneralInfo } from '../../types/generalInfo';
 import { PackageType } from '../../types/projectType';
 import { Severity, SeverityUtils } from '../../types/severity';
-import { DependencyScanResults, ScanResults } from '../../types/workspaceIssuesDetails';
+import { DependencyScanResults } from '../../types/workspaceIssuesDetails';
 import { GoUtils } from '../../utils/goUtils';
 import { MavenUtils } from '../../utils/mavenUtils';
 import { NpmUtils } from '../../utils/npmUtils';
@@ -26,11 +26,10 @@ import { LicenseIssueTreeNode } from '../issuesTree/descriptorTree/licenseIssueT
 import { ProjectDependencyTreeNode } from '../issuesTree/descriptorTree/projectDependencyTreeNode';
 import { FileTreeNode } from '../issuesTree/fileTreeNode';
 import { IssueTreeNode } from '../issuesTree/issueTreeNode';
-import { IssuesRootTreeNode } from '../issuesTree/issuesRootTreeNode';
-import { GraphScanProgress, StepProgress } from './stepProgress';
+import { GraphScanProgress } from './stepProgress';
 import { ApplicabilityRunner } from '../../scanLogic/scanRunners/applicabilityScan';
-import { JasRunnerFactory } from '../../scanLogic/sourceCodeScan/jasRunnerFactory';
 import { PnpmUtils } from '../../utils/pnpmUtils';
+import { WorkspaceScanDetails } from '../../types/workspaceScanDetails';
 
 export class DependencyUtils {
     public static readonly FAIL_TO_SCAN: string = '[Fail to scan]';
@@ -38,7 +37,7 @@ export class DependencyUtils {
     /**
      * Scan all the dependencies of a given package for security issues and populate the given data and view objects with the information.
      * @param scanManager - the scanManager that preforms the actual scans
-     * @param scanResults - the data object that hold the workspace issues and will be populated with data
+     * @param scanDetails - all the scan information needed for the scan (data, view, progressManager) the data object that hold the workspace issues and will be populated with data
      * @param root - the root view object of the workspace issues and will be populated with nodes
      * @param type - Package type to scan it's dependencies
      * @param descriptorsPaths - the paths for all the descriptors of the package type
@@ -47,38 +46,36 @@ export class DependencyUtils {
      */
     public static async scanPackageDependencies(
         scanManager: ScanManager,
-        scanResults: ScanResults,
-        root: IssuesRootTreeNode,
+        scanDetails: WorkspaceScanDetails,
         type: PackageType,
-        descriptorsPaths: vscode.Uri[],
-        progressManager: StepProgress,
-        entitledJasRunnerFactory: JasRunnerFactory
+        descriptorsPaths: vscode.Uri[]
     ): Promise<any> {
         let scansPromises: Promise<any>[] = [];
         let descriptorsParsed: Set<string> = new Set<string>();
         // Build dependency tree for all the package descriptors
         let packageDependenciesTree: DependenciesTreeNode = await DependencyUtils.createDependenciesTree(
-            root.workspace,
+            scanDetails.viewRoot.workspace,
             type,
             descriptorsPaths,
-            () => progressManager.onProgress,
+            () => scanDetails.progressManager.onProgress,
             scanManager.logManager
         );
-        progressManager.reportProgress();
+        scanDetails.progressManager.reportProgress();
         // Adjust progress value with 2 substeps and the new number of discovered project dependency tree items.
-        let progressIncValue: number = (descriptorsPaths.length / packageDependenciesTree.children.length) * progressManager.getStepIncValue;
+        let progressIncValue: number =
+            (descriptorsPaths.length / packageDependenciesTree.children.length) * scanDetails.progressManager.getStepIncValue;
         let bundlesWithIssues: FileScanBundle[] = [];
         for (let child of packageDependenciesTree.children) {
             if (child instanceof RootNode) {
                 // Create bundle for the scan
                 descriptorsParsed.add(child.fullPath);
                 let scanBundle: FileScanBundle = {
-                    workspaceResults: scanResults,
-                    rootNode: root,
+                    workspaceResults: scanDetails.results,
+                    rootNode: scanDetails.viewRoot,
                     data: child.createEmptyScanResultsObject()
                 };
                 if (this.isGraphHasBuildError(child, scanBundle, scanManager.logManager)) {
-                    progressManager.reportProgress(progressIncValue);
+                    scanDetails.progressManager.reportProgress(progressIncValue);
                     continue;
                 }
                 if (child.children.length > 0) {
@@ -89,28 +86,33 @@ export class DependencyUtils {
                             scanManager,
                             scanBundle,
                             child,
-                            progressManager.createScanProgress(child.fullPath, progressIncValue / 2)
+                            scanDetails.progressManager.createScanProgress(child.fullPath, progressIncValue / 2)
                         )
                             .then(issueCount => {
                                 if (issueCount > 0) {
                                     bundlesWithIssues.push(scanBundle);
                                 }
                             })
-                            .finally(() => progressManager.reportProgress(progressIncValue / 2))
+                            .finally(() => scanDetails.progressManager.reportProgress(progressIncValue / 2))
                     );
                 }
             }
             // Not root or have no dependencies
             // Has to be at least after error checks because files with errors has no dependencies
-            progressManager.reportProgress(progressIncValue);
+            scanDetails.progressManager.reportProgress(progressIncValue);
             descriptorsParsed.add(child.generalInfo.path);
         }
         this.reportNotFoundDescriptors(descriptorsPaths, descriptorsParsed, scanManager.logManager);
 
         await Promise.all(scansPromises);
-        const applicableRunners: ApplicabilityRunner | undefined = await entitledJasRunnerFactory.createApplicabilityRunner(bundlesWithIssues, type);
+        const applicableRunners: ApplicabilityRunner | undefined = await scanDetails.jasRunnerFactory.createApplicabilityRunner(
+            bundlesWithIssues,
+            type
+        );
         if (applicableRunners?.shouldRun()) {
-            await applicableRunners.scan().catch(err => ScanUtils.onScanError(err, scanManager.logManager, true));
+            await applicableRunners
+                .scan({ msi: await scanDetails.getMultiScanId() })
+                .catch(err => ScanUtils.onScanError(err, scanManager.logManager, true));
         }
     }
 

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -70,6 +70,7 @@ export class DependencyUtils {
                 // Create bundle for the scan
                 descriptorsParsed.add(child.fullPath);
                 let scanBundle: FileScanBundle = {
+                    multiScanId: scanDetails.multiScanId,
                     workspaceResults: scanDetails.results,
                     rootNode: scanDetails.viewRoot,
                     data: child.createEmptyScanResultsObject()
@@ -111,7 +112,7 @@ export class DependencyUtils {
         );
         if (applicableRunners?.shouldRun()) {
             await applicableRunners
-                .scan({ msi: await scanDetails.getMultiScanId() })
+                .scan({ msi: scanDetails.multiScanId })
                 .catch(err => ScanUtils.onScanError(err, scanManager.logManager, true));
         }
     }
@@ -214,7 +215,8 @@ export class DependencyUtils {
                 fileScanBundle.dataNode,
                 rootGraph,
                 scanProgress,
-                scanProgress.onProgress
+                scanProgress.onProgress,
+                fileScanBundle.multiScanId
             );
             if (issuesCount > 0) {
                 // populate data and view
@@ -249,12 +251,13 @@ export class DependencyUtils {
         projectNode: ProjectDependencyTreeNode,
         descriptorGraph: RootNode,
         scanProgress: GraphScanProgress,
-        checkCanceled: () => void
+        checkCanceled: () => void,
+        msi?: string
     ): Promise<number> {
         scanManager.logManager.logMessage('Scanning descriptor ' + dependencyIssues.fullPath + ' for dependencies issues', 'INFO');
         // Scan
         let startGraphScan: number = Date.now();
-        dependencyIssues.dependenciesGraphScan = await scanManager.scanDependencyGraph(scanProgress, descriptorGraph, checkCanceled).finally(() => {
+        dependencyIssues.dependenciesGraphScan = await scanManager.scanDependencyGraph(scanProgress, descriptorGraph, checkCanceled, msi).finally(() => {
             scanProgress.setPercentage(100);
             dependencyIssues.graphScanTimestamp = Date.now();
         });

--- a/src/main/types/workspaceIssuesDetails.ts
+++ b/src/main/types/workspaceIssuesDetails.ts
@@ -70,11 +70,12 @@ export class ScanResults {
             this.secretsScan?.filesWithIssues?.length > 0
         );
     }
-    
+
     public get scaIssueCount(): number {
         let acc: number = 0;
         for (const descriptorIssues of this.descriptorsIssues) {
-            let issues: IVulnerability[] = (descriptorIssues.dependenciesGraphScan.violations || descriptorIssues.dependenciesGraphScan.vulnerabilities)
+            let issues: IVulnerability[] =
+                descriptorIssues.dependenciesGraphScan.violations || descriptorIssues.dependenciesGraphScan.vulnerabilities;
             for (const issue of issues) {
                 acc += issue.components.size;
             }

--- a/src/main/types/workspaceIssuesDetails.ts
+++ b/src/main/types/workspaceIssuesDetails.ts
@@ -1,4 +1,4 @@
-import { IGraphResponse, IVulnerability } from 'jfrog-client-js';
+import { IGraphResponse } from 'jfrog-client-js';
 import { IImpactGraph } from 'jfrog-ide-webview';
 import { ApplicabilityScanResponse } from '../scanLogic/scanRunners/applicabilityScan';
 import { IacScanResponse } from '../scanLogic/scanRunners/iacScan';
@@ -72,15 +72,15 @@ export class ScanResults {
     }
 
     public get scaIssueCount(): number {
-        let acc: number = 0;
-        for (const descriptorIssues of this.descriptorsIssues) {
-            let issues: IVulnerability[] =
-                descriptorIssues.dependenciesGraphScan.violations || descriptorIssues.dependenciesGraphScan.vulnerabilities;
-            for (const issue of issues) {
-                acc += issue.components.size;
-            }
-        }
-        return acc;
+        let uniqueIssues: Set<string> = new Set();
+        this.descriptorsIssues.forEach(descriptorIssues => {
+            (descriptorIssues.dependenciesGraphScan.violations || descriptorIssues.dependenciesGraphScan.vulnerabilities).forEach(issue => {
+                Object.entries(issue.components).forEach((_, cName) => {
+                    uniqueIssues.add(`${issue.issue_id}${cName}`);
+                });
+            });
+        });
+        return uniqueIssues.size;
     }
 
     public get ignoreIssueCount(): number {

--- a/src/main/types/workspaceIssuesDetails.ts
+++ b/src/main/types/workspaceIssuesDetails.ts
@@ -1,4 +1,4 @@
-import { IGraphResponse } from 'jfrog-client-js';
+import { IGraphResponse, IVulnerability } from 'jfrog-client-js';
 import { IImpactGraph } from 'jfrog-ide-webview';
 import { ApplicabilityScanResponse } from '../scanLogic/scanRunners/applicabilityScan';
 import { IacScanResponse } from '../scanLogic/scanRunners/iacScan';
@@ -69,6 +69,22 @@ export class ScanResults {
             this.iacScan?.filesWithIssues?.length > 0 ||
             this.secretsScan?.filesWithIssues?.length > 0
         );
+    }
+
+    public get cveDiscovered(): number {
+        let uniqueCVEs: Set<string> = new Set();
+        this.descriptorsIssues.forEach(descriptor => {
+            let issues: IVulnerability[] = descriptor.dependenciesGraphScan.violations || descriptor.dependenciesGraphScan.vulnerabilities;
+            issues.forEach(issue => {
+                let cveIds: string[] = issue.cves.length > 0 ? issue.cves.map(cve => cve.cve) : [issue.issue_id];
+                cveIds.forEach(cveId => uniqueCVEs.add(cveId));
+            });
+        });
+        return uniqueCVEs.size;
+    }
+
+    public get ignoreIssueCount(): number {
+        return (this.secretsScan?.ignoreCount ?? 0) + (this.sastScan?.ignoreCount ?? 0);
     }
 
     get path(): string {

--- a/src/main/types/workspaceIssuesDetails.ts
+++ b/src/main/types/workspaceIssuesDetails.ts
@@ -70,21 +70,36 @@ export class ScanResults {
             this.secretsScan?.filesWithIssues?.length > 0
         );
     }
-
-    public get cveDiscovered(): number {
-        let uniqueCVEs: Set<string> = new Set();
-        this.descriptorsIssues.forEach(descriptor => {
-            let issues: IVulnerability[] = descriptor.dependenciesGraphScan.violations || descriptor.dependenciesGraphScan.vulnerabilities;
-            issues.forEach(issue => {
-                let cveIds: string[] = issue.cves.length > 0 ? issue.cves.map(cve => cve.cve) : [issue.issue_id];
-                cveIds.forEach(cveId => uniqueCVEs.add(cveId));
-            });
-        });
-        return uniqueCVEs.size;
+    
+    public get scaIssueCount(): number {
+        let acc: number = 0;
+        for (const descriptorIssues of this.descriptorsIssues) {
+            let issues: IVulnerability[] = (descriptorIssues.dependenciesGraphScan.violations || descriptorIssues.dependenciesGraphScan.vulnerabilities)
+            for (const issue of issues) {
+                acc += issue.components.size;
+            }
+        }
+        return acc;
     }
 
     public get ignoreIssueCount(): number {
         return (this.secretsScan?.ignoreCount ?? 0) + (this.sastScan?.ignoreCount ?? 0);
+    }
+
+    public get iacIssueCount(): number {
+        return this.iacScan?.filesWithIssues?.reduce((acc, file) => acc + file.issues.length, 0) ?? 0;
+    }
+
+    public get sastIssueCount(): number {
+        return this.sastScan?.filesWithIssues?.reduce((acc, file) => acc + file.issues.length, 0) ?? 0;
+    }
+
+    public get secretsIssueCount(): number {
+        return this.secretsScan?.filesWithIssues?.reduce((acc, file) => acc + file.issues.length, 0) ?? 0;
+    }
+
+    public get issueCount(): number {
+        return this.scaIssueCount + this.iacIssueCount + this.sastIssueCount + this.secretsIssueCount;
     }
 
     get path(): string {

--- a/src/main/types/workspaceScanDetails.ts
+++ b/src/main/types/workspaceScanDetails.ts
@@ -43,9 +43,6 @@ export class WorkspaceScanDetails {
     }
 
     public async startScan(): Promise<void> {
-        if (!this._connectionManager.shouldReportAnalytics()) {
-            return;
-        }
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         let packageJson: any = require('../../../package.json');
         let request: StartScanRequest = {
@@ -63,8 +60,8 @@ export class WorkspaceScanDetails {
     }
 
     public async endScan(): Promise<void> {
-        if (!this._scanEvent) {
-            // Analytics are disabled
+        if (!this._scanEvent || !this._scanEvent.multi_scan_id) {
+            // Analytics are disabled / failed to start scan
             return;
         }
 
@@ -74,7 +71,7 @@ export class WorkspaceScanDetails {
         this._scanEvent.total_ignored_findings = this._resultsData.ignoreIssueCount;
 
         this._logManager.logMessage(
-            `'${this.viewRoot.workspace.uri}' Scan event result:\n` + JSON.stringify(this._scanEvent),
+            `'${this.viewRoot.workspace.uri.fsPath}' Scan event result:\n` + JSON.stringify(this._scanEvent),
             this.status !== ScanEventStatus.Failed ? 'DEBUG' : 'ERR'
         );
         this._connectionManager.endScan(this._scanEvent);

--- a/src/main/types/workspaceScanDetails.ts
+++ b/src/main/types/workspaceScanDetails.ts
@@ -1,0 +1,109 @@
+import * as os from 'os';
+import { JfrogClient, ScanEvent, ScanEventStatus, StartScanRequest } from 'jfrog-client-js';
+import { ScanResults } from './workspaceIssuesDetails';
+import { ConnectionManager } from '../connect/connectionManager';
+import { Utils } from '../utils/utils';
+import { JFrogAppsConfig } from '../utils/jfrogAppsConfig/jfrogAppsConfig';
+import { JasRunnerFactory } from '../scanLogic/sourceCodeScan/jasRunnerFactory';
+import { ScanManager } from '../scanLogic/scanManager';
+import { LogManager } from '../log/logManager';
+import { IssuesRootTreeNode } from '../treeDataProviders/issuesTree/issuesRootTreeNode';
+import { StepProgress } from '../treeDataProviders/utils/stepProgress';
+import { SupportedScans } from '../scanLogic/sourceCodeScan/supportedScans';
+
+export class WorkspaceScanDetails {
+    private _connectionManager: ConnectionManager;
+    private _logManager: LogManager;
+
+    private _jasRunnerFactory: JasRunnerFactory;
+
+    private _startTime: number = Date.now();
+    private _scanEventPromise?: Promise<ScanEvent>;
+
+    private _multiScanId?: string;
+
+    constructor(
+        manager: ScanManager,
+        supportedScans: SupportedScans,
+        private _resultsData: ScanResults,
+        private _resultsViewRoot: IssuesRootTreeNode,
+        private _scanProgressManager: StepProgress
+    ) {
+        this._connectionManager = manager.connectionManager;
+        this._logManager = manager.logManager;
+
+        this._jasRunnerFactory = new JasRunnerFactory(
+            this._connectionManager,
+            this._logManager,
+            this._resultsData,
+            this._resultsViewRoot,
+            this._scanProgressManager,
+            supportedScans
+        );
+    }
+
+    public async startScan(): Promise<void> {
+        if (!this._connectionManager.shouldReportAnalytics()) {
+            return;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        let packageJson: any = require('../../../package.json');
+        let request: StartScanRequest = {
+            product: packageJson.name,
+            product_version: packageJson.version,
+            jfrog_user: this._connectionManager.username,
+            os_platform: Utils.getPlatform(),
+            os_architecture: Utils.getArchitecture(),
+            machine_id: JfrogClient.getClientId(Object.values(os.networkInterfaces())),
+            analyzer_manager_version: await this._jasRunnerFactory.analyzerManager?.version(),
+            jpd_version: this._connectionManager.artifactoryVersion,
+            is_default_config: !JFrogAppsConfig.isConfigFileExist(this.results.path)
+        };
+        this._scanEventPromise = this._connectionManager.startScan(request);
+    }
+
+    public async endScan(endStatus: ScanEventStatus): Promise<void> {
+        let msi: string | undefined = await this.getMultiScanId();
+        if (!msi) {
+            // Analytics are disabled
+            return;
+        }
+        let scanEvent: ScanEvent = {
+            multi_scan_id: msi,
+            total_scan_duration: `${Date.now() - this._startTime}`,
+            event_status: endStatus,
+            total_findings: this.results.cveDiscovered,
+            total_ignored_findings: this.results.ignoreIssueCount
+        };
+        this._logManager.logMessage(
+            `'${this.viewRoot.workspace.uri}' Scan event result:\n` + JSON.stringify(scanEvent),
+            endStatus !== ScanEventStatus.Failed ? 'DEBUG' : 'ERR'
+        );
+        this._connectionManager.endScan(scanEvent);
+    }
+
+    public async getMultiScanId(): Promise<string | undefined> {
+        if (!this._scanEventPromise || this._multiScanId !== '') {
+            // Disabled / already finished waiting and result is stored
+            return this._multiScanId;
+        }
+        this._multiScanId = (await this._scanEventPromise).multi_scan_id;
+        return this._multiScanId;
+    }
+
+    public get results(): ScanResults {
+        return this._resultsData;
+    }
+
+    public get viewRoot(): IssuesRootTreeNode {
+        return this._resultsViewRoot;
+    }
+
+    public get jasRunnerFactory(): JasRunnerFactory {
+        return this._jasRunnerFactory;
+    }
+
+    public get progressManager(): StepProgress {
+        return this._scanProgressManager;
+    }
+}

--- a/src/main/types/workspaceScanDetails.ts
+++ b/src/main/types/workspaceScanDetails.ts
@@ -70,8 +70,8 @@ export class WorkspaceScanDetails {
 
         this._scanEvent.total_scan_duration = `${Date.now() - this._startTime}`;
         this._scanEvent.event_status = this.status;
-        this._scanEvent.total_findings = this._resultsData.issueCount
-        this._scanEvent.total_ignored_findings = this._resultsData.ignoreIssueCount
+        this._scanEvent.total_findings = this._resultsData.issueCount;
+        this._scanEvent.total_ignored_findings = this._resultsData.ignoreIssueCount;
 
         this._logManager.logMessage(
             `'${this.viewRoot.workspace.uri}' Scan event result:\n` + JSON.stringify(this._scanEvent),

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -61,6 +61,10 @@ export class Configuration {
         return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('reportAnalytics', true);
     }
 
+    public static getShouldSaveJasLogs(): boolean {
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('saveAdvanceLog', true);
+    }
+
     /**
      * @returns the log level
      */

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -57,6 +57,10 @@ export class Configuration {
         return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('watches', []);
     }
 
+    public static getReportAnalytics(): boolean {
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('reportAnalytics', true);
+    }
+
     /**
      * @returns the log level
      */

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -62,7 +62,7 @@ export class Configuration {
     }
 
     public static getShouldShowJasLogs(): boolean {
-        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('showAdvanceScanLog', true);
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('showAdvanceScanLog', false);
     }
 
     /**

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -61,8 +61,8 @@ export class Configuration {
         return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('reportAnalytics', true);
     }
 
-    public static getShouldSaveJasLogs(): boolean {
-        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('saveAdvanceLog', true);
+    public static getShouldShowJasLogs(): boolean {
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('showAdvanceScanLog', true);
     }
 
     /**

--- a/src/main/utils/jfrogAppsConfig/jfrogAppsConfig.ts
+++ b/src/main/utils/jfrogAppsConfig/jfrogAppsConfig.ts
@@ -13,9 +13,10 @@ export class JFrogAppsConfig {
     private _modules: AppsConfigModule[] = [];
 
     constructor(workspace: string) {
-        let appConfigPath: string = path.join(workspace, '.jfrog', 'jfrog-apps-config.yml');
-        if (fs.existsSync(appConfigPath)) {
-            let jfrogAppsConfig: JFrogAppsConfigSchema = yaml.load(fs.readFileSync(appConfigPath, 'utf8')) as JFrogAppsConfigSchema;
+        if (JFrogAppsConfig.isConfigFileExist(workspace)) {
+            let jfrogAppsConfig: JFrogAppsConfigSchema = yaml.load(
+                fs.readFileSync(JFrogAppsConfig.getConfigFilePath(workspace), 'utf8')
+            ) as JFrogAppsConfigSchema;
             this._version = jfrogAppsConfig.version;
             if (jfrogAppsConfig.modules) {
                 for (let module of jfrogAppsConfig.modules) {
@@ -27,6 +28,14 @@ export class JFrogAppsConfig {
         if (this._modules.length === 0) {
             this._modules.push(new AppsConfigModule(workspace));
         }
+    }
+
+    private static getConfigFilePath(workspace: string): string {
+        return path.join(workspace, '.jfrog', 'jfrog-apps-config.yml');
+    }
+
+    public static isConfigFileExist(workspace: string): boolean {
+        return fs.existsSync(JFrogAppsConfig.getConfigFilePath(workspace));
     }
 
     public get version(): string {

--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -154,7 +154,7 @@ export class Resource {
         return ScanUtils.Hash('SHA256', fileBuffer);
     }
 
-    public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined): Promise<void> {
+    public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined): Promise<string> {
         let command: string = '"' + this.fullPath + '" ' + args.join(' ');
         this._logManager.debug("Executing '" + command + "' in directory '" + this._targetDir + "'");
         try {
@@ -162,6 +162,7 @@ export class Resource {
             if (output.length > 0) {
                 this._logManager.logMessage('Done executing "' + command + '" with output:\n' + output, 'DEBUG');
             }
+            return output;
         } catch (error) {
             throw new Error('Failed to execute "' + command + '" err: ' + error);
         }

--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -154,7 +154,12 @@ export class Resource {
         return ScanUtils.Hash('SHA256', fileBuffer);
     }
 
-    public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined, errIfStderrNotEmpty: boolean = true): Promise<string> {
+    public async run(
+        args: string[],
+        checkCancel: () => void,
+        env?: NodeJS.ProcessEnv | undefined,
+        errIfStderrNotEmpty: boolean = true
+    ): Promise<string> {
         let command: string = '"' + this.fullPath + '" ' + args.join(' ');
         this._logManager.debug("Executing '" + command + "' in directory '" + this._targetDir + "'");
         try {

--- a/src/main/utils/resource.ts
+++ b/src/main/utils/resource.ts
@@ -154,11 +154,11 @@ export class Resource {
         return ScanUtils.Hash('SHA256', fileBuffer);
     }
 
-    public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined): Promise<string> {
+    public async run(args: string[], checkCancel: () => void, env?: NodeJS.ProcessEnv | undefined, errIfStderrNotEmpty: boolean = true): Promise<string> {
         let command: string = '"' + this.fullPath + '" ' + args.join(' ');
         this._logManager.debug("Executing '" + command + "' in directory '" + this._targetDir + "'");
         try {
-            const output: string = await ScanUtils.executeCmdAsync(command, checkCancel, this._targetDir, env);
+            const output: string = await ScanUtils.executeCmdAsync(command, checkCancel, this._targetDir, env, errIfStderrNotEmpty);
             if (output.length > 0) {
                 this._logManager.logMessage('Done executing "' + command + '" with output:\n' + output, 'DEBUG');
             }

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -179,7 +179,6 @@ export class ScanUtils {
                 const childProcess: exec.ChildProcess = exec.exec(
                     command,
                     { cwd: cwd, maxBuffer: ScanUtils.SPAWN_PROCESS_BUFFER_SIZE, env: env } as exec.ExecOptions,
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     (error: exec.ExecException | null, stdout: string, stderr: string) => {
                         clearInterval(checkCancellationInterval);
                         if (error) {
@@ -193,7 +192,7 @@ export class ScanUtils {
                         }
                     }
                 );
-                const checkCancellationInterval: NodeJS.Timer = setInterval(() => {
+                const checkCancellationInterval: string | number | NodeJS.Timeout | undefined = setInterval(() => {
                     ScanUtils.cancelIfRequested(childProcess, checkCancel, reject);
                 }, ScanUtils.CANCELLATION_CHECK_INTERVAL_MS);
             } catch (error) {

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -186,6 +186,8 @@ export class ScanUtils {
                             reject(error);
                         } else if (errIfStderrNotEmpty) {
                             stderr.trim() ? reject(new Error(stderr.trim())) : resolve(stdout.trim());
+                        } else {
+                            stderr.trim() ? resolve(stderr.trim()) : resolve(stdout.trim());
                         }
                     }
                 );

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -184,10 +184,12 @@ export class ScanUtils {
                         clearInterval(checkCancellationInterval);
                         if (error) {
                             reject(error);
-                        } else if (errIfStderrNotEmpty) {
-                            stderr.trim() ? reject(new Error(stderr.trim())) : resolve(stdout.trim());
                         } else {
-                            stderr.trim() ? resolve(stderr.trim()) : resolve(stdout.trim());
+                            stderr.trim()
+                                ? errIfStderrNotEmpty
+                                    ? reject(new Error(stderr.trim()))
+                                    : resolve(stderr.trim())
+                                : resolve(stdout.trim());
                         }
                     }
                 );

--- a/src/main/utils/usageUtils.ts
+++ b/src/main/utils/usageUtils.ts
@@ -2,6 +2,7 @@ import { IUsageFeature } from 'jfrog-client-js';
 import * as vscode from 'vscode';
 import { ConnectionManager } from '../connect/connectionManager';
 import { PackageType } from '../types/projectType';
+import { Configuration } from './configuration';
 
 export class UsageUtils {
     private static translateToUsageFeature(usageFeatureDetails: Set<UsageJasScanType>): IUsageFeature[] {
@@ -32,6 +33,9 @@ export class UsageUtils {
         projectDescriptors: Map<PackageType, vscode.Uri[]>,
         connectionManager: ConnectionManager
     ) {
+        if (!Configuration.getReportAnalytics()) {
+            return;
+        }
         const features: IUsageFeature[] = [];
         features.push(...UsageUtils.translateToUsageFeature(usageFeatureDetails), ...this.getUsageFeaturesByExistTech(projectDescriptors, 'deps'));
         if (features.length === 0) {

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -161,17 +161,31 @@ export class Utils {
         }
     }
 
-    public static getArchitecture(): string {
+    public static getPlatform(): string {
         if (Utils.isWindows()) {
-            return 'windows-amd64';
+            return 'windows';
         }
         if (os.platform().includes('darwin')) {
-            return os.arch() === 'arm64' ? 'mac-arm64' : 'mac-amd64';
+            return 'mac';
+        }
+        return 'linux';
+    }
+
+    public static getPlatformAndArch(): string {
+        return Utils.getPlatform() + '-' + Utils.getArchitecture();
+    }
+
+    public static getArchitecture(): string {
+        if (Utils.isWindows()) {
+            return 'amd64';
+        }
+        if (os.platform().includes('darwin')) {
+            return os.arch() === 'arm64' ? 'arm64' : 'amd64';
         }
         if (os.arch().includes('arm')) {
-            return os.arch().includes('64') ? 'linux-arm64' : 'linux-arm';
+            return os.arch().includes('64') ? 'arm64' : 'arm';
         }
-        return os.arch().includes('64') ? 'linux-amd64' : 'linux-386';
+        return os.arch().includes('64') ? 'amd64' : '386';
     }
 
     public static isWindows(): boolean {

--- a/src/test/tests/integration/externalResourcesRepository.test.ts
+++ b/src/test/tests/integration/externalResourcesRepository.test.ts
@@ -30,13 +30,13 @@ describe('External Resources Repository Integration Tests', async () => {
         const expectedContent: any = JSON.parse(fs.readFileSync(dataPath, 'utf8').toString());
         assert.isDefined(expectedContent, 'Failed to read expected SecretsScanResponse content from ' + dataPath);
 
-        // Run
-        const response: SecretsScanResponse = await runner
-            .executeRequest(() => undefined, { roots: [testDataRoot] } as AnalyzeScanRequest)
-            .then(runResult => runner.convertResponse(runResult));
-
-        // Assert
-        assert.isUndefined(response.filesWithIssues);
+        // Run and Assert
+        try {
+            await runner.executeRequest(() => undefined, { roots: [testDataRoot] } as AnalyzeScanRequest)
+            assert.fail('Should throw error when executing runner and analyzer manager not downloaded');
+        } catch (error) {
+            assert.isDefined(error);
+        }
     });
 
     it('Should download the analyzer  manager from releases-proxy instead of direct releases.jfrog.io', async () => {

--- a/src/test/tests/integration/externalResourcesRepository.test.ts
+++ b/src/test/tests/integration/externalResourcesRepository.test.ts
@@ -32,9 +32,10 @@ describe('External Resources Repository Integration Tests', async () => {
 
         // Run and Assert
         try {
-            await runner.executeRequest(() => undefined, { roots: [testDataRoot] } as AnalyzeScanRequest)
+            await runner.executeRequest(() => undefined, { roots: [testDataRoot] } as AnalyzeScanRequest);
             assert.fail('Should throw error when executing runner and analyzer manager not downloaded');
         } catch (error) {
+            assert.instanceOf(error, Error);
             assert.isDefined(error);
         }
     });

--- a/src/test/tests/integration/iac.test.ts
+++ b/src/test/tests/integration/iac.test.ts
@@ -36,7 +36,6 @@ describe('Iac Integration Tests', async () => {
         expectedContent = JSON.parse(fs.readFileSync(dataPath, 'utf8').toString());
         assert.isDefined(expectedContent, 'Failed to read expected IacScanResponse content from ' + dataPath);
         // Run scan
-        // Try/Catch (with skip) should be removed after Iac is released
         response = await runner
             .executeRequest(() => undefined, { roots: [testDataRoot] } as AnalyzeScanRequest)
             .then(runResult => runner.generateScanResponse(runResult));

--- a/src/test/tests/integration/xsc.test.ts
+++ b/src/test/tests/integration/xsc.test.ts
@@ -1,0 +1,49 @@
+import { assert } from 'chai';
+import { LogManager } from '../../../main/log/logManager';
+import { ScanManager } from '../../../main/scanLogic/scanManager';
+import { SupportedScans } from '../../../main/scanLogic/sourceCodeScan/supportedScans';
+import { IssuesRootTreeNode } from '../../../main/treeDataProviders/issuesTree/issuesRootTreeNode';
+import { ScanResults } from '../../../main/types/workspaceIssuesDetails';
+import { WorkspaceScanDetails } from '../../../main/types/workspaceScanDetails';
+import { BaseIntegrationEnv } from '../utils/testIntegration.test';
+import { createTestStepProgress } from '../utils/utils.test';
+import { ConnectionUtils } from '../../../main/connect/connectionUtils';
+
+describe.only('XSC Integration Tests', async () => {
+    const integrationManager: BaseIntegrationEnv = new BaseIntegrationEnv();
+    let logManager: LogManager = new LogManager().activate();
+    let scanManager: ScanManager;
+    let supportedScans: SupportedScans;
+
+    before(async function() {
+        // Integration initialization
+        await integrationManager.initialize();
+        if ((await ConnectionUtils.testXscVersion(integrationManager.connectionManager.createJfrogClient())) === '') {
+            this.skip();
+        }
+        scanManager = new ScanManager(integrationManager.connectionManager, logManager);
+        supportedScans = await new SupportedScans(integrationManager.connectionManager, logManager).getSupportedScans();
+    });
+
+    it('Test send analytics log event', async () => {
+        await integrationManager.connectionManager.logWithAnalytics('VSCode XSC integration test', 'DEBUG');
+    });
+
+    it('Test send analytics Scan event', async () => {
+        let scanDetails: WorkspaceScanDetails = new WorkspaceScanDetails(
+            scanManager,
+            supportedScans,
+            new ScanResults('some-path'),
+            new IssuesRootTreeNode({ uri: 'some-uri' } as any),
+            createTestStepProgress()
+        );
+
+        assert.isUndefined(scanDetails.multiScanId);
+
+        await scanDetails.startScan();
+
+        assert.isDefined(scanDetails.multiScanId);
+
+        await scanDetails.endScan();
+    });
+});

--- a/src/test/tests/integration/xsc.test.ts
+++ b/src/test/tests/integration/xsc.test.ts
@@ -9,7 +9,7 @@ import { BaseIntegrationEnv } from '../utils/testIntegration.test';
 import { createTestStepProgress } from '../utils/utils.test';
 import { ConnectionUtils } from '../../../main/connect/connectionUtils';
 
-describe.only('XSC Integration Tests', async () => {
+describe('XSC Integration Tests', async () => {
     const integrationManager: BaseIntegrationEnv = new BaseIntegrationEnv();
     let logManager: LogManager = new LogManager().activate();
     let scanManager: ScanManager;

--- a/src/test/tests/integration/xsc.test.ts
+++ b/src/test/tests/integration/xsc.test.ts
@@ -18,7 +18,10 @@ describe('XSC Integration Tests', async () => {
     before(async function() {
         // Integration initialization
         await integrationManager.initialize();
-        if ((await ConnectionUtils.testXscVersion(integrationManager.connectionManager.createJfrogClient())) === '') {
+        try {
+            (await ConnectionUtils.testXscVersion(integrationManager.connectionManager.createJfrogClient())) !== '';
+        } catch (error) {
+            // Skip test if XSC is not supported
             this.skip();
         }
         scanManager = new ScanManager(integrationManager.connectionManager, logManager);

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -23,10 +23,10 @@ describe('Pnpm Utils Tests', async () => {
     let projectDirs: string[] = ['project-1', 'project-2'];
     let packageDescriptors: Map<PackageType, vscode.Uri[]> = new Map<PackageType, vscode.Uri[]>();
 
-    before(async () => {
+    before(async function() {
         // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
         if (parseInt(process.versions.node.slice(1).split('.')[0]) <= 14) {
-            test.skip('Skip pnpm tests for Node.js v14 or less');
+            this.skip();
         }
         // Copy test projects to temp folder
         fs.copySync(testProjectsDir, testFolder.fsPath);

--- a/src/test/tests/pnpmUtils.test.ts
+++ b/src/test/tests/pnpmUtils.test.ts
@@ -15,7 +15,6 @@ import { GeneralInfo } from '../../main/types/generalInfo';
  * Test functionality of @class PnpmUtils.
  */
 describe('Pnpm Utils Tests', async () => {
-    checkNodeVersionSupported();
     let logManager: LogManager = new LogManager().activate();
     let workspaceFolders: vscode.WorkspaceFolder[];
 
@@ -25,6 +24,10 @@ describe('Pnpm Utils Tests', async () => {
     let packageDescriptors: Map<PackageType, vscode.Uri[]> = new Map<PackageType, vscode.Uri[]>();
 
     before(async () => {
+        // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
+        if (parseInt(process.versions.node.slice(1).split('.')[0]) <= 14) {
+            test.skip('Skip pnpm tests for Node.js v14 or less');
+        }
         // Copy test projects to temp folder
         fs.copySync(testProjectsDir, testFolder.fsPath);
         workspaceFolders = [{ uri: testFolder, name: '', index: 0 } as vscode.WorkspaceFolder];
@@ -141,11 +144,4 @@ describe('Pnpm Utils Tests', async () => {
             assert.deepEqual(child?.parent, parent);
         }
     });
-
-    function checkNodeVersionSupported(): void {
-        // pnpm v8 has dropped Node.js 14 support. Skip test if Node.js version is 14 or less.
-        if (parseInt(process.versions.node.slice(1).split('.')[0]) <= 14) {
-            test.skip('Skip pnpm tests for Node.js v14 or less');
-        }
-    }
 });

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -6,7 +6,7 @@ import { ConnectionManager } from '../../main/connect/connectionManager';
 import { LogManager } from '../../main/log/logManager';
 
 import { AnalyzeScanRequest, AnalyzerScanRun, ScanType } from '../../main/scanLogic/scanRunners/analyzerModels';
-import { JasRunner } from '../../main/scanLogic/scanRunners/jasRunner';
+import { BinaryEnvParams, JasRunner, RunArgs } from '../../main/scanLogic/scanRunners/jasRunner';
 import { AppsConfigModule } from '../../main/utils/jfrogAppsConfig/jfrogAppsConfig';
 import { NotEntitledError, ScanCancellationError, ScanUtils } from '../../main/utils/scanUtils';
 import { Translators } from '../../main/utils/translators';
@@ -49,11 +49,11 @@ describe('Analyzer BinaryRunner tests', async () => {
 
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             async runBinary(
+                checkCancel: () => void,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                _yamlConfigPath: string,
+                args: RunArgs, 
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                _executionLogDirectory: string | undefined,
-                checkCancel: () => void
+                params?: BinaryEnvParams
             ): Promise<void> {
                 checkCancel();
                 await dummyAction();
@@ -72,11 +72,11 @@ describe('Analyzer BinaryRunner tests', async () => {
 
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             async runBinary(
+                checkCancel: () => void,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                _yamlConfigPath: string,
+                args: RunArgs, 
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                _executionLogDirectory: string | undefined,
-                checkCancel: () => void
+                params?: BinaryEnvParams
             ): Promise<void> {
                 checkCancel();
                 await dummyAction();
@@ -141,7 +141,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             process.env['HTTP_PROXY'] = test.proxy;
             process.env['HTTPS_PROXY'] = test.proxy;
 
-            let envVars: NodeJS.ProcessEnv | undefined = runner.createEnvForRun(test.logPath);
+            let envVars: NodeJS.ProcessEnv | undefined = runner.createEnvForRun({executionLogDirectory: test.logPath});
             if (test.shouldFail) {
                 assert.isUndefined(envVars);
             } else {
@@ -223,8 +223,10 @@ describe('Analyzer BinaryRunner tests', async () => {
     ].forEach(async test => {
         it('Run request - ' + test.name, async () => {
             let tempFolder: string = ScanUtils.createTmpDir();
-            let requestPath: string = path.join(tempFolder, 'request');
-            let responsePath: string = path.join(tempFolder, 'response');
+            let args: RunArgs = new RunArgs(tempFolder)
+            args.request.requestPath = path.join(tempFolder, 'request');
+            args.request.requestContent = 'request data'
+            args.request.responsePath = path.join(tempFolder, 'response');
 
             let runner: JasRunner = createDummyBinaryRunner(connectionManager, async () => {
                 if (test.shouldAbort) {
@@ -233,13 +235,13 @@ describe('Analyzer BinaryRunner tests', async () => {
                     throw new DummyRunnerError();
                 }
                 if (test.createDummyResponse) {
-                    fs.writeFileSync(responsePath, JSON.stringify({} as AnalyzerScanRun));
+                    fs.writeFileSync(args.request.responsePath, JSON.stringify({} as AnalyzerScanRun));
                 }
             });
 
             if (test.expectedErr) {
                 try {
-                    await runner.runRequest(() => undefined, 'request data', requestPath, responsePath);
+                    await runner.runRequest(() => undefined, args);
                     assert.fail('Expected run to throw error');
                 } catch (err) {
                     if (err instanceof Error) {
@@ -249,7 +251,7 @@ describe('Analyzer BinaryRunner tests', async () => {
                     }
                 }
             } else {
-                assert.doesNotThrow(async () => await runner.runRequest(() => undefined, 'request data', requestPath, responsePath));
+                assert.doesNotThrow(async () => await runner.runRequest(() => undefined, args));
             }
         });
     });

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -51,7 +51,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             async runBinary(
                 checkCancel: () => void,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                args: RunArgs, 
+                args: RunArgs,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 params?: BinaryEnvParams
             ): Promise<void> {
@@ -74,7 +74,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             async runBinary(
                 checkCancel: () => void,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                args: RunArgs, 
+                args: RunArgs,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 params?: BinaryEnvParams
             ): Promise<void> {
@@ -141,7 +141,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             process.env['HTTP_PROXY'] = test.proxy;
             process.env['HTTPS_PROXY'] = test.proxy;
 
-            let envVars: NodeJS.ProcessEnv | undefined = runner.createEnvForRun({executionLogDirectory: test.logPath});
+            let envVars: NodeJS.ProcessEnv | undefined = runner.createEnvForRun({ executionLogDirectory: test.logPath });
             if (test.shouldFail) {
                 assert.isUndefined(envVars);
             } else {
@@ -223,9 +223,9 @@ describe('Analyzer BinaryRunner tests', async () => {
     ].forEach(async test => {
         it('Run request - ' + test.name, async () => {
             let tempFolder: string = ScanUtils.createTmpDir();
-            let args: RunArgs = new RunArgs(tempFolder)
+            let args: RunArgs = new RunArgs(tempFolder);
             args.request.requestPath = path.join(tempFolder, 'request');
-            args.request.requestContent = 'request data'
+            args.request.requestContent = 'request data';
             args.request.responsePath = path.join(tempFolder, 'response');
 
             let runner: JasRunner = createDummyBinaryRunner(connectionManager, async () => {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

## Xray Source Control Integration

* Report scan analytics and summary information to the Xray Source Control service.
* Report errors to the XSC event service to notify about errors automatically to improve performance.

### New Configuration options:

* Don't report analytics and errors to XSC
* Show advance scan logs directly at the output channel, at debug level.

---

* Improvements to the Jas binary running, output handling and error management.

depends on: https://github.com/jfrog/jfrog-client-js/pull/95
