### PR TITLE
Fix - character must be non-negative in JAS issues with a location value of 0

### DIFF
--- a/src/main/scanLogic/scanManager.ts
+++ b/src/main/scanLogic/scanManager.ts
@@ -15,7 +15,7 @@ import { ScanResults } from '../types/workspaceIssuesDetails';
 import { DependencyUtils } from '../treeDataProviders/utils/dependencyUtils';
 import { PackageType } from '../types/projectType';
 import { UsageUtils } from '../utils/usageUtils';
-import { JasRunner } from './scanRunners/jasRunner';
+import { BinaryEnvParams, JasRunner } from './scanRunners/jasRunner';
 import { SupportedScans } from './sourceCodeScan/supportedScans';
 import { WorkspaceScanDetails } from '../types/workspaceScanDetails';
 import { Configuration } from '../utils/configuration';
@@ -105,10 +105,14 @@ export class ScanManager implements ExtensionComponent {
 
     private runSourceCodeScans(scanDetails: WorkspaceScanDetails, jasRunners: JasRunner[]): Promise<void>[] {
         const scansPromises: Promise<void>[] = [];
+        let params: BinaryEnvParams | undefined;
+        if (scanDetails.multiScanId) {
+            params = { msi: scanDetails.multiScanId };
+        }
         for (const runner of jasRunners) {
             if (runner.shouldRun()) {
                 scansPromises.push(
-                    runner.scan({ msi: scanDetails.multiScanId }).catch(error => {
+                    runner.scan(params).catch(error => {
                         LogUtils.logErrorWithAnalytics(error, this._connectionManager);
                         scanDetails.status = ScanEventStatus.Failed;
                     })

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -153,7 +153,7 @@ export class AnalyzerManager {
             binaryVars.AM_LOG_DIRECTORY = params.executionLogDirectory;
         }
         // Optional Multi scan id
-        if (params?.msi) {
+        if (params?.msi && params.msi !== '') {
             binaryVars[AnalyzerManager.ENV_MSI] = params.msi;
         }
     }

--- a/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
@@ -21,7 +21,8 @@ export abstract class CodeIssueTreeNode extends IssueTreeNode {
         return this._regionWithIssue;
     }
 
-    // Analyzer locations minimum is 1, vscode positions starts at 0
+    // For vscode the minimum value (i.e first row/col) is 0. 
+    // For analyzers, the minimum value is 1. (some uses 0 as well)
     private toVscodePosition(position: vscode.Position): vscode.Position {
         let line: number = position.line > 0 ? position.line - 1 : 0;
         let col: number = position.character > 0 ? position.character - 1 : 0;

--- a/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
@@ -9,11 +9,7 @@ export abstract class CodeIssueTreeNode extends IssueTreeNode {
 
     constructor(issueId: string, private _parent: CodeFileTreeNode, region: vscode.Range, severity?: Severity, label?: string) {
         super(issueId, severity ?? Severity.Unknown, label ?? issueId, vscode.TreeItemCollapsibleState.None);
-        this._regionWithIssue = new vscode.Range(
-            // Analyzer locations minimum is 1, vscode positions starts at 0
-            new vscode.Position(region.start.line - 1, region.start.character - 1),
-            new vscode.Position(region.end.line - 1, region.end.character - 1)
-        );
+        this._regionWithIssue = new vscode.Range(this.toVscodePosition(region.start), this.toVscodePosition(region.end));
         this.description = 'line = ' + region.start.line + ', column = ' + region.start.character;
     }
 
@@ -23,5 +19,12 @@ export abstract class CodeIssueTreeNode extends IssueTreeNode {
 
     public get regionWithIssue(): vscode.Range {
         return this._regionWithIssue;
+    }
+
+    // Analyzer locations minimum is 1, vscode positions starts at 0
+    private toVscodePosition(position: vscode.Position): vscode.Position {
+        let line: number = position.line > 0 ? position.line - 1 : 0;
+        let col: number = position.character > 0 ? position.character - 1 : 0;
+        return new vscode.Position(line, col);
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

```
[ERR - 18:12:36] Error: Illegal argument: character must be non-negative
```

There is a different mapping that vscode expects as positions at file. 
For vscode the minimum value (i.e first row/col) is 0 while the results mapped to it is 1 from the scanners.

Fixing a bug that occurs when issues discovered at JAS scans (CA and secrets) have a location with row/col 0:
```
"region": {
      "snippet": {
             "text": "*******"
      },
      "endColumn": 0,
      "endLine": 3,
      "startColumn": 0,
      "startLine": 3
},
```