### PR TITLE
Config AnalyzerManager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,12 +79,11 @@
         "configuration": {
             "title": "JFrog",
             "properties": {
-                "jfrog.analyzerManagerVersion": {
+                "jfrog.useSpecificScannersVersion": {
                     "type": "string",
-                    "default": "[RELEASE]",
                     "scope": "application",
-                    "pattern": "^\\[RELEASE\\]$|^\\d+\\.\\d+\\.\\d+$",
-                    "markdownDescription": "The version of the JFrog JAS scanners used to scan your project. The default value is [RELEASE], which means the latest version will be used. You can also specify a specific version number. (format X.X.X)."
+                    "pattern": "^$|^\\d+\\.\\d+\\.\\d+$",
+                    "markdownDescription": "Specifies the JFrog Scanners version to use. (format X.X.X). By default the latest scanners version is used."
                 },
                 "jfrog.xray.exclusions": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,13 @@
         "configuration": {
             "title": "JFrog",
             "properties": {
+                "jfrog.analyzerManagerVersion": {
+                    "type": "string",
+                    "default": "[RELEASE]",
+                    "scope": "application",
+                    "pattern": "^\\[RELEASE\\]$|^\\d+\\.\\d+\\.\\d+$",
+                    "markdownDescription": "The version of the JFrog JAS scanners used to scan your project. The default value is [RELEASE], which means the latest version will be used. You can also specify a specific version number. (format X.X.X)."
+                },
                 "jfrog.xray.exclusions": {
                     "type": "string",
                     "default": "**/*{.git,test,venv,node_modules,target}*",

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -15,13 +15,10 @@ import { LogUtils } from '../../log/logUtils';
  * Analyzer manager is responsible for running the analyzer on the workspace.
  */
 export class AnalyzerManager {
-    private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1/[RELEASE]';
+    private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1';
     private static readonly BINARY_NAME: string = 'analyzerManager';
     public static readonly ANALYZER_MANAGER_PATH: string = Utils.addWinSuffixIfNeeded(
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
-    );
-    private static readonly DOWNLOAD_URL: string = Utils.addZipSuffix(
-        AnalyzerManager.RELATIVE_DOWNLOAD_URL + '/' + Utils.getPlatformAndArch() + '/' + AnalyzerManager.BINARY_NAME
     );
 
     private static readonly JFROG_RELEASES_URL: string = 'https://releases.jfrog.io';
@@ -41,8 +38,20 @@ export class AnalyzerManager {
     private static FINISH_UPDATE_PROMISE: Promise<boolean>;
 
     constructor(private _connectionManager: ConnectionManager, protected _logManager: LogManager) {
-        this._binary = new Resource(AnalyzerManager.DOWNLOAD_URL, AnalyzerManager.ANALYZER_MANAGER_PATH, _logManager, this.createJFrogCLient());
+        this._binary = new Resource(AnalyzerManager.getDownloadUrl(), AnalyzerManager.ANALYZER_MANAGER_PATH, _logManager, this.createJFrogCLient());
         AnalyzerManager.FINISH_UPDATE_PROMISE = this.checkForUpdates();
+    }
+
+    private static getDownloadUrl(): string {
+        return Utils.addZipSuffix(
+            AnalyzerManager.RELATIVE_DOWNLOAD_URL +
+                '/' +
+                Configuration.getAnalyzerManagerVersion() +
+                '/' +
+                Utils.getPlatformAndArch() +
+                '/' +
+                AnalyzerManager.BINARY_NAME
+        );
     }
 
     private createJFrogCLient(): JfrogClient {

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -66,7 +66,11 @@ export class Configuration {
     }
 
     public static getAnalyzerManagerVersion(): string {
-        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('analyzerManagerVersion', '[RELEASE]');
+        let version: string = vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('useSpecificScannersVersion', '');
+        if (version === '') {
+            version = '[RELEASE]';
+        }
+        return version;
     }
 
     /**

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -65,6 +65,10 @@ export class Configuration {
         return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('showAdvanceScanLog', false);
     }
 
+    public static getAnalyzerManagerVersion(): string {
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('analyzerManagerVersion', '[RELEASE]');
+    }
+
     /**
      * @returns the log level
      */


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Add option to control the Analyzer Manager version used for scanning
![image](https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/deedba1c-2f5b-4477-9438-51d65f3845e9)
