### PR TITLE
Add Custom rules to SAST scan

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Install prerequisites
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16.x"
 

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install prerequisites
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             git config --global user.name "jfrog-ecosystem"
             git config --global user.email "eco-system@jfrog.com"
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
           check-latest: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
           check-latest: true
@@ -58,7 +58,7 @@ jobs:
         run: curl -fL https://install-cli.jfrog.io | sh && jf -v
 
       - name: Setup NodeJS for tests
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           check-latest: true

--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
                     "pattern": "^$|^\\d+\\.\\d+\\.\\d+$",
                     "markdownDescription": "Specifies the JFrog Scanners version to use. (format X.X.X). By default the latest scanners version is used."
                 },
+                "jfrog.customRulesPath": {
+                    "type": "string",
+                    "scope": "resource",
+                    "markdownDescription": "Absolute Path to a local custom rules file. The file should be in JSON format and contain the additional custom rules to be applied during the scan."
+                },
                 "jfrog.xray.exclusions": {
                     "type": "string",
                     "default": "**/*{.git,test,venv,node_modules,target}*",

--- a/src/main/scanLogic/scanRunners/sastScan.ts
+++ b/src/main/scanLogic/scanRunners/sastScan.ts
@@ -5,6 +5,7 @@ import { AnalyzerUtils } from '../../treeDataProviders/utils/analyzerUtils';
 import { StepProgress } from '../../treeDataProviders/utils/stepProgress';
 import { Severity } from '../../types/severity';
 import { ScanResults } from '../../types/workspaceIssuesDetails';
+import { Configuration } from '../../utils/configuration';
 import { AppsConfigModule } from '../../utils/jfrogAppsConfig/jfrogAppsConfig';
 import { Translators } from '../../utils/translators';
 import { AnalyzerManager } from './analyzerManager';
@@ -26,6 +27,7 @@ import { BinaryEnvParams, JasRunner, RunArgs } from './jasRunner';
  */
 export interface SastScanRequest extends AnalyzeScanRequest {
     language: LanguageType;
+    user_rules: string;
     exclude_patterns: string[];
     excluded_rules: string[];
 }
@@ -92,6 +94,7 @@ export class SastRunner extends JasRunner {
             type: this._scanType,
             roots: this._config.GetSourceRoots(this._scanType),
             language: this._config.GetScanLanguage(),
+            user_rules: Configuration.getSastCustomRulesPath(this._logManager),
             excluded_rules: this._config.getExcludeRules(),
             exclude_patterns: this._config.GetExcludePatterns(this._scanType)
         } as SastScanRequest;

--- a/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
@@ -21,7 +21,7 @@ export abstract class CodeIssueTreeNode extends IssueTreeNode {
         return this._regionWithIssue;
     }
 
-    // For vscode the minimum value (i.e first row/col) is 0. 
+    // For vscode the minimum value (i.e first row/col) is 0.
     // For analyzers, the minimum value is 1. (some uses 0 as well)
     private toVscodePosition(position: vscode.Position): vscode.Position {
         let line: number = position.line > 0 ? position.line - 1 : 0;

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import { LogLevel } from '../log/logManager';
+import * as fs from 'fs';
+import { LogLevel, LogManager } from '../log/logManager';
 export class Configuration {
     public static jfrogSectionConfigurationKey: string = 'jfrog';
     public static readonly JFROG_IDE_RELEASES_REPO_ENV: string = 'JFROG_IDE_RELEASES_REPO';
@@ -71,6 +72,24 @@ export class Configuration {
             version = '[RELEASE]';
         }
         return version;
+    }
+
+    public static getSastCustomRulesPath(logManager?: LogManager): string {
+        let customRulesPath: string = vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('customRulesPath', '');
+        if (customRulesPath === '') {
+            return '';
+        }
+        let fileExists: boolean = fs.existsSync(customRulesPath);
+        if (!fileExists) {
+            if (logManager) {
+                logManager.logMessage('Custom rules file not found: ' + customRulesPath, 'WARN');
+            }
+            return '';
+        }
+        if (logManager) {
+            logManager.logMessage('Using custom rules from: ' + customRulesPath, 'DEBUG');
+        }
+        return customRulesPath;
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

## Add Custom rules to the SAST scan in your workspace

<img width="557" alt="image" src="https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/e00a4b2d-f37f-465b-81fd-cef41404330f">


1. Prepare a custom json rules file with your rules:
```json
[
  {
    "name": "custom-rule",
    "message": "User-controlled data used as argument to math.sqrt",
    "finder": {
      "type": "FlowFinder",
      "sources": {
        "type": "calls",
        "names": [
          "input"
        ]
      },
      "sinks": {
        "type": "calls",
        "names": [
          "math.sqrt"
        ]
      }
    },
    "cwe": null,
    "description": "User-controlled square root",
    "severity": "high",
    "tags": []
  }
]
```

2. Provide the **Absolute** path to the user custom rule file at the extension's new configuration.
<img width="722" alt="image" src="https://github.com/jfrog/jfrog-vscode-extension/assets/49212512/8d20e42d-244e-4f81-a34a-6936366a2c9f">

3. Rescan your workspace.
