### PR TITLE
Fix build pattern configuration id

### DIFF
--- a/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
+++ b/src/main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode.ts
@@ -21,7 +21,7 @@ export abstract class CodeIssueTreeNode extends IssueTreeNode {
         return this._regionWithIssue;
     }
 
-    // For vscode the minimum value (i.e first row/col) is 0. 
+    // For vscode the minimum value (i.e first row/col) is 0.
     // For analyzers, the minimum value is 1. (some uses 0 as well)
     private toVscodePosition(position: vscode.Position): vscode.Position {
         let line: number = position.line > 0 ? position.line - 1 : 0;

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -29,7 +29,7 @@ export class Configuration {
     }
 
     public static getBuildsPattern(): string {
-        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('xray.ciIntegration.buildNamePattern') || '';
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('view.ciIntegration.buildNamePattern') || '';
     }
 
     public static getExternalResourcesRepository(): string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

There is a bug in the CI mode configurations. It did not took the actual configurations since there was a bug in the id of the configuration we used.
Expected:
```
view.ciIntegration.buildNamePattern
```
Found:
```
xray.ciIntegration.buildNamePattern
```