### PR TITLE
Use const AnalyzerManager version 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
                     "type": "string",
                     "scope": "application",
                     "pattern": "^$|^\\d+\\.\\d+\\.\\d+$",
-                    "markdownDescription": "Specifies the JFrog Scanners version to use. (format X.X.X). By default the latest scanners version is used."
+                    "markdownDescription": "Specifies the JFrog Scanners version to use. (format X.X.X). By default the latest stable scanners version is used."
                 },
                 "jfrog.customRulesPath": {
                     "type": "string",

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -17,6 +17,7 @@ import { LogUtils } from '../../log/logUtils';
 export class AnalyzerManager {
     private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1';
     private static readonly BINARY_NAME: string = 'analyzerManager';
+    public static readonly ANALYZER_MANAGER_VERSION: string = '1.8.3';
     public static readonly ANALYZER_MANAGER_PATH: string = Utils.addWinSuffixIfNeeded(
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
     );
@@ -46,12 +47,20 @@ export class AnalyzerManager {
         return Utils.addZipSuffix(
             AnalyzerManager.RELATIVE_DOWNLOAD_URL +
                 '/' +
-                Configuration.getAnalyzerManagerVersion() +
+                AnalyzerManager.getAnalyzerManagerVersion() +
                 '/' +
                 Utils.getPlatformAndArch() +
                 '/' +
                 AnalyzerManager.BINARY_NAME
         );
+    }
+
+    private static getAnalyzerManagerVersion(): string {
+        let version: string = AnalyzerManager.getAnalyzerManagerVersion();
+        if (version !== '') {
+            return version;
+        }
+        return AnalyzerManager.ANALYZER_MANAGER_VERSION;
     }
 
     private createJFrogCLient(): JfrogClient {

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -56,7 +56,7 @@ export class AnalyzerManager {
     }
 
     private static getAnalyzerManagerVersion(): string {
-        let version: string = AnalyzerManager.getAnalyzerManagerVersion();
+        let version: string = Configuration.getAnalyzerManagerVersion();
         if (version !== '') {
             return version;
         }

--- a/src/main/utils/configuration.ts
+++ b/src/main/utils/configuration.ts
@@ -67,11 +67,7 @@ export class Configuration {
     }
 
     public static getAnalyzerManagerVersion(): string {
-        let version: string = vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('useSpecificScannersVersion', '');
-        if (version === '') {
-            version = '[RELEASE]';
-        }
-        return version;
+        return vscode.workspace.getConfiguration(this.jfrogSectionConfigurationKey).get('useSpecificScannersVersion', '');
     }
 
     public static getSastCustomRulesPath(logManager?: LogManager): string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Use AnalyzerManager v1.8.3 (const version per vscode extension version).
You can still specified a specific version in the config