### PR TITLE
Fix - Analyzer manager extraction for Windows

### DIFF
--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import AdmZip, { IZipEntry } from 'adm-zip';
 
 export class Utils {
-    private static readonly MAX_FILES_EXTRACTED_ZIP: number = 4000;
+    private static readonly MAX_FILES_EXTRACTED_ZIP: number = 5000;
     // 1 GB
     private static readonly MAX_SIZE_EXTRACTED_ZIP_BYTES: number = 1000000000;
     private static readonly COMPRESSION_THRESHOLD_RATIO: number = 100;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

For windows user, when trying to extract the AM v1.8.9+ extraction resulted in max files reached.
![image](https://github.com/user-attachments/assets/27f81892-9b84-4edc-b270-1876c7c4813a)
