### PR TITLE
Update am 1.11.8

### DIFF
--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -17,7 +17,7 @@ import { LogUtils } from '../../log/logUtils';
 export class AnalyzerManager {
     private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1';
     private static readonly BINARY_NAME: string = 'analyzerManager';
-    public static readonly ANALYZER_MANAGER_VERSION: string = '1.11.7';
+    public static readonly ANALYZER_MANAGER_VERSION: string = '1.11.8';
     public static readonly ANALYZER_MANAGER_PATH: string = Utils.addWinSuffixIfNeeded(
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
     );

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -17,7 +17,7 @@ import { LogUtils } from '../../log/logUtils';
 export class AnalyzerManager {
     private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1';
     private static readonly BINARY_NAME: string = 'analyzerManager';
-    public static readonly ANALYZER_MANAGER_VERSION: string = '1.9.11';
+    public static readonly ANALYZER_MANAGER_VERSION: string = '1.11.7';
     public static readonly ANALYZER_MANAGER_PATH: string = Utils.addWinSuffixIfNeeded(
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
     );


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fix AM 1.11.8 - Fix SAST Scanner for old OS support