### PR TITLE
Fixed proxy configuration to retrieve the correct proxy details

### DIFF
--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -427,7 +427,7 @@ export class ConnectionUtils {
         let proxyConfig: IProxyConfig = {} as IProxyConfig;
         let proxyUri: URL = new URL(httpProxy);
         proxyConfig.protocol = proxyUri.protocol;
-        proxyConfig.host = proxyUri.host;
+        proxyConfig.host = proxyUri.hostname;
         if (proxyUri.port) {
             proxyConfig.port = +proxyUri.port;
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

When adding proxy to the vs code settings, the Analyzer Manager is outputting this error log: "proxyconnect tcp: dial tcp: lookup - no such host".
The VS code plugin was creating the proxy URL with the port written twice, for example: 123.11.1.11:8080:8080, instead of 123.11.1.11:8080. Than it was transferring it to the Analyzer Manager in the wrong format.
This PR is fixing the bug and changing the GetProxyConfig() function to parse the proxy URL correctly.
