### PR TITLE
Only pass the configure proxy protocol to AM

### DIFF
--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -151,15 +151,14 @@ export class AnalyzerManager {
 
     private async populateOptionalInformation(binaryVars: NodeJS.ProcessEnv, params?: BinaryEnvParams) {
         // Optional proxy information - environment variable
-        let proxyHttpUrl: string | undefined = process.env['HTTP_PROXY'];
-        let proxyHttpsUrl: string | undefined = process.env['HTTPS_PROXY'];
+        let proxyHttpUrl: string | undefined = process.env[AnalyzerManager.ENV_HTTP_PROXY];
+        let proxyHttpsUrl: string | undefined = process.env[AnalyzerManager.ENV_HTTPS_PROXY];
         // Optional proxy information - vscode configuration override
         let optional: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
         if (optional) {
             let proxyConfig: IProxyConfig = <IProxyConfig>optional;
-            let proxyUrl: string = proxyConfig.host + (proxyConfig.port !== 0 ? ':' + proxyConfig.port : '');
-            proxyHttpUrl = 'http://' + proxyUrl;
-            proxyHttpsUrl = 'https://' + proxyUrl;
+            proxyHttpsUrl = proxyConfig.protocol == 'https:' ? AnalyzerManager.toProxyUrl(proxyConfig) : proxyHttpsUrl;
+            proxyHttpUrl = proxyConfig.protocol == 'http:' ? AnalyzerManager.toProxyUrl(proxyConfig) : proxyHttpUrl;
         }
 
         if (params?.tokenValidation && params.tokenValidation === true) {
@@ -179,6 +178,10 @@ export class AnalyzerManager {
         if (params?.msi && params.msi !== '') {
             binaryVars[AnalyzerManager.ENV_MSI] = params.msi;
         }
+    }
+
+    private static toProxyUrl(proxyConfig: IProxyConfig): string {
+        return proxyConfig.protocol + '//' + proxyConfig.host + (proxyConfig.port ? ':' + proxyConfig.port : '');
     }
 
     /**


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

When passing a protocol to the vscode configuration, we were parsing the value and populating both `HTTP` and `HTTPS` proxy env vars and passing them to the AM. this has caused issue when proxy was `http`.