### PR TITLE
Log unique number of CVE discovered per descriptor

### DIFF
--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -272,7 +272,9 @@ export class DependencyUtils {
         scanManager.logManager.logMessage(
             'Found ' +
                 issuesCount +
-                ' unique CVE issues for descriptor ' +
+                ' unique CVE issues (in ' +
+                projectNode.dependenciesWithIssue.length +
+                ' dependencies) for descriptor ' +
                 dependencyIssues.fullPath +
                 ' (elapsed ' +
                 (dependencyIssues.graphScanTimestamp - startGraphScan) / 1000 +

--- a/src/main/treeDataProviders/utils/dependencyUtils.ts
+++ b/src/main/treeDataProviders/utils/dependencyUtils.ts
@@ -412,7 +412,16 @@ export class DependencyUtils {
                     });
             });
         }
-        return projectNode.dependenciesWithIssue.length;
+        // count unique issues
+        let unique: Set<string> = new Set<string>();
+        projectNode.dependenciesWithIssue.forEach(dependency => {
+            dependency.issues.forEach(issue => {
+                if (issue instanceof CveTreeNode) {
+                    unique.add(issue.issueId);
+                }
+            });
+        });
+        return unique.size;
     }
 
     /**

--- a/src/test/tests/dependencyUtils.test.ts
+++ b/src/test/tests/dependencyUtils.test.ts
@@ -18,7 +18,7 @@ import { DependenciesTreeNode } from '../../main/treeDataProviders/dependenciesT
 import { DependencyIssuesTreeNode } from '../../main/treeDataProviders/issuesTree/descriptorTree/dependencyIssuesTreeNode';
 import { IssueTreeNode } from '../../main/treeDataProviders/issuesTree/issueTreeNode';
 
-describe('Dependency Utils Tests', () => {
+describe.only('Dependency Utils Tests', () => {
     let logManager: LogManager = new LogManager().activate();
 
     const scanResponses: string = path.join(__dirname, '..', 'resources', 'scanResponses');
@@ -31,6 +31,7 @@ describe('Dependency Utils Tests', () => {
             name: 'No issues response',
             response: {} as IGraphResponse,
             expectedTree: {},
+            expectedCveCount: 0,
             expectedComponentsWithIssueCount: 0,
             expectedTotalIssueCount: 0,
             expectedDirect: []
@@ -39,6 +40,7 @@ describe('Dependency Utils Tests', () => {
             name: 'Vulnerabilities response',
             response: getGraphResponse('scanGraphVulnerabilities'),
             expectedTree: Object.fromEntries(expectedImpactedTree.entries()),
+            expectedCveCount: 3,
             expectedComponentsWithIssueCount: 4,
             expectedTotalIssueCount: 5,
             expectedDirect: ['A:1.0.0', 'B:1.0.0', 'C:2.0.0']
@@ -47,6 +49,7 @@ describe('Dependency Utils Tests', () => {
             name: 'Violations response',
             response: getGraphResponse('scanGraphViolations'),
             expectedTree: Object.fromEntries(expectedImpactedTree.entries()),
+            expectedCveCount: 3,
             expectedComponentsWithIssueCount: 4,
             expectedTotalIssueCount: 5,
             expectedDirect: ['A:1.0.0', 'B:1.0.0', 'C:2.0.0']
@@ -155,7 +158,7 @@ describe('Dependency Utils Tests', () => {
             } as DependencyScanResults;
             let node: DescriptorTreeNode = new DescriptorTreeNode('path');
             let issuesFound: number = DependencyUtils.populateDependencyScanResults(node, scanResult);
-            assert.equal(issuesFound, test.expectedComponentsWithIssueCount);
+            assert.equal(issuesFound, test.expectedCveCount);
             assert.lengthOf(node.dependenciesWithIssue, test.expectedComponentsWithIssueCount);
             assert.lengthOf(node.issues, test.expectedTotalIssueCount);
             if (issuesFound > 0) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fixing an issue with the logs,
Instead of outputting the actual unique CVE detected, we output a wrong number (calculating the unique number of dependencies with issue)

This PR fixes this issue and add the actual unique CVE in addition to the number of deps with issues