### PR TITLE
Fixed AM version log error

### DIFF
--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -17,7 +17,7 @@ import { LogUtils } from '../../log/logUtils';
 export class AnalyzerManager {
     private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1';
     private static readonly BINARY_NAME: string = 'analyzerManager';
-    public static readonly ANALYZER_MANAGER_VERSION: string = '1.20.1';
+    public static readonly ANALYZER_MANAGER_VERSION: string = '1.23.0';
     public static readonly ANALYZER_MANAGER_PATH: string = Utils.addWinSuffixIfNeeded(
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
     );
@@ -209,8 +209,9 @@ export class AnalyzerManager {
         }
         await AnalyzerManager.FINISH_UPDATE_PROMISE;
         try {
+            const envVars: NodeJS.ProcessEnv = { [AnalyzerManager.ENV_PLATFORM_URL]: this._connectionManager.url };
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            let versionString: string = await this._binary.run(['version'], () => {});
+            let versionString: string = await this._binary.run(['version'], () => {}, envVars);
             // Extract the version from the output
             const match: RegExpMatchArray | null = versionString.match('analyzer manager version:\\s*(\\S+)');
             if (match && match.length > 1) {


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [X] I used `npm run format` for formatting the code before submitting the pull request.
-----
Added the needed env var for version request to am
plus upgraded AM version where the info logs arent written to the std.err