### PR TITLE
Fix issue where project not detected in Nuget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.4.2.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
-                "nuget-deps-tree": "^0.3.1",
+                "nuget-deps-tree": "^0.4.2",
                 "original-fs": "~1.1.0",
                 "p-queue": "~6.6.2",
                 "retries": "~1.0.0",
@@ -5402,9 +5402,11 @@
             }
         },
         "node_modules/nuget-deps-tree": {
-            "version": "0.3.1",
-            "license": "Apache-2.0",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/nuget-deps-tree/-/nuget-deps-tree-0.4.2.tgz",
+            "integrity": "sha512-F3cdlzdAYpeLu7ct5VdgHu0RvVJE0mGTlc5rt6JsXdCOygeOFuHBHjQAqvhYXzlf3I+/aPGHiFeWYzTmOsUJlw==",
             "dependencies": {
+                "commander": "^12.0.0",
                 "fast-xml-parser": "^4.3.2",
                 "fs-extra": "^9.0.1",
                 "lodash": "^4.17.21",
@@ -5416,8 +5418,16 @@
                 "nuget-deps-tree": "dist/bin/command.js"
             },
             "engines": {
-                "node": ">=16",
-                "npm": ">=7"
+                "node": ">=18",
+                "npm": ">=10"
+            }
+        },
+        "node_modules/nuget-deps-tree/node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/nuget-deps-tree/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -346,7 +346,7 @@
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.4.2.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",
-        "nuget-deps-tree": "^0.3.1",
+        "nuget-deps-tree": "^0.4.2",
         "original-fs": "~1.1.0",
         "p-queue": "~6.6.2",
         "retries": "~1.0.0",


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Update `nuget-dep-tree` dependency to version `0.4.2` that includes: 
* https://github.com/jfrog/nuget-deps-tree/pull/40

Fixes issue where sometimes `.sln` files are present but not recognized as project since dependency command fails on `TypeError`