### PR TITLE
Fix Nuget Dependency Detection bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.4.2.tgz",
                 "js-yaml": "^4.1.0",
                 "json2csv": "~5.0.7",
-                "nuget-deps-tree": "^0.4.2",
+                "nuget-deps-tree": "^0.4.3",
                 "original-fs": "~1.1.0",
                 "p-queue": "~6.6.2",
                 "retries": "~1.0.0",
@@ -5402,9 +5402,9 @@
             }
         },
         "node_modules/nuget-deps-tree": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/nuget-deps-tree/-/nuget-deps-tree-0.4.2.tgz",
-            "integrity": "sha512-F3cdlzdAYpeLu7ct5VdgHu0RvVJE0mGTlc5rt6JsXdCOygeOFuHBHjQAqvhYXzlf3I+/aPGHiFeWYzTmOsUJlw==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/nuget-deps-tree/-/nuget-deps-tree-0.4.3.tgz",
+            "integrity": "sha512-mgaq5HQ+LBoDEElqxLzeEVg/RTPw+FR/bNUQ+AJ7bAieNc72Eu57xXRAGFwSqUFoqW/8Ocw5CbnYcT9AJLXdBQ==",
             "dependencies": {
                 "commander": "^12.0.0",
                 "fast-xml-parser": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -346,7 +346,7 @@
         "jfrog-ide-webview": "https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/jfrog-ide-webview-0.4.2.tgz",
         "js-yaml": "^4.1.0",
         "json2csv": "~5.0.7",
-        "nuget-deps-tree": "^0.4.2",
+        "nuget-deps-tree": "^0.4.3",
         "original-fs": "~1.1.0",
         "p-queue": "~6.6.2",
         "retries": "~1.0.0",


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Depends On:
* https://github.com/jfrog/nuget-deps-tree/pull/43
* https://github.com/jfrog/nuget-deps-tree/pull/44