### PR TITLE
Fix proxy configuration and command output handling

### DIFF
--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -430,8 +430,14 @@ export class ConnectionUtils {
             return false;
         }
 
+        let proxyUri: URL;
+        try {
+            proxyUri = new URL(httpProxy);
+        } catch {
+            return false;
+        }
+
         let proxyConfig: IProxyConfig = {} as IProxyConfig;
-        let proxyUri: URL = new URL(httpProxy);
         proxyConfig.protocol = proxyUri.protocol;
         proxyConfig.host = proxyUri.hostname;
         if (proxyUri.port) {

--- a/src/main/connect/connectionUtils.ts
+++ b/src/main/connect/connectionUtils.ts
@@ -422,6 +422,11 @@ export class ConnectionUtils {
         let httpProxy: string | undefined = vscode.workspace.getConfiguration().get('http.proxy');
 
         if (!httpProxy) {
+            // Fall back to environment variables when no explicit VS Code proxy setting is configured
+            httpProxy = process.env['HTTPS_PROXY'] ?? process.env['HTTP_PROXY'];
+        }
+
+        if (!httpProxy) {
             return false;
         }
 

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -157,8 +157,11 @@ export class AnalyzerManager {
         let optional: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
         if (optional) {
             let proxyConfig: IProxyConfig = <IProxyConfig>optional;
-            proxyHttpsUrl = proxyConfig.protocol == 'https:' ? AnalyzerManager.toProxyUrl(proxyConfig) : proxyHttpsUrl;
-            proxyHttpUrl = proxyConfig.protocol == 'http:' ? AnalyzerManager.toProxyUrl(proxyConfig) : proxyHttpUrl;
+            // An HTTP proxy (http://) handles both HTTP and HTTPS traffic via CONNECT tunneling,
+            // so always set both proxy env vars from the single VS Code proxy configuration.
+            const proxyUrl: string = AnalyzerManager.toProxyUrl(proxyConfig);
+            proxyHttpsUrl = proxyUrl;
+            proxyHttpUrl = proxyUrl;
         }
 
         if (params?.tokenValidation && params.tokenValidation === true) {

--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -47,6 +47,54 @@ describe('Connection Manager Tests', () => {
         assert.deepEqual(proxyAuthorization, 'testProxyAuthorization');
     });
 
+    describe('getProxyConfig', () => {
+        afterEach(async () => {
+            await vscode.workspace.getConfiguration().update('http.proxy', undefined, true);
+            await vscode.workspace.getConfiguration().update('http.proxySupport', undefined, true);
+            delete process.env['HTTP_PROXY'];
+            delete process.env['HTTPS_PROXY'];
+        });
+
+        it('Returns proxy config from VS Code http.proxy setting', async () => {
+            await vscode.workspace.getConfiguration().update('http.proxy', 'http://proxy.example.com:8080', true);
+            const result: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
+            assert.isObject(result);
+            const proxyConfig: IProxyConfig = result as IProxyConfig;
+            assert.equal(proxyConfig.host, 'proxy.example.com');
+            assert.equal(proxyConfig.port, 8080);
+        });
+
+        it('Falls back to HTTPS_PROXY env var when http.proxy setting is not configured', () => {
+            process.env['HTTPS_PROXY'] = 'http://envproxy.example.com:3128';
+            const result: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
+            assert.isObject(result);
+            const proxyConfig: IProxyConfig = result as IProxyConfig;
+            assert.equal(proxyConfig.host, 'envproxy.example.com');
+            assert.equal(proxyConfig.port, 3128);
+        });
+
+        it('Falls back to HTTP_PROXY env var when http.proxy and HTTPS_PROXY are not set', () => {
+            process.env['HTTP_PROXY'] = 'http://httpenvproxy.example.com:8888';
+            const result: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
+            assert.isObject(result);
+            const proxyConfig: IProxyConfig = result as IProxyConfig;
+            assert.equal(proxyConfig.host, 'httpenvproxy.example.com');
+            assert.equal(proxyConfig.port, 8888);
+        });
+
+        it('Returns false when no proxy is configured', () => {
+            const result: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
+            assert.isFalse(result);
+        });
+
+        it('Returns false when proxySupport is off', async () => {
+            await vscode.workspace.getConfiguration().update('http.proxy', 'http://proxy.example.com:8080', true);
+            await vscode.workspace.getConfiguration().update('http.proxySupport', 'off', true);
+            const result: IProxyConfig | boolean = ConnectionUtils.getProxyConfig();
+            assert.isFalse(result);
+        });
+    });
+
     describe('Populate credentials from env', async () => {
         [
             {

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import * as fs from 'fs';
 import { describe } from 'mocha';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { ConnectionManager } from '../../main/connect/connectionManager';
 import { LogManager } from '../../main/log/logManager';
 
@@ -160,6 +161,24 @@ describe('Analyzer BinaryRunner tests', async () => {
                 assert.equal(envVars?.[AnalyzerManager.ENV_LOG_DIR], test.logPath);
             }
         });
+    });
+
+    it('Create environment variables for execution - With VS Code http.proxy setting (http:// proxy sets both HTTP_PROXY and HTTPS_PROXY)', async () => {
+        const proxyUrl: string = 'http://vscodeproxy.example.com:8080';
+        await vscode.workspace.getConfiguration().update('http.proxy', proxyUrl, true);
+        delete process.env['HTTP_PROXY'];
+        delete process.env['HTTPS_PROXY'];
+
+        try {
+            let runner: AnalyzerManager = createDummyAnalyzerManager(createBinaryRunnerConnectionManager('platformUrl', '', '', 'access-token'));
+            let envVars: NodeJS.ProcessEnv | undefined = runner.createEnvForRun({});
+            assert.isDefined(envVars);
+            // An http:// proxy must be set for both protocols since it handles HTTPS via CONNECT tunneling
+            assert.equal(envVars?.[AnalyzerManager.ENV_HTTP_PROXY], proxyUrl);
+            assert.equal(envVars?.[AnalyzerManager.ENV_HTTPS_PROXY], proxyUrl);
+        } finally {
+            await vscode.workspace.getConfiguration().update('http.proxy', undefined, true);
+        }
     });
 
     [

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -85,6 +85,11 @@ describe('Analyzer BinaryRunner tests', async () => {
         })(connection, logManager);
     }
 
+    afterEach(() => {
+        delete process.env['HTTP_PROXY'];
+        delete process.env['HTTPS_PROXY'];
+    });
+
     [
         {
             name: 'With password credentials',
@@ -123,7 +128,7 @@ describe('Analyzer BinaryRunner tests', async () => {
             user: '',
             pass: '',
             token: 'access-token',
-            proxy: 'proxyUrlEnvVarValue',
+            proxy: 'http://proxy.example.com:8080',
             logPath: undefined
         },
         {
@@ -139,8 +144,14 @@ describe('Analyzer BinaryRunner tests', async () => {
     ].forEach(test => {
         it('Create environment variables for execution - ' + test.name, () => {
             let runner: AnalyzerManager = createDummyAnalyzerManager(createBinaryRunnerConnectionManager(test.url, test.user, test.pass, test.token));
-            process.env['HTTP_PROXY'] = test.proxy;
-            process.env['HTTPS_PROXY'] = test.proxy;
+            
+            if (test.proxy !== undefined) {
+                process.env['HTTP_PROXY'] = test.proxy;
+                process.env['HTTPS_PROXY'] = test.proxy;
+            } else {
+                delete process.env['HTTP_PROXY'];
+                delete process.env['HTTPS_PROXY'];
+            }
 
             let envVars: NodeJS.ProcessEnv | undefined = runner.createEnvForRun({ executionLogDirectory: test.logPath });
             if (test.shouldFail) {


### PR DESCRIPTION
## Changes

- **Proxy Configuration**: Fix proxy not being picked up from VS Code settings for both extension and analyzer
  - Added fallback to `HTTPS_PROXY` and `HTTP_PROXY` environment variables when VS Code proxy setting is not configured
  - Simplified proxy URL handling in analyzer to set both HTTP and HTTPS proxy environment variables from single VS Code proxy configuration (HTTP proxy handles both via CONNECT tunneling)

- **Tests**: Added comprehensive tests for proxy configuration fallback and analyzer environment variable handling