### PR TITLE
Update AM default version to 1.30.2

### DIFF
--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -17,7 +17,7 @@ import { LogUtils } from '../../log/logUtils';
 export class AnalyzerManager {
     private static readonly RELATIVE_DOWNLOAD_URL: string = '/xsc-gen-exe-analyzer-manager-local/v1';
     private static readonly BINARY_NAME: string = 'analyzerManager';
-    public static readonly ANALYZER_MANAGER_VERSION: string = '1.23.7';
+    public static readonly ANALYZER_MANAGER_VERSION: string = '1.30.2';
     public static readonly ANALYZER_MANAGER_PATH: string = Utils.addWinSuffixIfNeeded(
         path.join(ScanUtils.getIssuesPath(), AnalyzerManager.BINARY_NAME, AnalyzerManager.BINARY_NAME)
     );

--- a/src/main/scanLogic/scanRunners/analyzerModels.ts
+++ b/src/main/scanLogic/scanRunners/analyzerModels.ts
@@ -11,7 +11,7 @@ export enum ScanType {
 
 export type AnalyzerManagerSeverityLevel = 'none' | 'note' | 'warning' | 'error';
 
-export type ResultKind = 'pass' | 'fail';
+export type ResultKind = 'pass' | 'fail' | 'informational';
 
 export interface AnalyzeScanRequest {
     // What type of scan

--- a/src/main/scanLogic/scanRunners/secretsScan.ts
+++ b/src/main/scanLogic/scanRunners/secretsScan.ts
@@ -90,6 +90,10 @@ export class SecretsRunner extends JasRunner {
                 ignoreCount++;
                 return;
             }
+            if (analyzeIssue.locations.length === 0 || analyzeIssue.kind === 'informational') {
+                // We only care about issues that have locations and are not informational
+                return;
+            }
             AnalyzerUtils.generateIssueData(secretsResponse, analyzeIssue, rulesFullDescription.get(analyzeIssue.ruleId));
         });
         secretsResponse.ignoreCount = ignoreCount;

--- a/src/main/treeDataProviders/utils/analyzerUtils.ts
+++ b/src/main/treeDataProviders/utils/analyzerUtils.ts
@@ -84,11 +84,14 @@ export class AnalyzerUtils {
 
     /**
      * Generate the data for a specific analyze issue (the file object, the issue in the file object and all the location objects of this issue).
-     * @param iacResponse - the response of the scan that holds all the file objects
+     * @param response - the response of the scan that holds all the file objects
      * @param analyzeIssue - the issue to handle and generate information base on it
      * @param fullDescription - the description of the analyzeIssue
      */
     public static generateIssueData(response: { filesWithIssues: FileWithSecurityIssues[] }, analyzeIssue: AnalyzeIssue, fullDescription?: string) {
+        if (!analyzeIssue || !analyzeIssue.locations || analyzeIssue.locations.length === 0) {
+            return;
+        }
         analyzeIssue.locations.forEach(location => {
             if (location?.physicalLocation?.artifactLocation?.uri) {
                 let fileWithIssues: FileWithSecurityIssues = AnalyzerUtils.getOrCreateFileWithSecurityIssues(

--- a/src/test/tests/analyzerUtils.test.ts
+++ b/src/test/tests/analyzerUtils.test.ts
@@ -77,6 +77,40 @@ describe('Analyzer Utils Tests', async () => {
             assert.equal(response.filesWithIssues.length, 0);
         });
 
+        it('Should handle undefined analyzeIssue without errors', () => {
+            const response: { filesWithIssues: any[] } = { filesWithIssues: [] };
+            assert.doesNotThrow(() => {
+                AnalyzerUtils.generateIssueData(response, undefined as any);
+            });
+            assert.equal(response.filesWithIssues.length, 0);
+        });
+
+        it('Should handle null analyzeIssue without errors', () => {
+            const response: { filesWithIssues: any[] } = { filesWithIssues: [] };
+            assert.doesNotThrow(() => {
+                AnalyzerUtils.generateIssueData(response, null as any);
+            });
+            assert.equal(response.filesWithIssues.length, 0);
+        });
+
+        it('Should handle analyzeIssue with undefined locations without errors', () => {
+            const response: { filesWithIssues: any[] } = { filesWithIssues: [] };
+            const analyzeIssue: any = { ruleId: 'test-rule', message: { text: 'test' } };
+            assert.doesNotThrow(() => {
+                AnalyzerUtils.generateIssueData(response, analyzeIssue);
+            });
+            assert.equal(response.filesWithIssues.length, 0);
+        });
+
+        it('Should handle analyzeIssue with empty locations array without errors', () => {
+            const response: { filesWithIssues: any[] } = { filesWithIssues: [] };
+            const analyzeIssue: any = { ruleId: 'test-rule', message: { text: 'test' }, locations: [] };
+            assert.doesNotThrow(() => {
+                AnalyzerUtils.generateIssueData(response, analyzeIssue);
+            });
+            assert.equal(response.filesWithIssues.length, 0);
+        });
+
         it('Should process valid locations correctly', () => {
             const response: { filesWithIssues: any[] } = { filesWithIssues: [] };
             const analyzeIssue: any = {

--- a/src/test/tests/nugetUtils.test.ts
+++ b/src/test/tests/nugetUtils.test.ts
@@ -98,10 +98,7 @@ describe('Nuget Utils Tests', async () => {
     it('Create NuGet Dependencies Trees - tolerates .csproj count mismatch', async () => {
         const partialDir: vscode.Uri = vscode.Uri.file(path.join(tmpDir.fsPath, 'partial'));
         const partialFolders: vscode.WorkspaceFolder[] = [{ uri: partialDir, name: '', index: 0 }];
-        const packageDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors(
-            partialFolders,
-            treesManager.logManager
-        );
+        const packageDescriptors: Map<PackageType, vscode.Uri[]> = await ScanUtils.locatePackageDescriptors(partialFolders, treesManager.logManager);
         const solutions: vscode.Uri[] | undefined = packageDescriptors.get(PackageType.Nuget);
         assert.isDefined(solutions);
 

--- a/src/test/tests/secretsScan.test.ts
+++ b/src/test/tests/secretsScan.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { assert } from 'chai';
 import { ConnectionManager } from '../../main/connect/connectionManager';
 import { LogManager } from '../../main/log/logManager';
-import { FileRegion } from '../../main/scanLogic/scanRunners/analyzerModels';
+import { AnalyzerScanResponse, FileRegion } from '../../main/scanLogic/scanRunners/analyzerModels';
 import { SecretsRunner, SecretsScanResponse } from '../../main/scanLogic/scanRunners/secretsScan';
 import { CodeFileTreeNode } from '../../main/treeDataProviders/issuesTree/codeFileTree/codeFileTreeNode';
 import { CodeIssueTreeNode } from '../../main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode';
@@ -120,6 +120,90 @@ describe('Secrets Scan Tests', () => {
 
                 it('Check snippet text at location transferred', () => assertIssuesSnippet(testRoot, expectedFilesWithIssues, getTestIssueNode));
             });
+        });
+    });
+
+    describe('Secrets scan skips informational and empty-location issues', () => {
+        function createResponseWithResults(results: any[]): AnalyzerScanResponse {
+            return {
+                runs: [
+                    {
+                        tool: { driver: { name: 'JFrog Secrets scanner', rules: [{ id: 'generic' }] } },
+                        results: results
+                    }
+                ]
+            } as AnalyzerScanResponse;
+        }
+
+        const validResult: any = {
+            ruleId: 'generic',
+            message: { text: 'Hardcoded secrets were found' },
+            kind: 'fail',
+            locations: [
+                {
+                    physicalLocation: {
+                        artifactLocation: { uri: 'file:///test/file.js' },
+                        region: { startLine: 1, endLine: 1, startColumn: 1, endColumn: 10, snippet: { text: 'secret123' } }
+                    }
+                }
+            ]
+        };
+
+        it('Informational issues are skipped', () => {
+            const informationalResult: any = {
+                ruleId: 'generic',
+                message: { text: 'Informational finding' },
+                kind: 'informational',
+                locations: [
+                    {
+                        physicalLocation: {
+                            artifactLocation: { uri: 'file:///test/info.js' },
+                            region: { startLine: 1, endLine: 1, startColumn: 1, endColumn: 10, snippet: { text: 'data' } }
+                        }
+                    }
+                ]
+            };
+            const response: SecretsScanResponse = getDummyRunner().convertResponse(createResponseWithResults([informationalResult]));
+            assert.isDefined(response.filesWithIssues);
+            assert.equal(response.filesWithIssues.length, 0);
+        });
+
+        it('Empty-location issues are skipped', () => {
+            const emptyLocationsResult: any = {
+                ruleId: 'generic',
+                message: { text: 'Issue with no locations' },
+                locations: []
+            };
+            const response: SecretsScanResponse = getDummyRunner().convertResponse(createResponseWithResults([emptyLocationsResult]));
+            assert.isDefined(response.filesWithIssues);
+            assert.equal(response.filesWithIssues.length, 0);
+        });
+
+        it('Mixed: only actionable issues are kept', () => {
+            const informationalResult: any = {
+                ruleId: 'generic',
+                message: { text: 'Informational finding' },
+                kind: 'informational',
+                locations: [
+                    {
+                        physicalLocation: {
+                            artifactLocation: { uri: 'file:///test/info.js' },
+                            region: { startLine: 1, endLine: 1, startColumn: 1, endColumn: 10, snippet: { text: 'data' } }
+                        }
+                    }
+                ]
+            };
+            const emptyLocationsResult: any = {
+                ruleId: 'generic',
+                message: { text: 'No locations' },
+                locations: []
+            };
+            const response: SecretsScanResponse = getDummyRunner().convertResponse(
+                createResponseWithResults([validResult, informationalResult, emptyLocationsResult])
+            );
+            assert.isDefined(response.filesWithIssues);
+            assert.equal(response.filesWithIssues.length, 1);
+            assert.equal(response.filesWithIssues[0].full_path, '/test/file.js');
         });
     });
 

--- a/src/test/tests/secretsScan.test.ts
+++ b/src/test/tests/secretsScan.test.ts
@@ -203,7 +203,7 @@ describe('Secrets Scan Tests', () => {
             );
             assert.isDefined(response.filesWithIssues);
             assert.equal(response.filesWithIssues.length, 1);
-            assert.equal(response.filesWithIssues[0].full_path, '/test/file.js');
+            assert.equal(response.filesWithIssues[0].full_path, 'file:///test/file.js');
         });
     });
 


### PR DESCRIPTION
## Upgrade Analyzer Manager to 1.30.2 & handle edge cases in secrets scan

### Summary

Upgrades the Analyzer Manager default version from 1.23.7 to 1.30.2 and adds handling for issues that lack locations or have an `informational` kind, which the newer AM version may produce. This prevents potential runtime errors and filters out noise from secrets scan results.

### Changes

- **Analyzer Manager version bump**: Updated `ANALYZER_MANAGER_VERSION` from `1.23.7` to `1.30.2` in `analyzerManager.ts`.
- **New `informational` result kind**: Added `'informational'` to the `ResultKind` type in `analyzerModels.ts` to reflect new AM output.
- **Secrets scan filtering**: Skip issues in `secretsScan.ts` that have zero locations or `kind === 'informational'`, since they are not actionable.
- **Defensive guard in `generateIssueData`**: Added an early return in `analyzerUtils.ts` when `analyzeIssue` or its locations are missing/empty, preventing potential crashes.
- **Minor formatting**: Collapsed a multi-line call in `nugetUtils.test.ts` to a single line.

### Testing

- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----