### PR TITLE
Fix parsing secrets where no location exist

### DIFF
--- a/src/main/scanLogic/scanRunners/secretsScan.ts
+++ b/src/main/scanLogic/scanRunners/secretsScan.ts
@@ -90,7 +90,7 @@ export class SecretsRunner extends JasRunner {
                 ignoreCount++;
                 return;
             }
-            if (analyzeIssue.locations.length === 0 || analyzeIssue.kind === 'informational') {
+            if (analyzeIssue.locations?.length === 0 || analyzeIssue.kind === 'informational') {
                 // We only care about issues that have locations and are not informational
                 return;
             }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-vscode-extension#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Following:
* https://github.com/jfrog/jfrog-vscode-extension/pull/550

fix issue on results without locations (`TypeError` issue)
```
[ERR - 1:57:38 PM] TypeError: Cannot read properties of undefined (reading 'length')
[DEBUG - 1:57:38 PM] TypeError: Cannot read properties of undefined (reading 'length')
	at /Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:51593:40
	at Array.forEach (<anonymous>)
	at SecretsRunner.convertResponse (/Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:51588:80)
	at SecretsRunner.scan (/Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:51562:40)
	at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
	at async Promise.all (index 3)
	at async ScanManager.scanWorkspace (/Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:50521:13)
	at async IssuesTreeDataProvider.repopulateWorkspaceTree (/Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:55153:9)
	at async /Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:55116:17
	at async /Users/assafa/code/jfrog/jfrog-vscode-extension/dist/extension.js:59789:13
```