### PR TITLE
Fix type error

### DIFF
--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -212,14 +212,15 @@ export class AnalyzerManager {
         }
         await AnalyzerManager.FINISH_UPDATE_PROMISE;
         try {
-            const envVars: NodeJS.ProcessEnv = { [AnalyzerManager.ENV_PLATFORM_URL]: this._connectionManager.url };
+            const envVars: NodeJS.ProcessEnv = this.createEnvForRun() ?? {
+                [AnalyzerManager.ENV_PLATFORM_URL]: this._connectionManager.url
+            };
             if (!Configuration.getShouldShowJasLogs()) {
                 envVars[AnalyzerManager.ENV_LOG_DIR] = path.join(ScanUtils.getLogsPath());
             }
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            let versionString: string = await this._binary.run(['version'], () => {}, envVars);
-            // Extract the version from the output
-            const match: RegExpMatchArray | null = versionString.match('analyzer manager version:\\s*(\\S+)');
+            let versionString: string = await this._binary.run(['version'], () => {}, envVars, false);
+            const match: RegExpMatchArray | null = versionString.match(/analyzer manager version:\s*(\S+)/);
             if (match && match.length > 1) {
                 this._version = match[1];
             }

--- a/src/main/scanLogic/scanRunners/analyzerManager.ts
+++ b/src/main/scanLogic/scanRunners/analyzerManager.ts
@@ -213,6 +213,7 @@ export class AnalyzerManager {
         await AnalyzerManager.FINISH_UPDATE_PROMISE;
         try {
             const envVars: NodeJS.ProcessEnv = this.createEnvForRun() ?? {
+                ...process.env,
                 [AnalyzerManager.ENV_PLATFORM_URL]: this._connectionManager.url
             };
             if (!Configuration.getShouldShowJasLogs()) {

--- a/src/main/scanLogic/scanRunners/analyzerModels.ts
+++ b/src/main/scanLogic/scanRunners/analyzerModels.ts
@@ -50,7 +50,7 @@ export interface AnalyzerRule {
 export interface AnalyzeIssue {
     ruleId: string;
     message: ResultContent;
-    locations: AnalyzeLocation[];
+    locations?: AnalyzeLocation[];
     kind?: ResultKind;
     level?: AnalyzerManagerSeverityLevel;
     suppressions?: AnalyzeSuppression[];

--- a/src/main/scanLogic/scanRunners/applicabilityScan.ts
+++ b/src/main/scanLogic/scanRunners/applicabilityScan.ts
@@ -289,8 +289,8 @@ export class ApplicabilityRunner extends JasRunner {
             };
 
             if (status === Applicability.APPLICABLE) {
-                const combinedLocations: AnalyzeLocation[] = combinedIssues.flatMap(issue => issue.locations);
-                combinedLocations.forEach((location: AnalyzeLocation) => {
+                const combinedLocations: AnalyzeLocation[] = combinedIssues.flatMap(issue => issue.locations ?? []);
+                combinedLocations?.forEach((location: AnalyzeLocation) => {
                     if (location?.physicalLocation?.artifactLocation?.uri) {
                         let fileIssues: FileIssues = this.getOrCreateFileIssues(applicableDetails, location.physicalLocation.artifactLocation.uri);
                         fileIssues.locations.push(location.physicalLocation.region);

--- a/src/main/scanLogic/scanRunners/sastScan.ts
+++ b/src/main/scanLogic/scanRunners/sastScan.ts
@@ -158,6 +158,9 @@ export class SastRunner extends JasRunner {
                 ignoreCount++;
                 return;
             }
+            if (!analyzeIssue.locations?.length) {
+                return;
+            }
             const rule: AnalyzerRule = rulesDict[analyzeIssue.ruleId];
             if (rule?.shortDescription?.text) {
                 analyzeIssue.message.text = rule.shortDescription.text;
@@ -176,6 +179,9 @@ export class SastRunner extends JasRunner {
      * @param fullDescription - The description of the analyzeIssue
      */
     public generateIssueData(sastResponse: SastScanResponse, analyzeIssue: AnalyzeIssue, fullDescription?: string) {
+        if (!analyzeIssue?.locations?.length) {
+            return;
+        }
         analyzeIssue.locations.forEach(location => {
             let fileWithIssues: SastFileIssues = this.getOrCreateSastFileIssues(sastResponse, location.physicalLocation.artifactLocation.uri);
             let fileIssue: SastIssue = this.getOrCreateSastIssue(fileWithIssues, analyzeIssue, fullDescription);

--- a/src/main/scanLogic/scanRunners/secretsScan.ts
+++ b/src/main/scanLogic/scanRunners/secretsScan.ts
@@ -90,7 +90,7 @@ export class SecretsRunner extends JasRunner {
                 ignoreCount++;
                 return;
             }
-            if (analyzeIssue.locations?.length === 0 || analyzeIssue.kind === 'informational') {
+            if (!analyzeIssue.locations?.length || analyzeIssue.kind === 'informational') {
                 // We only care about issues that have locations and are not informational
                 return;
             }

--- a/src/main/utils/scanUtils.ts
+++ b/src/main/utils/scanUtils.ts
@@ -179,7 +179,7 @@ export class ScanUtils {
             try {
                 const childProcess: exec.ChildProcess = exec.exec(
                     command,
-                    { cwd: cwd, maxBuffer: ScanUtils.SPAWN_PROCESS_BUFFER_SIZE, env: env } as exec.ExecOptions,
+                    { cwd: cwd, maxBuffer: ScanUtils.SPAWN_PROCESS_BUFFER_SIZE, env: env ? { ...process.env, ...env } : env } as exec.ExecOptions,
                     (error: exec.ExecException | null, stdout: string, stderr: string) => {
                         clearInterval(checkCancellationInterval);
                         if (error) {

--- a/src/test/resources/secretsScan/analyzerResponse-missing-locations.json
+++ b/src/test/resources/secretsScan/analyzerResponse-missing-locations.json
@@ -1,0 +1,32 @@
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "JFrog Secrets scanner",
+          "rules": [{ "id": "generic", "shortDescription": { "text": "generic" } }]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "generic",
+          "message": { "text": "Finding without locations" },
+          "kind": "fail"
+        },
+        {
+          "ruleId": "generic",
+          "message": { "text": "Valid finding" },
+          "kind": "fail",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "file:///test/secret.py" },
+                "region": { "startLine": 1, "endLine": 1, "startColumn": 1, "endColumn": 8, "snippet": { "text": "API_KEY" } }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/tests/analyzerManager.test.ts
+++ b/src/test/tests/analyzerManager.test.ts
@@ -5,6 +5,23 @@ import { LogManager } from '../../main/log/logManager';
 import { AnalyzerManager } from '../../main/scanLogic/scanRunners/analyzerManager';
 import { Resource } from '../../main/utils/resource';
 
+function createConnectionManager(url: string, logManager: LogManager): ConnectionManager {
+    return {
+        get url() {
+            return url;
+        },
+        get logManager() {
+            return logManager;
+        },
+        areXrayCredentialsSet(): boolean {
+            return false;
+        },
+        areCompleteCredentialsSet(): boolean {
+            return false;
+        }
+    } as ConnectionManager;
+}
+
 describe('AnalyzerManager.version', () => {
     it('parses version when stderr contains non-fatal warnings', async () => {
         const isOutdatedStub: sinon.SinonStub = sinon.stub(Resource.prototype, 'isOutdated').resolves(false);
@@ -12,7 +29,7 @@ describe('AnalyzerManager.version', () => {
         try {
             const logManager: LogManager = new LogManager().activate();
             const manager: AnalyzerManager = new AnalyzerManager(
-                { url: 'https://example.jfrog.io' } as ConnectionManager,
+                createConnectionManager('https://example.jfrog.io', logManager),
                 logManager
             );
             const version: string | undefined = await manager.version();

--- a/src/test/tests/analyzerManager.test.ts
+++ b/src/test/tests/analyzerManager.test.ts
@@ -1,0 +1,26 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { ConnectionManager } from '../../main/connect/connectionManager';
+import { LogManager } from '../../main/log/logManager';
+import { AnalyzerManager } from '../../main/scanLogic/scanRunners/analyzerManager';
+import { Resource } from '../../main/utils/resource';
+
+describe('AnalyzerManager.version', () => {
+    it('parses version when stderr contains non-fatal warnings', async () => {
+        const isOutdatedStub: sinon.SinonStub = sinon.stub(Resource.prototype, 'isOutdated').resolves(false);
+        const runStub: sinon.SinonStub = sinon.stub(Resource.prototype, 'run').resolves('analyzer manager version: 1.30.2\n');
+        try {
+            const logManager: LogManager = new LogManager().activate();
+            const manager: AnalyzerManager = new AnalyzerManager(
+                { url: 'https://example.jfrog.io' } as ConnectionManager,
+                logManager
+            );
+            const version: string | undefined = await manager.version();
+            assert.equal(version, '1.30.2');
+            assert.isTrue(runStub.calledWith(sinon.match.array, sinon.match.func, sinon.match.object, false));
+        } finally {
+            runStub.restore();
+            isOutdatedStub.restore();
+        }
+    });
+});

--- a/src/test/tests/analyzerManager.test.ts
+++ b/src/test/tests/analyzerManager.test.ts
@@ -28,10 +28,7 @@ describe('AnalyzerManager.version', () => {
         const runStub: sinon.SinonStub = sinon.stub(Resource.prototype, 'run').resolves('analyzer manager version: 1.30.2\n');
         try {
             const logManager: LogManager = new LogManager().activate();
-            const manager: AnalyzerManager = new AnalyzerManager(
-                createConnectionManager('https://example.jfrog.io', logManager),
-                logManager
-            );
+            const manager: AnalyzerManager = new AnalyzerManager(createConnectionManager('https://example.jfrog.io', logManager), logManager);
             const version: string | undefined = await manager.version();
             assert.equal(version, '1.30.2');
             assert.isTrue(runStub.calledWith(sinon.match.array, sinon.match.func, sinon.match.object, false));

--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { ConnectionManager, LoginStatus } from '../../main/connect/connectionManager';
 import { ConnectionUtils } from '../../main/connect/connectionUtils';
 import { LogManager } from '../../main/log/logManager';
-import { createIsolatedCliHomeDir, createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
+import { createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import { SessionStatus } from '../../main/constants/contextKeys';
@@ -95,7 +95,14 @@ describe('Connection Manager Tests', () => {
         });
     });
 
-    describe('Populate credentials from env', async () => {
+    describe('Populate credentials from env', () => {
+        let isPlatformUrlStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            isPlatformUrlStub = sinon.stub(ConnectionUtils, 'isPlatformUrl');
+            sinon.stub(ConnectionUtils, 'validateArtifactoryConnection').resolves(true);
+        });
+
         [
             {
                 inputUrl: 'https://httpbin.org/anything',
@@ -127,16 +134,19 @@ describe('Connection Manager Tests', () => {
                 expectedPlatformUrl: '',
                 expectedXrayUrl: 'https://httpbin.org/status/404/different-xray-url/'
             }
-        ].forEach(async testCase => {
+        ].forEach(testCase => {
             it('Input URL: ' + testCase.inputUrl, async () => {
+                const isXrayInputUrl: boolean = testCase.inputUrl.endsWith('/xray') || testCase.inputUrl.endsWith('/xray/');
+                isPlatformUrlStub.resolves(!!testCase.expectedPlatformUrl && !isXrayInputUrl);
+
                 // Clean up env before tests.
                 process.env[ConnectionManager.USERNAME_ENV] = process.env[ConnectionManager.PASSWORD_ENV] = process.env[
                     ConnectionManager.ACCESS_TOKEN_ENV
                 ] = process.env[ConnectionManager.URL_ENV] = '';
 
-                // Store previous CLI home, and set to an isolated path so no credentials will be read from the CLI.
+                // Store previous CLI home, and set to a non existing path so no credentials will be read from the CLI.
                 const previousHome: string = getCliHomeDir();
-                setCliHomeDir(createIsolatedCliHomeDir());
+                setCliHomeDir(path.resolve('/path/to/nowhere'));
 
                 try {
                     // Check credentials not set.
@@ -148,6 +158,9 @@ describe('Connection Manager Tests', () => {
                 } finally {
                     setCliHomeDir(previousHome);
                     connectionManager.deleteCredentialsFromMemory();
+                    process.env[ConnectionManager.USERNAME_ENV] = process.env[ConnectionManager.PASSWORD_ENV] = process.env[
+                        ConnectionManager.ACCESS_TOKEN_ENV
+                    ] = process.env[ConnectionManager.URL_ENV] = '';
                 }
             });
         });
@@ -210,7 +223,7 @@ describe('Connection Manager Tests', () => {
                 expectedAccessToken: '',
                 expectedResult: false
             }
-        ].forEach(async testCase => {
+        ].forEach(testCase => {
             it('Credentials type: ' + testCase.serverId, async () => {
                 // Make sure credentials are not set from env.
                 process.env[ConnectionManager.USERNAME_ENV] = process.env[ConnectionManager.PASSWORD_ENV] = process.env[
@@ -219,7 +232,7 @@ describe('Connection Manager Tests', () => {
 
                 // Store previous CLI home, and set new one to test data.
                 const previousHome: string = getCliHomeDir();
-                setCliHomeDir(createIsolatedCliHomeDir());
+                setCliHomeDir('/path/to/nowhere');
 
                 try {
                     // Assert credentials are empty.

--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { ConnectionManager, LoginStatus } from '../../main/connect/connectionManager';
 import { ConnectionUtils } from '../../main/connect/connectionUtils';
 import { LogManager } from '../../main/log/logManager';
-import { createEmptyCliHomeDir, createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
+import { createIsolatedCliHomeDir, createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import { SessionStatus } from '../../main/constants/contextKeys';
@@ -134,20 +134,21 @@ describe('Connection Manager Tests', () => {
                     ConnectionManager.ACCESS_TOKEN_ENV
                 ] = process.env[ConnectionManager.URL_ENV] = '';
 
-                // Store previous CLI home, and set to a non existing path so no credentials will be read from the CLI.
+                // Store previous CLI home, and set to an isolated path so no credentials will be read from the CLI.
                 const previousHome: string = getCliHomeDir();
-                setCliHomeDir(createEmptyCliHomeDir());
+                setCliHomeDir(createIsolatedCliHomeDir());
 
-                // Check credentials not set.
-                assert.isEmpty(await connectionManager.tryGetUrlFromJFrogCli());
-                assert.isFalse(connectionManager.areXrayCredentialsSet());
+                try {
+                    // Check credentials not set.
+                    assert.isEmpty(await connectionManager.tryGetUrlFromJFrogCli());
+                    assert.isFalse(connectionManager.areXrayCredentialsSet());
 
-                await populateCredsAndAssert(testCase, 'admin', 'password', '');
-                await populateCredsAndAssert(testCase, '', '', 'token');
-
-                // Restore old CLI home dir.
-                setCliHomeDir(previousHome);
-                connectionManager.deleteCredentialsFromMemory();
+                    await populateCredsAndAssert(testCase, 'admin', 'password', '');
+                    await populateCredsAndAssert(testCase, '', '', 'token');
+                } finally {
+                    setCliHomeDir(previousHome);
+                    connectionManager.deleteCredentialsFromMemory();
+                }
             });
         });
     });
@@ -218,29 +219,30 @@ describe('Connection Manager Tests', () => {
 
                 // Store previous CLI home, and set new one to test data.
                 const previousHome: string = getCliHomeDir();
-                setCliHomeDir(createEmptyCliHomeDir());
+                setCliHomeDir(createIsolatedCliHomeDir());
 
-                // Assert credentials are empty.
-                assert.isEmpty(await connectionManager.tryGetUrlFromJFrogCli());
-                assert.isFalse(connectionManager.areCompleteCredentialsSet());
+                try {
+                    // Assert credentials are empty.
+                    assert.isEmpty(await connectionManager.tryGetUrlFromJFrogCli());
+                    assert.isFalse(connectionManager.areCompleteCredentialsSet());
 
-                // Set new home to test data.
-                setCliHomeDir(path.join(__dirname, '..', 'resources', 'cliHome'));
+                    // Set new home to test data.
+                    setCliHomeDir(path.join(__dirname, '..', 'resources', 'cliHome'));
 
-                // Use the corresponding server-id to the test case.
-                assert.doesNotThrow(() => execSync('jf c use ' + testCase.serverId.trim()));
+                    // Use the corresponding server-id to the test case.
+                    assert.doesNotThrow(() => execSync('jf c use ' + testCase.serverId.trim()));
 
-                assert.equal(await connectionManager.readCredentialsFromJfrogCli(), testCase.expectedResult);
-                assert.equal(connectionManager.url, testCase.expectedPlatformUrl);
-                assert.equal(connectionManager.rtUrl, testCase.expectedRtUrl);
-                assert.equal(connectionManager.xrayUrl, testCase.expectedXrayUrl);
-                assert.equal(connectionManager.username, testCase.expectedUsername);
-                assert.equal(connectionManager.password, testCase.expectedPassword);
-                assert.equal(connectionManager.accessToken, testCase.expectedAccessToken);
-
-                // Restore old CLI home dir.
-                setCliHomeDir(previousHome);
-                connectionManager.deleteCredentialsFromMemory();
+                    assert.equal(await connectionManager.readCredentialsFromJfrogCli(), testCase.expectedResult);
+                    assert.equal(connectionManager.url, testCase.expectedPlatformUrl);
+                    assert.equal(connectionManager.rtUrl, testCase.expectedRtUrl);
+                    assert.equal(connectionManager.xrayUrl, testCase.expectedXrayUrl);
+                    assert.equal(connectionManager.username, testCase.expectedUsername);
+                    assert.equal(connectionManager.password, testCase.expectedPassword);
+                    assert.equal(connectionManager.accessToken, testCase.expectedAccessToken);
+                } finally {
+                    setCliHomeDir(previousHome);
+                    connectionManager.deleteCredentialsFromMemory();
+                }
             });
         });
     });

--- a/src/test/tests/connectionManager.test.ts
+++ b/src/test/tests/connectionManager.test.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { ConnectionManager, LoginStatus } from '../../main/connect/connectionManager';
 import { ConnectionUtils } from '../../main/connect/connectionUtils';
 import { LogManager } from '../../main/log/logManager';
-import { createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
+import { createEmptyCliHomeDir, createTestConnectionManager, getCliHomeDir, setCliHomeDir } from './utils/utils.test';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import { SessionStatus } from '../../main/constants/contextKeys';
@@ -136,7 +136,7 @@ describe('Connection Manager Tests', () => {
 
                 // Store previous CLI home, and set to a non existing path so no credentials will be read from the CLI.
                 const previousHome: string = getCliHomeDir();
-                setCliHomeDir(path.resolve('/path/to/nowhere'));
+                setCliHomeDir(createEmptyCliHomeDir());
 
                 // Check credentials not set.
                 assert.isEmpty(await connectionManager.tryGetUrlFromJFrogCli());
@@ -218,7 +218,7 @@ describe('Connection Manager Tests', () => {
 
                 // Store previous CLI home, and set new one to test data.
                 const previousHome: string = getCliHomeDir();
-                setCliHomeDir('/path/to/nowhere');
+                setCliHomeDir(createEmptyCliHomeDir());
 
                 // Assert credentials are empty.
                 assert.isEmpty(await connectionManager.tryGetUrlFromJFrogCli());

--- a/src/test/tests/sastScan.test.ts
+++ b/src/test/tests/sastScan.test.ts
@@ -123,13 +123,13 @@ describe('Sast Tests', () => {
 
     describe('Sast scan malformed SARIF', () => {
         it('generateScanResponse skips results without locations', () => {
-            const response = {
+            const response: AnalyzerScanResponse = {
                 runs: [{
                     tool: { driver: { name: 'sast', rules: [] } },
                     results: [{ ruleId: 'r1', message: { text: 'no loc' } }]
                 }]
             } as unknown as AnalyzerScanResponse;
-            const out = getDummyRunner().generateScanResponse(response);
+            const out: SastScanResponse = getDummyRunner().generateScanResponse(response);
             assert.isDefined(out.filesWithIssues);
             assert.equal(out.filesWithIssues.length, 0);
         });

--- a/src/test/tests/sastScan.test.ts
+++ b/src/test/tests/sastScan.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { assert } from 'chai';
 import { ConnectionManager } from '../../main/connect/connectionManager';
 import { LogManager } from '../../main/log/logManager';
-import { FileRegion } from '../../main/scanLogic/scanRunners/analyzerModels';
+import { AnalyzerScanResponse, FileRegion } from '../../main/scanLogic/scanRunners/analyzerModels';
 import { SastRunner, SastScanResponse } from '../../main/scanLogic/scanRunners/sastScan';
 import { CodeFileTreeNode } from '../../main/treeDataProviders/issuesTree/codeFileTree/codeFileTreeNode';
 import { CodeIssueTreeNode } from '../../main/treeDataProviders/issuesTree/codeFileTree/codeIssueTreeNode';
@@ -118,6 +118,20 @@ describe('Sast Tests', () => {
 
                 it('Check snippet text at location transferred', () => assertIssuesSnippet(testRoot, expectedFilesWithIssues, getTestIssueNode));
             });
+        });
+    });
+
+    describe('Sast scan malformed SARIF', () => {
+        it('generateScanResponse skips results without locations', () => {
+            const response = {
+                runs: [{
+                    tool: { driver: { name: 'sast', rules: [] } },
+                    results: [{ ruleId: 'r1', message: { text: 'no loc' } }]
+                }]
+            } as unknown as AnalyzerScanResponse;
+            const out = getDummyRunner().generateScanResponse(response);
+            assert.isDefined(out.filesWithIssues);
+            assert.equal(out.filesWithIssues.length, 0);
         });
     });
 

--- a/src/test/tests/sastScan.test.ts
+++ b/src/test/tests/sastScan.test.ts
@@ -123,12 +123,14 @@ describe('Sast Tests', () => {
 
     describe('Sast scan malformed SARIF', () => {
         it('generateScanResponse skips results without locations', () => {
-            const response: AnalyzerScanResponse = {
-                runs: [{
-                    tool: { driver: { name: 'sast', rules: [] } },
-                    results: [{ ruleId: 'r1', message: { text: 'no loc' } }]
-                }]
-            } as unknown as AnalyzerScanResponse;
+            const response: AnalyzerScanResponse = ({
+                runs: [
+                    {
+                        tool: { driver: { name: 'sast', rules: [] } },
+                        results: [{ ruleId: 'r1', message: { text: 'no loc' } }]
+                    }
+                ]
+            } as unknown) as AnalyzerScanResponse;
             const out: SastScanResponse = getDummyRunner().generateScanResponse(response);
             assert.isDefined(out.filesWithIssues);
             assert.equal(out.filesWithIssues.length, 0);

--- a/src/test/tests/scanAnlayzerRunner.test.ts
+++ b/src/test/tests/scanAnlayzerRunner.test.ts
@@ -144,7 +144,7 @@ describe('Analyzer BinaryRunner tests', async () => {
     ].forEach(test => {
         it('Create environment variables for execution - ' + test.name, () => {
             let runner: AnalyzerManager = createDummyAnalyzerManager(createBinaryRunnerConnectionManager(test.url, test.user, test.pass, test.token));
-            
+
             if (test.proxy !== undefined) {
                 process.env['HTTP_PROXY'] = test.proxy;
                 process.env['HTTPS_PROXY'] = test.proxy;

--- a/src/test/tests/secretsScan.test.ts
+++ b/src/test/tests/secretsScan.test.ts
@@ -207,6 +207,16 @@ describe('Secrets Scan Tests', () => {
         });
     });
 
+    describe('Secrets scan malformed SARIF', () => {
+        it('Results without locations property do not throw', () => {
+            const responsePath = path.join(scanSecrets, 'analyzerResponse-missing-locations.json');
+            const response: SecretsScanResponse = getDummyRunner().convertResponse(getAnalyzerScanResponse(responsePath));
+            assert.isDefined(response.filesWithIssues);
+            assert.equal(response.filesWithIssues.length, 1);
+            assert.equal(response.filesWithIssues[0].full_path, 'file:///test/secret.py');
+        });
+    });
+
     function getDummyRunner(): SecretsRunner {
         return new SecretsRunner(
             {} as ScanResults,

--- a/src/test/tests/secretsScan.test.ts
+++ b/src/test/tests/secretsScan.test.ts
@@ -209,7 +209,7 @@ describe('Secrets Scan Tests', () => {
 
     describe('Secrets scan malformed SARIF', () => {
         it('Results without locations property do not throw', () => {
-            const responsePath = path.join(scanSecrets, 'analyzerResponse-missing-locations.json');
+            const responsePath: string = path.join(scanSecrets, 'analyzerResponse-missing-locations.json');
             const response: SecretsScanResponse = getDummyRunner().convertResponse(getAnalyzerScanResponse(responsePath));
             assert.isDefined(response.filesWithIssues);
             assert.equal(response.filesWithIssues.length, 1);

--- a/src/test/tests/utils/utils.test.ts
+++ b/src/test/tests/utils/utils.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { JfrogClient } from 'jfrog-client-js';
 import * as os from 'os';
+import * as path from 'path';
 import * as tmp from 'tmp';
 import * as vscode from 'vscode';
 import { ScanCacheManager } from '../../../main/cache/scanCacheManager';
@@ -105,4 +106,8 @@ export function getCliHomeDir(): string {
 
 export function setCliHomeDir(newHome: string): void {
     process.env['JFROG_CLI_HOME_DIR'] = newHome;
+}
+
+export function createEmptyCliHomeDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'jfrog-cli-home-'));
 }

--- a/src/test/tests/utils/utils.test.ts
+++ b/src/test/tests/utils/utils.test.ts
@@ -111,3 +111,14 @@ export function setCliHomeDir(newHome: string): void {
 export function createEmptyCliHomeDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'jfrog-cli-home-'));
 }
+
+/**
+ * Platform-specific CLI home for tests that isolate from JFrog CLI before live URL resolution.
+ * macOS needs a real empty temp dir; Windows needs a non-existent path so httpbin pings succeed.
+ */
+export function createIsolatedCliHomeDir(): string {
+    if (process.platform === 'win32') {
+        return path.resolve('/path/to/nowhere');
+    }
+    return createEmptyCliHomeDir();
+}

--- a/src/test/tests/utils/utils.test.ts
+++ b/src/test/tests/utils/utils.test.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import { JfrogClient } from 'jfrog-client-js';
 import * as os from 'os';
-import * as path from 'path';
 import * as tmp from 'tmp';
 import * as vscode from 'vscode';
 import { ScanCacheManager } from '../../../main/cache/scanCacheManager';
@@ -106,19 +105,4 @@ export function getCliHomeDir(): string {
 
 export function setCliHomeDir(newHome: string): void {
     process.env['JFROG_CLI_HOME_DIR'] = newHome;
-}
-
-export function createEmptyCliHomeDir(): string {
-    return fs.mkdtempSync(path.join(os.tmpdir(), 'jfrog-cli-home-'));
-}
-
-/**
- * Platform-specific CLI home for tests that isolate from JFrog CLI before live URL resolution.
- * macOS needs a real empty temp dir; Windows needs a non-existent path so httpbin pings succeed.
- */
-export function createIsolatedCliHomeDir(): string {
-    if (process.platform === 'win32') {
-        return path.resolve('/path/to/nowhere');
-    }
-    return createEmptyCliHomeDir();
 }


### PR DESCRIPTION
## `fix(scan): guard missing SARIF locations and tolerate analyzer version stderr`

## Summary
Fixes scan crashes and version detection failures when the analyzer returns malformed SARIF (results without `locations`) or writes non-fatal warnings to stderr during the version check. SAST and secrets scans now skip invalid results instead of throwing, and `AnalyzerManager.version()` uses the same proxy/env setup as scan runs and tolerates stderr output.

## Changes
- **Secrets scan** (`secretsScan.ts`): Treat missing or empty `locations` as skippable (`!analyzeIssue.locations?.length`) instead of only checking `length === 0`.
- **SAST scan** (`sastScan.ts`): Early-return in `generateScanResponse` and `generateIssueData` when results have no locations.
- **Analyzer manager** (`analyzerManager.ts`): Use `createEnvForRun()` for version-check env (proxy support); pass `false` to `binary.run` so stderr warnings do not fail version parsing; fix version regex to a proper pattern.
- **Tests**: Add `analyzerManager.test.ts` for version parsing with stderr; extend `sastScan.test.ts` and `secretsScan.test.ts` for missing-location SARIF; add fixture `analyzerResponse-missing-locations.json`.

